### PR TITLE
Content for user perception strategies

### DIFF
--- a/docs/strategies/user-perception/bundling/index.md
+++ b/docs/strategies/user-perception/bundling/index.md
@@ -128,9 +128,8 @@ From a value chain perspective, bundling can represent a form of vertical integr
 ## 🔀 **Related Strategies**
 
 - [Confusion of Choice](/strategies/user-perception/confusion-of-choice) – Bundling can be combined with complex packages to make alternatives hard to compare.
-- [Raising Barriers to Entry](/strategies/market-position/barriers-to-entry) – Bundling many features raises customer expectations and can deter new entrants.
-- [Land Grab](/strategies/market-position/land-grab) – Bundling can quickly expand user base for a new service by piggybacking on an existing one.
-- [Unbundling](/strategies/user-perception/unbundling) – The counter-strategy, offering standalone products to appeal to customers who dislike bundles.
+- [Raising Barriers to Entry](/strategies/defensive/barriers-to-entry) – Bundling many features raises customer expectations and can deter new entrants.
+- [Land Grab](/strategies/positional/land-grab) – Bundling can quickly expand user base for a new service by piggybacking on an existing one.
 
 ## 📚 **Further Reading & References**
 

--- a/docs/strategies/user-perception/bundling/index.md
+++ b/docs/strategies/user-perception/bundling/index.md
@@ -22,7 +22,7 @@ The purpose of bundling is often to **drive adoption of a new or disruptive comp
 
 ### Historical: Microsoft bundling Internet Explorer with Windows
 
-Microsoft bundling Internet Explorer with Windows in the 1990s is a classic case . Users got a free browser with their OS (a need: access to the web), which **hid the disadvantage** for competitors (it undercut Netscape). Over time, this bundling made IE ubiquitous. (It also led to antitrust action -- a risk of bundling strategy when too successful.)
+Microsoft bundling Internet Explorer with Windows in the 1990s is a classic case. Users got a free browser with their OS (a need: access to the web), which **hid the disadvantage** for competitors (it undercut Netscape). Over time, this bundling made IE ubiquitous. (It also led to antitrust action -- a risk of bundling strategy when too successful.)
 
 ### Historical: Cable TV providers bundling channels
 
@@ -34,36 +34,35 @@ A SaaS software company needs to deprecate an old feature that some legacy custo
 
 ## 🚦 **When to Use / When to Avoid**
 
--  **Use when:** You have a change or component that users would likely reject on its own (e.g. a price increase, a new but initially inconvenient standard) but you can pair it with something they strongly desire . It's effective for rolling out evolutionary steps in your value chain without giving customers a stark choice to opt-out.
+<Assessment strategyName="Bundling">
+  <MapSignals>
+    <li>Our map shows a component facing user resistance or inertia.</li>
+    <li>We have a highly desirable product or service with strong demand.</li>
+    <li>The less desirable component is strategically important for our value chain or evolution.</li>
+    <li>Competitors are gaining traction with standalone offerings that threaten our ecosystem.</li>
+    <li>There is an opportunity to accelerate adoption of a new standard or feature.</li>
+  </MapSignals>
+  <Readiness>
+    <li>We understand our customers' needs and pain points well.</li>
+    <li>We can clearly communicate the value of the bundle.</li>
+    <li>We have the ability to monitor and respond to customer feedback rapidly.</li>
+    <li>We are prepared to address potential legal or regulatory concerns.</li>
+    <li>We can coordinate across product, marketing, and sales teams.</li>
+  </Readiness>
+</Assessment>
 
--  **Avoid when:** The bundled items are unrelated -- customers aren't fooled and may resent being forced to take something they don't want. Also avoid if bundling triggers regulatory concern (tying arrangements can be illegal in some contexts if you have market power, as seen with Microsoft).
+- **Use when:** You have a change or component that users would likely reject on its own (e.g. a price increase, a new but initially inconvenient standard) but you can pair it with something they strongly desire. It's effective for rolling out evolutionary steps in your value chain without giving customers a stark choice to opt-out.
 
-## ⚠️ **Common Pitfalls and Warning Signs**
-
-### **Customer frustration**
-
-If customers feel the bundle is coercive (e.g. "Why must I buy X to get Y?"), it can cause backlash and even drive them to seek alternatives.
-
-### **Overshadowing value**
-
-The positive part of the bundle must clearly outweigh the negative; if not, users focus on what they're unhappy about (like bloatware bundled on new PCs hurt user satisfaction).
-
-### **Legal risks**
-
-As noted, aggressive bundling by a dominant player can invite antitrust scrutiny (courts ruled Microsoft's bundling as anti-competitive ).
-
-## 🔀 **Related Strategies**
-
-- **Confusion of Choice** (bundling can be combined with complex packages to make alternatives hard to compare)
-- **Raising Barriers to Entry** (bundling many features raises customer expectations)
-- **Land Grab** (bundling can quickly expand user base for a new service by piggybacking on an existing one)
+- **Avoid when:** The bundled items are unrelated -- customers aren't fooled and may resent being forced to take something they don't want. Also avoid if bundling triggers regulatory concern (tying arrangements can be illegal in some contexts if you have market power, as seen with Microsoft).
 
 ## 🎯 **Leadership**
 
 ### Core challenge
+
 The core challenge in implementing a bundling strategy lies in identifying complementary products or services where the combined value is greater than the sum of its parts, while ensuring the bundle doesn't alienate customers or appear anti-competitive. Leaders must balance the drive for adoption of less desirable components with genuine user benefit, navigating potential ethical and legal pitfalls associated with coercive or overly aggressive bundling.
 
 ### Key leadership skills required
+
 - **Strategic Vision:** Ability to see how different products/services can be combined to create new value propositions and achieve broader market goals.
 - **Customer Empathy:** Understanding customer needs and perceptions to ensure bundles are attractive and not seen as exploitative.
 - **Market Analysis:** Accurately assessing competitive responses and market dynamics to ensure the bundle is well-positioned.
@@ -71,15 +70,16 @@ The core challenge in implementing a bundling strategy lies in identifying compl
 - **Ethical Judgement:** Navigating the fine line between persuasive bundling and anti-competitive or coercive practices.
 
 ### Ethical considerations
+
 Bundling can raise significant ethical concerns if perceived as coercive, forcing customers to acquire unwanted items to access desired ones. Transparency is key; customers should understand what they are getting and why the items are bundled. Predatory bundling, where a dominant market player uses bundling to stifle competition and limit consumer choice, can lead to anti-trust issues and damage brand reputation. Leaders must ensure that bundling strategies are fair, provide genuine value, and do not exploit captive audiences or create unjust market advantages.
 
 ## 📋 **How to Execute**
 
-1.  **Identify Core and Target Components:** Clearly define the desirable "core" product/service that attracts users and the "target" product/service you aim to promote through the bundle. The core component should have strong existing demand or a clear value proposition.
-2.  **Assess Complementarity and Value:** Ensure the bundled items have a logical connection or offer enhanced value together. The perceived benefit of the core item must be high enough to offset any reluctance towards the target item. Avoid bundling unrelated items, which can frustrate users.
-3.  **Design the Bundle Structure and Pricing:** Determine the terms of the bundle. Will the target item be "free," discounted, or will the bundle have a unique price? The overall perceived value must be compelling. Consider tiered bundles if appropriate for different customer segments.
-4.  **Develop Clear Messaging and Marketing:** Communicate the bundle's benefits clearly. Highlight the value of the combined package and, if necessary, the reasons for the bundling (e.g., "enhanced experience," "better together"). Be transparent about what's included.
-5.  **Monitor Adoption and Feedback:** Track the adoption rate of the bundle and its impact on individual component sales/usage. Gather customer feedback to understand their perception of the bundle's value and identify any points of friction or resentment. Be prepared to iterate or unbundle if the strategy backfires.
+1. **Identify Core and Target Components:** Clearly define the desirable "core" product/service that attracts users and the "target" product/service you aim to promote through the bundle. The core component should have strong existing demand or a clear value proposition.
+2. **Assess Complementarity and Value:** Ensure the bundled items have a logical connection or offer enhanced value together. The perceived benefit of the core item must be high enough to offset any reluctance towards the target item. Avoid bundling unrelated items, which can frustrate users.
+3. **Design the Bundle Structure and Pricing:** Determine the terms of the bundle. Will the target item be "free," discounted, or will the bundle have a unique price? The overall perceived value must be compelling. Consider tiered bundles if appropriate for different customer segments.
+4. **Develop Clear Messaging and Marketing:** Communicate the bundle's benefits clearly. Highlight the value of the combined package and, if necessary, the reasons for the bundling (e.g., "enhanced experience," "better together"). Be transparent about what's included.
+5. **Monitor Adoption and Feedback:** Track the adoption rate of the bundle and its impact on individual component sales/usage. Gather customer feedback to understand their perception of the bundle's value and identify any points of friction or resentment. Be prepared to iterate or unbundle if the strategy backfires.
 
 ## 📈 **Measuring Success**
 
@@ -93,15 +93,19 @@ Bundling can raise significant ethical concerns if perceived as coercive, forcin
 ## ⚠️ **Common Pitfalls and Warning Signs**
 
 ### **Customer frustration**
+
 If customers feel the bundle is coercive (e.g., "Why must I buy X to get Y?"), it can cause backlash, negative sentiment, and even drive them to seek alternatives that offer more choice.
 
 ### **Overshadowing value**
+
 The positive part of the bundle must clearly outweigh the negative or any perceived inconvenience of the bundled item. If not, users may focus on what they're unhappy about (like bloatware bundled on new PCs that hurt user satisfaction).
 
 ### **Legal and Regulatory Risks**
+
 As noted, aggressive bundling by a dominant player can invite antitrust scrutiny if it's seen as unfairly stifling competition by tying products together (courts ruled Microsoft's bundling as anti-competitive).
 
 ### **Cannibalization of Premium Products**
+
 If a bundle offers a "good enough" version of a premium standalone product at a lower effective price, it might inadvertently cannibalize sales of that higher-margin offering.
 
 ## 🧠 **Strategic Insights**
@@ -121,7 +125,15 @@ From a value chain perspective, bundling can represent a form of vertical integr
 - **Impact on Innovation:** Will bundling this component encourage or stifle innovation around it, both internally and in the broader market?
 - **Ethical and Legal Boundaries:** Are we confident that our bundling strategy is ethically sound and compliant with all relevant anti-competition laws?
 
+## 🔀 **Related Strategies**
+
+- [Confusion of Choice](/strategies/user-perception/confusion-of-choice) – Bundling can be combined with complex packages to make alternatives hard to compare.
+- [Raising Barriers to Entry](/strategies/market-position/barriers-to-entry) – Bundling many features raises customer expectations and can deter new entrants.
+- [Land Grab](/strategies/market-position/land-grab) – Bundling can quickly expand user base for a new service by piggybacking on an existing one.
+- [Unbundling](/strategies/user-perception/unbundling) – The counter-strategy, offering standalone products to appeal to customers who dislike bundles.
+
 ## 📚 **Further Reading & References**
 
-- Wardley, S. -- *On Bundling* . Defines bundling as "hiding a disadvantageous change by bundling with other needs" and cites examples like introducing changes under the guise of packaged deals.
-- U.S. vs Microsoft (1998) -- Antitrust case documents (DOJ findings) . Describes how bundling Internet Explorer with Windows gave Microsoft a strategic edge (and the legal ramifications).
+- [U.S. v. Microsoft (1998) – DOJ Antitrust Case Documents](https://www.justice.gov/atr/us-v-microsoft-courts-findings-fact) – Describes how bundling Internet Explorer with Windows gave Microsoft a strategic edge and the legal ramifications.
+- [Bundling and Tying: Antitrust Analysis](https://www.ftc.gov/advice-guidance/competition-guidance/guide-antitrust-laws/single-firm-conduct/tying-sale-two-products) – Federal Trade Commission guidance on bundling and tying practices.
+- [The Strategy and Tactics of Pricing](https://www.amazon.co.uk/Double-Your-Price-Strategy-Tactics/dp/1292426349) – Book covering pricing strategies, including bundling.

--- a/docs/strategies/user-perception/bundling/index.md
+++ b/docs/strategies/user-perception/bundling/index.md
@@ -128,7 +128,7 @@ From a value chain perspective, bundling can represent a form of vertical integr
 ## 🔀 **Related Strategies**
 
 - [Confusion of Choice](/strategies/user-perception/confusion-of-choice) – Bundling can be combined with complex packages to make alternatives hard to compare.
-- [Raising Barriers to Entry](/strategies/defensive/barriers-to-entry) – Bundling many features raises customer expectations and can deter new entrants.
+- [Raising Barriers to Entry](/strategies/defensive/raising-barriers-to-entry) – Bundling many features raises customer expectations and can deter new entrants.
 - [Land Grab](/strategies/positional/land-grab) – Bundling can quickly expand user base for a new service by piggybacking on an existing one.
 
 ## 📚 **Further Reading & References**

--- a/docs/strategies/user-perception/bundling/index.md
+++ b/docs/strategies/user-perception/bundling/index.md
@@ -1,50 +1,127 @@
 ---
+title: Bundling
+description: Combining products or changes together so that a less desirable item is packaged with a desirable one, encouraging adoption of the whole package.
 tags: [bundling, user-perception, packaging, adoption, hiding disadvantage, pricing]
 ---
 
 # Bundling
 
+**Combining products or changes together so that a less desirable item is packaged with a desirable one, encouraging adoption of the whole package.**
 
-:::warning
+> Hiding a disadvantageous change by bundling the change with other needs.
+>
+> - Simon Wardley
 
-This is an **early draft** and isn't yet up to our standard.
-You can [contribute improvements](https://github.com/dave1010/wardley-leadership-strategies).
+## 🤔 **Explanation**
 
-:::
+### What is Bundling?
 
+The purpose of bundling is often to **drive adoption of a new or disruptive component** by coupling it with existing demand. Origins lie in price bundling (e.g. sell two complementary goods together), but strategically it's used to push changes covertly. Key principle: ensure the bundle's overall value proposition is positive for the user, so they accept the "bad" with the good. This can accelerate evolution -- for example, forcing an upgrade by bundling a necessary service with an upgraded one. It was infamously used in tech to introduce new standards hidden in bigger releases. In practice, bundling hides or offsets something that might face resistance by delivering it alongside something the user needs or wants.
 
-### **Bundling**
+## 🗺️ **Real-World Examples**
 
-**Definition & Summary:** Combining products or changes together so that a **less desirable item is packaged with a desirable one**, encouraging adoption of the whole package . In practice, bundling hides or offsets something that might face resistance by delivering it alongside something the user needs or wants.
+### Historical: Microsoft bundling Internet Explorer with Windows
 
-**Detailed Explanation:** The purpose of bundling is often to **drive adoption of a new or disruptive component** by coupling it with existing demand. Origins lie in price bundling (e.g. sell two complementary goods together), but strategically it's used to push changes covertly. Key principle: ensure the bundle's overall value proposition is positive for the user, so they accept the "bad" with the good. This can accelerate evolution -- for example, forcing an upgrade by bundling a necessary service with an upgraded one. It was infamously used in tech to introduce new standards hidden in bigger releases.
+Microsoft bundling Internet Explorer with Windows in the 1990s is a classic case . Users got a free browser with their OS (a need: access to the web), which **hid the disadvantage** for competitors (it undercut Netscape). Over time, this bundling made IE ubiquitous. (It also led to antitrust action -- a risk of bundling strategy when too successful.)
 
-**Real-World Examples:**
+### Historical: Cable TV providers bundling channels
 
--  *Historical:* Microsoft bundling Internet Explorer with Windows in the 1990s is a classic case . Users got a free browser with their OS (a need: access to the web), which **hid the disadvantage** for competitors (it undercut Netscape). Over time, this bundling made IE ubiquitous. (It also led to antitrust action -- a risk of bundling strategy when too successful.)
+Cable TV providers bundle less-popular channels with very popular ones in packages. Consumers who want the popular channel must pay for the bundle, effectively driving distribution for channels that would not survive alone. This "hide a disadvantageous change" (like a price increase) by mixing it with must-have content is a bundling play.
 
--  *Historical:* Cable TV providers bundle less-popular channels with very popular ones in packages. Consumers who want the popular channel must pay for the bundle, effectively driving distribution for channels that would not survive alone. This "hide a disadvantageous change" (like a price increase) by mixing it with must-have content is a bundling play.
+### Hypothetical: SaaS company deprecating a feature
 
--  *Hypothetical:* A SaaS software company needs to deprecate an old feature that some legacy customers still use. They release a new upgrade bundle: the old feature is removed, but the upgrade includes extra storage and a new AI tool at the same price. By **bundling improvements** with the removal of the old feature, they soften the blow and get customers to accept the change.
+A SaaS software company needs to deprecate an old feature that some legacy customers still use. They release a new upgrade bundle: the old feature is removed, but the upgrade includes extra storage and a new AI tool at the same price. By **bundling improvements** with the removal of the old feature, they soften the blow and get customers to accept the change.
 
-**When to Use / When to Avoid:**
+## 🚦 **When to Use / When to Avoid**
 
 -  **Use when:** You have a change or component that users would likely reject on its own (e.g. a price increase, a new but initially inconvenient standard) but you can pair it with something they strongly desire . It's effective for rolling out evolutionary steps in your value chain without giving customers a stark choice to opt-out.
 
 -  **Avoid when:** The bundled items are unrelated -- customers aren't fooled and may resent being forced to take something they don't want. Also avoid if bundling triggers regulatory concern (tying arrangements can be illegal in some contexts if you have market power, as seen with Microsoft).
 
-**Common Pitfalls:**
+## ⚠️ **Common Pitfalls and Warning Signs**
 
--  **Customer frustration:** If customers feel the bundle is coercive (e.g. "Why must I buy X to get Y?"), it can cause backlash and even drive them to seek alternatives.
+### **Customer frustration**
 
--  **Overshadowing value:** The positive part of the bundle must clearly outweigh the negative; if not, users focus on what they're unhappy about (like bloatware bundled on new PCs hurt user satisfaction).
+If customers feel the bundle is coercive (e.g. "Why must I buy X to get Y?"), it can cause backlash and even drive them to seek alternatives.
 
--  **Legal risks:** As noted, aggressive bundling by a dominant player can invite antitrust scrutiny (courts ruled Microsoft's bundling as anti-competitive ).
+### **Overshadowing value**
 
-**Related Strategies:** **Confusion of Choice** (bundling can be combined with complex packages to make alternatives hard to compare), **Raising Barriers to Entry** (bundling many features raises customer expectations), **Land Grab** (bundling can quickly expand user base for a new service by piggybacking on an existing one).
+The positive part of the bundle must clearly outweigh the negative; if not, users focus on what they're unhappy about (like bloatware bundled on new PCs hurt user satisfaction).
 
-**Further Reading & References:**
+### **Legal risks**
 
--  Wardley, S. -- *On Bundling* . Defines bundling as "hiding a disadvantageous change by bundling with other needs" and cites examples like introducing changes under the guise of packaged deals.
+As noted, aggressive bundling by a dominant player can invite antitrust scrutiny (courts ruled Microsoft's bundling as anti-competitive ).
 
--  U.S. vs Microsoft (1998) -- Antitrust case documents (DOJ findings) . Describes how bundling Internet Explorer with Windows gave Microsoft a strategic edge (and the legal ramifications).
+## 🔀 **Related Strategies**
+
+- **Confusion of Choice** (bundling can be combined with complex packages to make alternatives hard to compare)
+- **Raising Barriers to Entry** (bundling many features raises customer expectations)
+- **Land Grab** (bundling can quickly expand user base for a new service by piggybacking on an existing one)
+
+## 🎯 **Leadership**
+
+### Core challenge
+The core challenge in implementing a bundling strategy lies in identifying complementary products or services where the combined value is greater than the sum of its parts, while ensuring the bundle doesn't alienate customers or appear anti-competitive. Leaders must balance the drive for adoption of less desirable components with genuine user benefit, navigating potential ethical and legal pitfalls associated with coercive or overly aggressive bundling.
+
+### Key leadership skills required
+- **Strategic Vision:** Ability to see how different products/services can be combined to create new value propositions and achieve broader market goals.
+- **Customer Empathy:** Understanding customer needs and perceptions to ensure bundles are attractive and not seen as exploitative.
+- **Market Analysis:** Accurately assessing competitive responses and market dynamics to ensure the bundle is well-positioned.
+- **Cross-functional Collaboration:** Effectively working with product, marketing, and sales teams to develop and launch successful bundles.
+- **Ethical Judgement:** Navigating the fine line between persuasive bundling and anti-competitive or coercive practices.
+
+### Ethical considerations
+Bundling can raise significant ethical concerns if perceived as coercive, forcing customers to acquire unwanted items to access desired ones. Transparency is key; customers should understand what they are getting and why the items are bundled. Predatory bundling, where a dominant market player uses bundling to stifle competition and limit consumer choice, can lead to anti-trust issues and damage brand reputation. Leaders must ensure that bundling strategies are fair, provide genuine value, and do not exploit captive audiences or create unjust market advantages.
+
+## 📋 **How to Execute**
+
+1.  **Identify Core and Target Components:** Clearly define the desirable "core" product/service that attracts users and the "target" product/service you aim to promote through the bundle. The core component should have strong existing demand or a clear value proposition.
+2.  **Assess Complementarity and Value:** Ensure the bundled items have a logical connection or offer enhanced value together. The perceived benefit of the core item must be high enough to offset any reluctance towards the target item. Avoid bundling unrelated items, which can frustrate users.
+3.  **Design the Bundle Structure and Pricing:** Determine the terms of the bundle. Will the target item be "free," discounted, or will the bundle have a unique price? The overall perceived value must be compelling. Consider tiered bundles if appropriate for different customer segments.
+4.  **Develop Clear Messaging and Marketing:** Communicate the bundle's benefits clearly. Highlight the value of the combined package and, if necessary, the reasons for the bundling (e.g., "enhanced experience," "better together"). Be transparent about what's included.
+5.  **Monitor Adoption and Feedback:** Track the adoption rate of the bundle and its impact on individual component sales/usage. Gather customer feedback to understand their perception of the bundle's value and identify any points of friction or resentment. Be prepared to iterate or unbundle if the strategy backfires.
+
+## 📈 **Measuring Success**
+
+- **Bundle Adoption Rate:** Percentage of new or existing customers opting for the bundled package compared to standalone offerings.
+- **Attach Rate:** The number of units of the target (less desirable) product sold as part of a bundle for every unit of the core (desirable) product sold.
+- **Impact on Standalone Sales:** Changes in sales velocity or volume for the individual components of the bundle (both positive and negative).
+- **Customer Acquisition Cost (CAC) for Bundled Services:** How effectively the bundle attracts new customers to the ecosystem.
+- **Customer Lifetime Value (CLV):** Assess if customers acquired through bundles exhibit higher retention or overall spending.
+- **User Engagement with Target Component:** For software or services, track how actively users engage with the less desirable component after adopting the bundle.
+
+## ⚠️ **Common Pitfalls and Warning Signs**
+
+### **Customer frustration**
+If customers feel the bundle is coercive (e.g., "Why must I buy X to get Y?"), it can cause backlash, negative sentiment, and even drive them to seek alternatives that offer more choice.
+
+### **Overshadowing value**
+The positive part of the bundle must clearly outweigh the negative or any perceived inconvenience of the bundled item. If not, users may focus on what they're unhappy about (like bloatware bundled on new PCs that hurt user satisfaction).
+
+### **Legal and Regulatory Risks**
+As noted, aggressive bundling by a dominant player can invite antitrust scrutiny if it's seen as unfairly stifling competition by tying products together (courts ruled Microsoft's bundling as anti-competitive).
+
+### **Cannibalization of Premium Products**
+If a bundle offers a "good enough" version of a premium standalone product at a lower effective price, it might inadvertently cannibalize sales of that higher-margin offering.
+
+## 🧠 **Strategic Insights**
+
+Bundling is a powerful strategic tool that can significantly shape market dynamics and value chains. By packaging a less established or less desired product with a highly sought-after one, companies can accelerate the adoption of new technologies or features, effectively creating de facto standards and increasing switching costs for customers embedded in their ecosystem. This is particularly effective when the bundled component benefits from network effects; its inclusion, even if initially forced, can drive it towards critical mass. For instance, bundling a new communication protocol within a popular operating system can rapidly establish it as an industry norm, sidelining competing protocols. This integration can also shift profit pools, as the value once captured by a standalone product (now part of a bundle) may be redistributed across the bundle's components or used to subsidize the core product's price, making it more competitive.
+
+Competitors facing a bundling strategy have several potential counter-strategies. They can focus on unbundling, offering specialized, best-of-breed standalone products that appeal to customers who resent the bundled approach or require more advanced features than the bundled component offers. Another approach is to create an alternative bundle, perhaps by partnering with other players to offer a compelling counter-package. Furthermore, competitors can highlight the hidden costs or drawbacks of the bundle, such as feature bloat, reduced choice, or the potential for the bundled component to be inferior. In some cases, legal challenges based on anti-competitive practices may be viable if the bundler has significant market power.
+
+From a value chain perspective, bundling can represent a form of vertical integration or a way to extend control over adjacent market segments. By making a previously separate component an integral part of a larger offering, a company can capture more of the total value delivered to the customer. This can also be a defensive move to protect a core product by ensuring that complementary components, which could be points of leverage for competitors, are instead controlled by the bundler. However, this strategy requires careful management of the user experience; a poorly integrated or low-quality bundled component can detract from the overall value proposition and open doors for competitors who excel in that specific area. The long-term success of bundling often depends on whether the bundled elements genuinely enhance each other or if the bundle is merely a temporary tactic to push a product.
+
+## ❓ **Key Questions to Ask**
+
+- **Value Proposition:** Does the bundle offer a genuinely superior value proposition to the customer, or is it primarily serving our internal goal of pushing a specific product?
+- **Customer Perception:** How are customers likely to perceive the bundle? Will they see it as a benefit, a convenience, or a coercive tactic?
+- **Competitive Response:** How might our competitors react to this bundling strategy? Are we prepared for potential counter-bundling or unbundling plays?
+- **Modularity vs. Integration:** What is the right balance between offering integrated bundles and maintaining modularity for customer choice? Does the bundle lock customers in excessively?
+- **Impact on Innovation:** Will bundling this component encourage or stifle innovation around it, both internally and in the broader market?
+- **Ethical and Legal Boundaries:** Are we confident that our bundling strategy is ethically sound and compliant with all relevant anti-competition laws?
+
+## 📚 **Further Reading & References**
+
+- Wardley, S. -- *On Bundling* . Defines bundling as "hiding a disadvantageous change by bundling with other needs" and cites examples like introducing changes under the guise of packaged deals.
+- U.S. vs Microsoft (1998) -- Antitrust case documents (DOJ findings) . Describes how bundling Internet Explorer with Windows gave Microsoft a strategic edge (and the legal ramifications).

--- a/docs/strategies/user-perception/confusion-of-choice/index.md
+++ b/docs/strategies/user-perception/confusion-of-choice/index.md
@@ -143,11 +143,9 @@ Ethically, Confusion of Choice is a gray area. While businesses are not obligate
 
 ## 🔀 **Related Strategies**
 
-- [Bundling](/strategies/pricing/bundling) – Used with confusion: unique bundles make direct comparison hard.
-- [FUD](/strategies/market/fud) – Also prevents rational decision-making but via fear instead of complexity.
-- [Last Man Standing](/strategies/competition/last-man-standing) – Another strategy that exploits competitors' complacency; confusion exploits customers' cognitive limits.
-- [Default Trap](/strategies/user-perception/default-trap) – Relies on users sticking with the default when overwhelmed by choice.
-- [Obfuscation](/strategies/user-perception/obfuscation) – Directly related in method; confusion is a form of obfuscation.
+- [Bundling](/strategies/user-perception/bundling) – Used with confusion: unique bundles make direct comparison hard.
+- [FUD](/strategies/user-perception/fear-uncertainty-and-doubt) – Also prevents rational decision-making but via fear instead of complexity.
+- [Last Man Standing](/strategies/markets/last-man-standing) – Another strategy that exploits competitors' complacency; confusion exploits customers' cognitive limits.
 
 ## 📚 **Further Reading & References**
 

--- a/docs/strategies/user-perception/confusion-of-choice/index.md
+++ b/docs/strategies/user-perception/confusion-of-choice/index.md
@@ -1,14 +1,12 @@
 ---
 title: Confusion of Choice
 description: Overwhelming customers with too many options or complex choices so that making a rational decision becomes difficult.
-tags: [confusion-of-choice, user-perception, choice overload, complexity, inertia, comparison prevention]
+tags: [user-perception, choice overload, complexity, inertia, comparison prevention]
 ---
-
-# Confusion of choice
 
 **Overwhelming customers with too many options or complex choices so that making a rational decision becomes difficult.**
 
-> Preventing users from making rational decisions by overwhelming them with choice.
+> *"Preventing users from making rational decisions by overwhelming them with choice."*
 >
 > - Simon Wardley
 
@@ -16,112 +14,143 @@ tags: [confusion-of-choice, user-perception, choice overload, complexity, inerti
 
 ### What is Confusion of Choice?
 
-The strategy's origin is in consumer behavior research: too much choice can paradoxically reduce satisfaction and decision-making ("analysis paralysis"). By introducing confusion, you nudge users to either stick with the familiar or default option (often yours) or make suboptimal choices that favor you. The purpose here is often defensive -- to keep customers from easily comparing alternatives. **Key principle:** make offerings incomparable on key points so customers give up on switching . For example, by having many pricing plans with different feature sets, a competitor's single plan is hard to line up side-by-side; the user may default to staying put. It can also be used offensively in markets -- flood with variants of your own product to crowd shelves and confuse competitor's positioning. Essentially, it exploits cognitive overload.
+Confusion of Choice is a strategy rooted in consumer behavior research, where too much choice paradoxically reduces satisfaction and impedes decision-making ("analysis paralysis"). By introducing complexity or a multitude of options, organizations nudge users to stick with the familiar or default option (often their own), or to make suboptimal choices that favor the provider. The purpose is often defensive—to keep customers from easily comparing alternatives. 
+
+**Key principle:** Make offerings incomparable on key points so customers give up on switching. For example, by having many pricing plans with different feature sets, a competitor's single plan is hard to line up side-by-side; the user may default to staying put. It can also be used offensively—flooding the market with variants of your own product to crowd shelves and confuse competitor positioning. Essentially, it exploits cognitive overload.
+
+### Why use Confusion of Choice?
+
+- To reduce customer churn by making switching or comparison difficult.
+- To steer customers toward higher-margin or default options.
+- To crowd out competitors by saturating the market with variants.
+- To create perceived flexibility or customization, even if it increases complexity.
+
+### How does Confusion of Choice affect the landscape?
+
+This strategy shifts competition away from direct, feature-for-feature or price-for-price comparisons. It leverages cognitive biases such as decision fatigue and analysis paralysis, creating customer inertia and reducing price sensitivity. However, it also opens the door for "simplifier" competitors and can damage brand trust if overused.
 
 ## 🗺️ **Real-World Examples**
 
-### Everyday: Mobile carrier plans
+### Mobile carrier plans
 
-**Mobile carrier plans** are notorious for this . A carrier might offer dozens of slightly different packages (varying data, voice, text, rollover, etc.), making it extremely hard for a customer to identify which plan (even from another carrier) is the best deal. The confusion often leads them to just stick with their current plan or choose a mid-range one that tends to have a higher margin for the carrier.
+Mobile carriers often offer dozens of slightly different packages (varying data, voice, text, rollover, etc.), making it extremely hard for a customer to identify which plan—even from another carrier—is the best deal. The confusion often leads them to stick with their current plan or choose a mid-range one that tends to have a higher margin for the carrier.
 
 ### Financial services: Credit cards and insurance policies
 
-Credit cards and insurance policies present so many parameters (rates, fees, rewards, exclusions) that consumers struggle to compare across providers . This confusion can lead to inertia (not switching banks/insurers) or picking an option that *sounds* best due to a promotional feature, while hiding downsides in fine print.
+Credit cards and insurance policies present so many parameters (rates, fees, rewards, exclusions) that consumers struggle to compare across providers. This confusion can lead to inertia (not switching banks/insurers) or picking an option that *sounds* best due to a promotional feature, while hiding downsides in fine print.
 
 ### Hypothetical: SaaS company response to newcomer
 
-A SaaS software company is facing a newcomer with a simple, one-price-for-all product. The incumbent responds by segmenting its product into **tiers and add-on modules**, creating a matrix of options. Prospective customers attempting to evaluate it against the newcomer get bogged down deciding which tier they'd need and calculating total cost with add-ons -- a hassle that may tilt them to stick with the incumbent which "at least offers flexibility."
+A SaaS company faces a newcomer with a simple, one-price-for-all product. The incumbent responds by segmenting its product into tiers and add-on modules, creating a matrix of options. Prospective customers attempting to evaluate it against the newcomer get bogged down deciding which tier they'd need and calculating total cost with add-ons—a hassle that may tilt them to stick with the incumbent, which "at least offers flexibility."
 
 ## 🚦 **When to Use / When to Avoid**
 
--  **Use when:** You have a complex offering or multiple products and you're the incumbent, and you want to **discourage customers from evaluating competitors** on a straightforward cost/value basis. It's also useful when you can trap customers with a default or "recommended" choice among the confusing options that is in your interest.
+<Assessment strategyName="Confusion of Choice">
+  <MapSignals>
+    <li>Our map shows a critical user decision point with many possible options.</li>
+    <li>Competitors offer simpler, more transparent alternatives.</li>
+    <li>We control the default or recommended option in a complex choice set.</li>
+    <li>Switching costs are low unless confusion is introduced.</li>
+    <li>Market is mature and direct comparison is easy without intervention.</li>
+  </MapSignals>
+  <Readiness>
+    <li>We can manage operational complexity from multiple offerings.</li>
+    <li>We have strong product portfolio management skills.</li>
+    <li>We monitor customer feedback for signs of frustration or backlash.</li>
+    <li>We can quickly adapt if "simplifier" competitors gain traction.</li>
+    <li>We have clear ethical guidelines for choice architecture.</li>
+  </Readiness>
+</Assessment>
 
--  **Avoid when:** Customers demand simplicity -- in some markets, confusion will just drive them to a competitor who offers a simpler solution. Also avoid if your brand relies on trust and transparency; being overly confusing can erode goodwill.
+### Use when
 
-## ⚠️ **Common Pitfalls and Warning Signs**
+- You have a complex offering or multiple products and you're the incumbent, and you want to discourage customers from evaluating competitors on a straightforward cost/value basis.
+- You can trap customers with a default or "recommended" choice among the confusing options that is in your interest.
 
-### **Customer frustration and Backlash**
-There's a fine line between confusion that causes inertia and confusion that angers customers into leaving or publicly complaining. If they feel tricked or that their time is wasted, it can severely damage goodwill.
+### Avoid when
 
-### **Operational Complexity and Costs**
-Supporting too many product variants, pricing schemes, or service tiers can strain internal operations, increase costs, and make it difficult for sales or support staff to provide clear guidance.
-
-### **Attracting 'Simplifier' Competitors**
-Excessive complexity creates a market opportunity for competitors who offer deliberately simple, transparent alternatives, which can be highly appealing to frustrated customers.
-
-### **Damaging Brand Trust and Reputation**
-If a brand becomes known for being intentionally opaque or difficult to deal with, it erodes long-term trust and can lead to a negative reputation that is hard to reverse.
-
-## 🔀 **Related Strategies**
-
-- **Bundling** (often used with confusion: unique bundles make direct comparison hard)
-- **FUD** (also prevents rational decision-making but via fear instead of complexity)
-- **Last Man Standing** (unrelated in method but another strategy that exploits competitors' complacency -- confusion exploits customers' cognitive limits)
+- Customers demand simplicity—confusion will just drive them to a competitor who offers a simpler solution.
+- Your brand relies on trust and transparency; being overly confusing can erode goodwill.
 
 ## 🎯 **Leadership**
 
 ### Core challenge
-The primary leadership challenge with "Confusion of Choice" is to strategically introduce complexity or a multitude of options to guide customer behavior or deter switching, without inadvertently creating so much frustration that customers abandon the offerings altogether. Leaders must carefully balance the line between beneficial guidance (e.g., defaults for novice users) and manipulative obfuscation, ensuring that the complexity serves a strategic purpose (like reducing direct comparability with competitors) rather than merely reflecting internal disorganization.
+
+The primary leadership challenge is to strategically introduce complexity or a multitude of options to guide customer behavior or deter switching, without creating so much frustration that customers abandon the offerings altogether. Leaders must balance beneficial guidance (e.g., defaults for novice users) and manipulative obfuscation, ensuring complexity serves a strategic purpose rather than reflecting internal disorganization.
 
 ### Key leadership skills required
-- **Ethical Judgment:** Discerning the fine line between strategic ambiguity and harmful customer deception.
-- **Product Portfolio Management:** Skillfully managing a diverse range of products or service tiers to create perceived choice without overwhelming operational capacity.
-- **Market Segmentation Savvy:** Understanding different customer segments' tolerance for complexity and their decision-making processes.
-- **Communication Strategy:** Crafting messaging that simplifies choices where beneficial, while maintaining strategic complexity elsewhere.
-- **Risk Assessment:** Evaluating potential backlash, brand damage, or the creation of opportunities for "simplifier" competitors.
+
+- Ethical judgment: discerning the line between strategic ambiguity and harmful customer deception.
+- Product portfolio management: managing a diverse range of products or service tiers.
+- Market segmentation savvy: understanding customer segments' tolerance for complexity.
+- Communication strategy: simplifying choices where beneficial, maintaining strategic complexity elsewhere.
+- Risk assessment: evaluating potential backlash, brand damage, or opportunities for "simplifier" competitors.
 
 ### Ethical considerations
-The deliberate creation of confusion to exploit customer decision-making limitations is ethically dubious. While guiding choices through well-designed defaults or tiered options can be beneficial, intentionally making it difficult for customers to make rational, informed decisions for the company's sole benefit can be seen as manipulative. Transparency is often a casualty. Leaders must consider if the strategy preys on vulnerable customers or creates unfair competitive advantages, potentially damaging long-term trust and brand reputation for short-term gains.
+
+Deliberately creating confusion to exploit customer decision-making limitations is ethically dubious. While guiding choices through well-designed defaults or tiered options can be beneficial, intentionally making it difficult for customers to make rational, informed decisions for the company's sole benefit can be seen as manipulative. Leaders must consider if the strategy preys on vulnerable customers or creates unfair competitive advantages, potentially damaging long-term trust and brand reputation for short-term gains.
 
 ## 📋 **How to Execute**
 
-1.  **Identify Strategic Goal:** Determine the objective: Is it to reduce churn, steer customers to higher-margin products, make competitor comparison difficult, or project an image of catering to all needs?
-2.  **Introduce Product/Service Differentiation:** Create multiple product versions, service tiers, or add-on modules with overlapping or subtly different features and pricing structures. Ensure the differences are complex enough to make direct, apples-to-apples comparisons (especially with competitors) challenging.
-3.  **Design Choice Architecture:** Structure the presentation of options. This might involve highlighting a "recommended" (often high-margin) option, using complex naming conventions, or presenting a very large number of choices simultaneously.
-4.  **Craft Ambiguous Messaging (Optional):** Use marketing language that emphasizes variety and customization but avoids clear, simple explanations of which option is best for whom, or how they directly compare on key metrics.
-5.  **Monitor and Adjust:** Track customer choice patterns, drop-off rates during selection, and competitor responses. Be prepared to simplify certain aspects if customer frustration becomes too high or if "simplifier" competitors gain traction.
+1. Identify strategic goal: Is it to reduce churn, steer customers to higher-margin products, make competitor comparison difficult, or project an image of catering to all needs?
+2. Introduce product/service differentiation: Create multiple product versions, service tiers, or add-on modules with overlapping or subtly different features and pricing structures. Ensure the differences are complex enough to make direct, apples-to-apples comparisons (especially with competitors) challenging.
+3. Design choice architecture: Structure the presentation of options. This might involve highlighting a "recommended" (often high-margin) option, using complex naming conventions, or presenting a very large number of choices simultaneously.
+4. Craft ambiguous messaging (optional): Use marketing language that emphasizes variety and customization but avoids clear, simple explanations of which option is best for whom, or how they directly compare on key metrics.
+5. Monitor and adjust: Track customer choice patterns, drop-off rates during selection, and competitor responses. Be prepared to simplify certain aspects if customer frustration becomes too high or if "simplifier" competitors gain traction.
 
 ## 📈 **Measuring Success**
 
-- **Customer Inertia/Retention Rate:** Higher retention rates, especially if competitors offer simpler or cheaper alternatives, may indicate successful confusion.
-- **Choice of Default/Recommended Options:** High adoption rates of options strategically highlighted or set as default.
-- **Reduced Price Sensitivity:** Customers are less likely to switch based on small price differences if the comparison is too complex.
-- **Sales Cycle Length:** An increase in sales cycle length might indicate customers are struggling with choices, or conversely, are engaging more deeply (needs careful interpretation).
-- **Market Share Stability/Growth:** Maintaining or growing market share despite simpler or more transparent offerings from competitors.
-- **Qualitative Feedback:** Surveys or feedback indicating customers find choices "flexible" or "comprehensive" (positive spin) versus "confusing" or "overwhelming" (negative, but potentially intended).
+- Customer inertia/retention rate: Higher retention rates, especially if competitors offer simpler or cheaper alternatives.
+- Choice of default/recommended options: High adoption rates of options strategically highlighted or set as default.
+- Reduced price sensitivity: Customers are less likely to switch based on small price differences if the comparison is too complex.
+- Sales cycle length: An increase may indicate customers are struggling with choices, or conversely, are engaging more deeply (needs careful interpretation).
+- Market share stability/growth: Maintaining or growing market share despite simpler or more transparent offerings from competitors.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
 
-### **Customer frustration and Backlash**
+### Customer frustration and backlash
+
 There's a fine line between confusion that causes inertia and confusion that angers customers into leaving or publicly complaining. If they feel tricked or that their time is wasted, it can severely damage goodwill.
 
-### **Operational Complexity and Costs**
+### Operational complexity and costs
+
 Supporting too many product variants, pricing schemes, or service tiers can strain internal operations, increase costs, and make it difficult for sales or support staff to provide clear guidance.
 
-### **Attracting 'Simplifier' Competitors**
+### Attracting 'simplifier' competitors
+
 Excessive complexity creates a market opportunity for competitors who offer deliberately simple, transparent alternatives, which can be highly appealing to frustrated customers.
 
-### **Damaging Brand Trust and Reputation**
+### Damaging brand trust and reputation
+
 If a brand becomes known for being intentionally opaque or difficult to deal with, it erodes long-term trust and can lead to a negative reputation that is hard to reverse.
 
 ## 🧠 **Strategic Insights**
 
-"Confusion of Choice" fundamentally alters competitive dynamics by shifting the basis of competition away from direct, feature-for-feature or price-for-price comparisons. By leveraging cognitive biases such as decision fatigue and analysis paralysis, this strategy can create significant customer inertia, making them less likely to switch providers even if objectively better alternatives exist. This is because the perceived effort of evaluating complex options and comparing them to a competitor's offering outweighs the potential benefit of switching. This can lead to reduced price sensitivity, as customers are unable to easily determine the true value or cost difference between offerings. The strategy often thrives in markets with information asymmetry, where customers lack the expertise or time to fully understand the nuances of different choices.
+Confusion of Choice fundamentally alters competitive dynamics by shifting the basis of competition away from direct, feature-for-feature or price-for-price comparisons. By leveraging cognitive biases such as decision fatigue and analysis paralysis, this strategy can create significant customer inertia, making them less likely to switch providers even if objectively better alternatives exist. The perceived effort of evaluating complex options and comparing them to a competitor's offering outweighs the potential benefit of switching, leading to reduced price sensitivity.
 
-However, the deliberate obfuscation inherent in "Confusion of Choice" carries substantial risks. While it might deter some customers from switching, it can severely damage brand perception for others, leading to resentment and a loss of trust if customers feel manipulated. This creates an opening for "simplifier" competitors who can differentiate themselves by offering transparent pricing and straightforward product tiers. The emergence of such competitors is a common second-order effect. Furthermore, as markets mature and information becomes more readily available (e.g., through online reviews, comparison sites), the effectiveness of deliberately induced confusion may wane. Companies employing this strategy must be mindful of the evolving information landscape and the increasing consumer demand for transparency.
+However, the deliberate obfuscation inherent in this strategy carries substantial risks. While it might deter some customers from switching, it can severely damage brand perception for others, leading to resentment and a loss of trust if customers feel manipulated. This creates an opening for "simplifier" competitors who can differentiate themselves by offering transparent pricing and straightforward product tiers. As markets mature and information becomes more readily available (e.g., through online reviews, comparison sites), the effectiveness of deliberately induced confusion may wane. Companies must be mindful of the evolving information landscape and increasing consumer demand for transparency.
 
-Ethically, "Confusion of Choice" is a gray area. While businesses are not obligated to make comparisons easy for competitors, intentionally making it difficult for customers to make informed decisions that are in their own best interest can be viewed as exploitative. The strategy's sustainability often depends on a delicate balance: providing enough perceived choice to satisfy diverse needs (or appear to do so) while introducing enough complexity to achieve the desired strategic outcome (e.g., reduced churn, steered choices). Overplaying this hand can lead to significant backlash and regulatory scrutiny, particularly in consumer-facing industries.
+Ethically, Confusion of Choice is a gray area. While businesses are not obligated to make comparisons easy for competitors, intentionally making it difficult for customers to make informed decisions that are in their own best interest can be viewed as exploitative. The strategy's sustainability depends on a delicate balance: providing enough perceived choice to satisfy diverse needs while introducing enough complexity to achieve the desired outcome. Overplaying this hand can lead to significant backlash and regulatory scrutiny, particularly in consumer-facing industries.
 
 ## ❓ **Key Questions to Ask**
 
-- **Strategic Intent:** Are we trying to genuinely cater to diverse needs, or primarily to make comparison with competitors difficult?
-- **Customer Impact:** What is the likely cognitive load on our customers? At what point does helpful variety become harmful confusion?
-- **Ethical Boundaries:** Would we be comfortable explaining our choice architecture and its intended effects to our customers? Does this strategy disproportionately affect vulnerable customers?
-- **Competitive Vulnerability:** How might this strategy make us vulnerable to competitors who position themselves on simplicity and transparency?
-- **Brand Perception:** What is the long-term impact on our brand if we are perceived as intentionally confusing?
-- **Operational Feasibility:** Can we efficiently manage the complexity we are introducing, or will it lead to internal inefficiencies and increased costs?
+- **Strategic intent:** Are we trying to genuinely cater to diverse needs, or primarily to make comparison with competitors difficult?
+- **Customer impact:** What is the likely cognitive load on our customers? At what point does helpful variety become harmful confusion?
+- **Ethical boundaries:** Would we be comfortable explaining our choice architecture and its intended effects to our customers? Does this strategy disproportionately affect vulnerable customers?
+- **Competitive vulnerability:** How might this strategy make us vulnerable to competitors who position themselves on simplicity and transparency?
+- **Brand perception:** What is the long-term impact on our brand if we are perceived as intentionally confusing?
+- **Operational feasibility:** Can we efficiently manage the complexity we are introducing, or will it lead to internal inefficiencies and increased costs?
+
+## 🔀 **Related Strategies**
+
+- [Bundling](/strategies/pricing/bundling) – Used with confusion: unique bundles make direct comparison hard.
+- [FUD](/strategies/market/fud) – Also prevents rational decision-making but via fear instead of complexity.
+- [Last Man Standing](/strategies/competition/last-man-standing) – Another strategy that exploits competitors' complacency; confusion exploits customers' cognitive limits.
+- [Default Trap](/strategies/user-perception/default-trap) – Relies on users sticking with the default when overwhelmed by choice.
+- [Obfuscation](/strategies/user-perception/obfuscation) – Directly related in method; confusion is a form of obfuscation.
 
 ## 📚 **Further Reading & References**
 
-- Wardley Maps Forum -- *"Confusion of Choice" examples* . Discusses how mobile tariffs and financial products use overwhelming parameters to prevent rational comparison shopping.
-- *The Paradox of Choice* by Barry Schwartz (book) -- though not a strategy manual, it explains the psychology behind why too much choice can hinder decision-making, which is the effect this strategy leverages.
+- [The Paradox of Choice by Barry Schwartz](https://en.wikipedia.org/wiki/The_Paradox_of_Choice) – Explains the psychology behind why too much choice can hinder decision-making.
+- [Choice Overload: A Conceptual Review and Meta-Analysis](https://www.researchgate.net/publication/265170803_Choice_Overload_A_Conceptual_Review_and_Meta-Analysis) – Academic paper on the effects of excessive choice.
+- [Harnessing the power of simplicity in a complex consumer-product environment](https://www.mckinsey.com/~/media/McKinsey/Business%20Functions/Marketing%20and%20Sales/Our%20Insights/Harnessing%20the%20power%20of%20simplicity%20in%20a%20complex%20consumer%20product%20environment/Harnessing-the-power-of-simplicity-in-a-complex-consumer-product-environment.pdf) – Explores the operational and customer impacts of complexity.

--- a/docs/strategies/user-perception/confusion-of-choice/index.md
+++ b/docs/strategies/user-perception/confusion-of-choice/index.md
@@ -1,50 +1,127 @@
 ---
+title: Confusion of Choice
+description: Overwhelming customers with too many options or complex choices so that making a rational decision becomes difficult.
 tags: [confusion-of-choice, user-perception, choice overload, complexity, inertia, comparison prevention]
 ---
 
 # Confusion of choice
 
+**Overwhelming customers with too many options or complex choices so that making a rational decision becomes difficult.**
 
-:::warning
+> Preventing users from making rational decisions by overwhelming them with choice.
+>
+> - Simon Wardley
 
-This is an **early draft** and isn't yet up to our standard.
-You can [contribute improvements](https://github.com/dave1010/wardley-leadership-strategies).
+## 🤔 **Explanation**
 
-:::
+### What is Confusion of Choice?
 
+The strategy's origin is in consumer behavior research: too much choice can paradoxically reduce satisfaction and decision-making ("analysis paralysis"). By introducing confusion, you nudge users to either stick with the familiar or default option (often yours) or make suboptimal choices that favor you. The purpose here is often defensive -- to keep customers from easily comparing alternatives. **Key principle:** make offerings incomparable on key points so customers give up on switching . For example, by having many pricing plans with different feature sets, a competitor's single plan is hard to line up side-by-side; the user may default to staying put. It can also be used offensively in markets -- flood with variants of your own product to crowd shelves and confuse competitor's positioning. Essentially, it exploits cognitive overload.
 
-### **Confusion of Choice**
+## 🗺️ **Real-World Examples**
 
-**Definition & Summary:** Overwhelming customers with **too many options or complex choices** so that making a rational decision becomes difficult . By introducing confusion, you nudge users to either stick with the familiar or default option (often yours) or make suboptimal choices that favor you.
+### Everyday: Mobile carrier plans
 
-**Detailed Explanation:** The strategy's origin is in consumer behavior research: too much choice can paradoxically reduce satisfaction and decision-making ("analysis paralysis"). The purpose here is often defensive -- to keep customers from easily comparing alternatives. **Key principle:** make offerings incomparable on key points so customers give up on switching . For example, by having many pricing plans with different feature sets, a competitor's single plan is hard to line up side-by-side; the user may default to staying put. It can also be used offensively in markets -- flood with variants of your own product to crowd shelves and confuse competitor's positioning. Essentially, it exploits cognitive overload.
+**Mobile carrier plans** are notorious for this . A carrier might offer dozens of slightly different packages (varying data, voice, text, rollover, etc.), making it extremely hard for a customer to identify which plan (even from another carrier) is the best deal. The confusion often leads them to just stick with their current plan or choose a mid-range one that tends to have a higher margin for the carrier.
 
-**Real-World Examples:**
+### Financial services: Credit cards and insurance policies
 
--  *Everyday:* **Mobile carrier plans** are notorious for this . A carrier might offer dozens of slightly different packages (varying data, voice, text, rollover, etc.), making it extremely hard for a customer to identify which plan (even from another carrier) is the best deal. The confusion often leads them to just stick with their current plan or choose a mid-range one that tends to have a higher margin for the carrier.
+Credit cards and insurance policies present so many parameters (rates, fees, rewards, exclusions) that consumers struggle to compare across providers . This confusion can lead to inertia (not switching banks/insurers) or picking an option that *sounds* best due to a promotional feature, while hiding downsides in fine print.
 
--  *Financial services:* Credit cards and insurance policies present so many parameters (rates, fees, rewards, exclusions) that consumers struggle to compare across providers . This confusion can lead to inertia (not switching banks/insurers) or picking an option that *sounds* best due to a promotional feature, while hiding downsides in fine print.
+### Hypothetical: SaaS company response to newcomer
 
--  *Hypothetical:* A SaaS software company is facing a newcomer with a simple, one-price-for-all product. The incumbent responds by segmenting its product into **tiers and add-on modules**, creating a matrix of options. Prospective customers attempting to evaluate it against the newcomer get bogged down deciding which tier they'd need and calculating total cost with add-ons -- a hassle that may tilt them to stick with the incumbent which "at least offers flexibility."
+A SaaS software company is facing a newcomer with a simple, one-price-for-all product. The incumbent responds by segmenting its product into **tiers and add-on modules**, creating a matrix of options. Prospective customers attempting to evaluate it against the newcomer get bogged down deciding which tier they'd need and calculating total cost with add-ons -- a hassle that may tilt them to stick with the incumbent which "at least offers flexibility."
 
-**When to Use / When to Avoid:**
+## 🚦 **When to Use / When to Avoid**
 
 -  **Use when:** You have a complex offering or multiple products and you're the incumbent, and you want to **discourage customers from evaluating competitors** on a straightforward cost/value basis. It's also useful when you can trap customers with a default or "recommended" choice among the confusing options that is in your interest.
 
 -  **Avoid when:** Customers demand simplicity -- in some markets, confusion will just drive them to a competitor who offers a simpler solution. Also avoid if your brand relies on trust and transparency; being overly confusing can erode goodwill.
 
-**Common Pitfalls:**
+## ⚠️ **Common Pitfalls and Warning Signs**
 
--  **Customer frustration:** There's a fine line between confusion that causes inertia and confusion that angers customers into leaving. If they feel tricked (like hidden fees due to confusing terms), it can backfire.
+### **Customer frustration and Backlash**
+There's a fine line between confusion that causes inertia and confusion that angers customers into leaving or publicly complaining. If they feel tricked or that their time is wasted, it can severely damage goodwill.
 
--  **Operational complexity:** Supporting too many variants can strain your operations or sales team (though often companies rationalize variants behind the scenes).
+### **Operational Complexity and Costs**
+Supporting too many product variants, pricing schemes, or service tiers can strain internal operations, increase costs, and make it difficult for sales or support staff to provide clear guidance.
 
--  **Competitive opportunity:** A savvy competitor can *use your confusion against you* -- e.g., market themselves as the simple, transparent alternative, which can be very appealing to customers fed up with complexity.
+### **Attracting 'Simplifier' Competitors**
+Excessive complexity creates a market opportunity for competitors who offer deliberately simple, transparent alternatives, which can be highly appealing to frustrated customers.
 
-**Related Strategies:** **Bundling** (often used with confusion: unique bundles make direct comparison hard), **FUD** (also prevents rational decision-making but via fear instead of complexity), **Last Man Standing** (unrelated in method but another strategy that exploits competitors' complacency -- confusion exploits customers' cognitive limits).
+### **Damaging Brand Trust and Reputation**
+If a brand becomes known for being intentionally opaque or difficult to deal with, it erodes long-term trust and can lead to a negative reputation that is hard to reverse.
 
-**Further Reading & References:**
+## 🔀 **Related Strategies**
 
--  Wardley Maps Forum -- *"Confusion of Choice" examples* . Discusses how mobile tariffs and financial products use overwhelming parameters to prevent rational comparison shopping.
+- **Bundling** (often used with confusion: unique bundles make direct comparison hard)
+- **FUD** (also prevents rational decision-making but via fear instead of complexity)
+- **Last Man Standing** (unrelated in method but another strategy that exploits competitors' complacency -- confusion exploits customers' cognitive limits)
 
--  *The Paradox of Choice* by Barry Schwartz (book) -- though not a strategy manual, it explains the psychology behind why too much choice can hinder decision-making, which is the effect this strategy leverages.
+## 🎯 **Leadership**
+
+### Core challenge
+The primary leadership challenge with "Confusion of Choice" is to strategically introduce complexity or a multitude of options to guide customer behavior or deter switching, without inadvertently creating so much frustration that customers abandon the offerings altogether. Leaders must carefully balance the line between beneficial guidance (e.g., defaults for novice users) and manipulative obfuscation, ensuring that the complexity serves a strategic purpose (like reducing direct comparability with competitors) rather than merely reflecting internal disorganization.
+
+### Key leadership skills required
+- **Ethical Judgment:** Discerning the fine line between strategic ambiguity and harmful customer deception.
+- **Product Portfolio Management:** Skillfully managing a diverse range of products or service tiers to create perceived choice without overwhelming operational capacity.
+- **Market Segmentation Savvy:** Understanding different customer segments' tolerance for complexity and their decision-making processes.
+- **Communication Strategy:** Crafting messaging that simplifies choices where beneficial, while maintaining strategic complexity elsewhere.
+- **Risk Assessment:** Evaluating potential backlash, brand damage, or the creation of opportunities for "simplifier" competitors.
+
+### Ethical considerations
+The deliberate creation of confusion to exploit customer decision-making limitations is ethically dubious. While guiding choices through well-designed defaults or tiered options can be beneficial, intentionally making it difficult for customers to make rational, informed decisions for the company's sole benefit can be seen as manipulative. Transparency is often a casualty. Leaders must consider if the strategy preys on vulnerable customers or creates unfair competitive advantages, potentially damaging long-term trust and brand reputation for short-term gains.
+
+## 📋 **How to Execute**
+
+1.  **Identify Strategic Goal:** Determine the objective: Is it to reduce churn, steer customers to higher-margin products, make competitor comparison difficult, or project an image of catering to all needs?
+2.  **Introduce Product/Service Differentiation:** Create multiple product versions, service tiers, or add-on modules with overlapping or subtly different features and pricing structures. Ensure the differences are complex enough to make direct, apples-to-apples comparisons (especially with competitors) challenging.
+3.  **Design Choice Architecture:** Structure the presentation of options. This might involve highlighting a "recommended" (often high-margin) option, using complex naming conventions, or presenting a very large number of choices simultaneously.
+4.  **Craft Ambiguous Messaging (Optional):** Use marketing language that emphasizes variety and customization but avoids clear, simple explanations of which option is best for whom, or how they directly compare on key metrics.
+5.  **Monitor and Adjust:** Track customer choice patterns, drop-off rates during selection, and competitor responses. Be prepared to simplify certain aspects if customer frustration becomes too high or if "simplifier" competitors gain traction.
+
+## 📈 **Measuring Success**
+
+- **Customer Inertia/Retention Rate:** Higher retention rates, especially if competitors offer simpler or cheaper alternatives, may indicate successful confusion.
+- **Choice of Default/Recommended Options:** High adoption rates of options strategically highlighted or set as default.
+- **Reduced Price Sensitivity:** Customers are less likely to switch based on small price differences if the comparison is too complex.
+- **Sales Cycle Length:** An increase in sales cycle length might indicate customers are struggling with choices, or conversely, are engaging more deeply (needs careful interpretation).
+- **Market Share Stability/Growth:** Maintaining or growing market share despite simpler or more transparent offerings from competitors.
+- **Qualitative Feedback:** Surveys or feedback indicating customers find choices "flexible" or "comprehensive" (positive spin) versus "confusing" or "overwhelming" (negative, but potentially intended).
+
+## ⚠️ **Common Pitfalls and Warning Signs**
+
+### **Customer frustration and Backlash**
+There's a fine line between confusion that causes inertia and confusion that angers customers into leaving or publicly complaining. If they feel tricked or that their time is wasted, it can severely damage goodwill.
+
+### **Operational Complexity and Costs**
+Supporting too many product variants, pricing schemes, or service tiers can strain internal operations, increase costs, and make it difficult for sales or support staff to provide clear guidance.
+
+### **Attracting 'Simplifier' Competitors**
+Excessive complexity creates a market opportunity for competitors who offer deliberately simple, transparent alternatives, which can be highly appealing to frustrated customers.
+
+### **Damaging Brand Trust and Reputation**
+If a brand becomes known for being intentionally opaque or difficult to deal with, it erodes long-term trust and can lead to a negative reputation that is hard to reverse.
+
+## 🧠 **Strategic Insights**
+
+"Confusion of Choice" fundamentally alters competitive dynamics by shifting the basis of competition away from direct, feature-for-feature or price-for-price comparisons. By leveraging cognitive biases such as decision fatigue and analysis paralysis, this strategy can create significant customer inertia, making them less likely to switch providers even if objectively better alternatives exist. This is because the perceived effort of evaluating complex options and comparing them to a competitor's offering outweighs the potential benefit of switching. This can lead to reduced price sensitivity, as customers are unable to easily determine the true value or cost difference between offerings. The strategy often thrives in markets with information asymmetry, where customers lack the expertise or time to fully understand the nuances of different choices.
+
+However, the deliberate obfuscation inherent in "Confusion of Choice" carries substantial risks. While it might deter some customers from switching, it can severely damage brand perception for others, leading to resentment and a loss of trust if customers feel manipulated. This creates an opening for "simplifier" competitors who can differentiate themselves by offering transparent pricing and straightforward product tiers. The emergence of such competitors is a common second-order effect. Furthermore, as markets mature and information becomes more readily available (e.g., through online reviews, comparison sites), the effectiveness of deliberately induced confusion may wane. Companies employing this strategy must be mindful of the evolving information landscape and the increasing consumer demand for transparency.
+
+Ethically, "Confusion of Choice" is a gray area. While businesses are not obligated to make comparisons easy for competitors, intentionally making it difficult for customers to make informed decisions that are in their own best interest can be viewed as exploitative. The strategy's sustainability often depends on a delicate balance: providing enough perceived choice to satisfy diverse needs (or appear to do so) while introducing enough complexity to achieve the desired strategic outcome (e.g., reduced churn, steered choices). Overplaying this hand can lead to significant backlash and regulatory scrutiny, particularly in consumer-facing industries.
+
+## ❓ **Key Questions to Ask**
+
+- **Strategic Intent:** Are we trying to genuinely cater to diverse needs, or primarily to make comparison with competitors difficult?
+- **Customer Impact:** What is the likely cognitive load on our customers? At what point does helpful variety become harmful confusion?
+- **Ethical Boundaries:** Would we be comfortable explaining our choice architecture and its intended effects to our customers? Does this strategy disproportionately affect vulnerable customers?
+- **Competitive Vulnerability:** How might this strategy make us vulnerable to competitors who position themselves on simplicity and transparency?
+- **Brand Perception:** What is the long-term impact on our brand if we are perceived as intentionally confusing?
+- **Operational Feasibility:** Can we efficiently manage the complexity we are introducing, or will it lead to internal inefficiencies and increased costs?
+
+## 📚 **Further Reading & References**
+
+- Wardley Maps Forum -- *"Confusion of Choice" examples* . Discusses how mobile tariffs and financial products use overwhelming parameters to prevent rational comparison shopping.
+- *The Paradox of Choice* by Barry Schwartz (book) -- though not a strategy manual, it explains the psychology behind why too much choice can hinder decision-making, which is the effect this strategy leverages.

--- a/docs/strategies/user-perception/creating-artificial-needs/index.md
+++ b/docs/strategies/user-perception/creating-artificial-needs/index.md
@@ -140,9 +140,8 @@ Counter-strategies often involve education, promoting conscious consumerism, or 
 
 ## 🔀 **Related Strategies**
 
-- [Brand & Marketing](/strategies/user-perception/brand-marketing) - Central to creating needs via messaging.
+- [Brand & Marketing](/strategies/user-perception/brand-and-marketing) - Central to creating needs via messaging.
 - [Education](/strategies/user-perception/education) - A more genuine way to create need by informing why something is important; in artificial needs, the education might be closer to propaganda.
-- [Signal Distortion](/strategies/user-perception/signal-distortion) - Hype can distort signals about what people should care about, contributing to false needs.
 
 ## 📚 **Further Reading & References**
 

--- a/docs/strategies/user-perception/creating-artificial-needs/index.md
+++ b/docs/strategies/user-perception/creating-artificial-needs/index.md
@@ -4,11 +4,9 @@ description: Generating demand by inventing or amplifying a need that did not pr
 tags: [user perception, demand generation, marketing, consumers, influence, creating-artificial-needs]
 ---
 
-# Creating artificial needs
-
 **Generating demand by inventing or amplifying a need that did not previously exist.**
 
-> Creating and elevating an artificial need through marketing and behavioural influence. Take a rock and make it a pet etc.
+> *"Creating and elevating an artificial need through marketing and behavioural influence. Take a rock and make it a pet etc."*
 >
 > - Simon Wardley
 
@@ -16,54 +14,69 @@ tags: [user perception, demand generation, marketing, consumers, influence, crea
 
 ### What is Creating Artificial Needs?
 
-In this strategy, through marketing and influence, a company makes consumers believe they require something new or additional -- essentially shaping desires into perceived needs. The origin of this play is classic consumer marketing: if natural demand is insufficient, create it. The purpose is to **drive new consumption** where none was before. Key principles include clever marketing narratives, social proof, and sometimes psychological triggers (status, fear of missing out, etc.). As one Wardley example humorously notes, "take a rock and make it a pet" -- meaning even a useless object can be sold if you create a need for it in consumers' minds. Often these "needs" attach to emotions or identity (e.g. the need to belong, to appear trendy, to feel secure).
+In this strategy, through marketing and influence, a company makes consumers believe they require something new or additional—essentially shaping desires into perceived needs. The origin of this play is classic consumer marketing: if natural demand is insufficient, create it. The purpose is to **drive new consumption** where none was before. Key principles include clever marketing narratives, social proof, and sometimes psychological triggers (status, fear of missing out, etc.). As one Wardley example humorously notes, "take a rock and make it a pet"—meaning even a useless object can be sold if you create a need for it in consumers' minds. Often these "needs" attach to emotions or identity (e.g. the need to belong, to appear trendy, to feel secure).
+
+### Why use Creating Artificial Needs?
+
+- To unlock new markets or upsell by shifting consumer mindset.
+- To differentiate in a saturated market.
+- To drive growth when organic demand is limited.
+
+### How does Creating Artificial Needs affect the landscape?
+
+- Can redefine market expectations and norms.
+- May create new product categories.
+- Risks backlash if perceived as manipulative or inauthentic.
 
 ## 🗺️ **Real-World Examples**
 
-### *Historical:* De Beers and the diamond engagement ring
+### De Beers and the diamond engagement ring
 
-**De Beers and the diamond engagement ring** is a textbook case . Early 20th century, diamond rings weren't a widespread necessity for engagement. De Beers launched a marketing campaign ("A diamond is forever") that effectively **created an artificial need** -- convincing people that a marriage proposal isn't complete without a diamond ring. Decades later, this invented need persists and De Beers profited immensely .
+Early 20th century, diamond rings weren't a widespread necessity for engagement. De Beers launched a marketing campaign ("A diamond is forever") that effectively **created an artificial need**—convincing people that a marriage proposal isn't complete without a diamond ring. Decades later, this invented need persists and De Beers profited immensely.
 
-### *Contemporary:* High-end electronics makers
+### High-end electronics makers
 
-High-end electronics makers often create needs via iterative product releases -- e.g., Apple's marketing can make consumers feel they *need* the latest smartphone camera features for better life experiences, even if their current phone is adequate. This need is artificially amplified by marketing that equates product ownership with lifestyle or creative potential.
+High-end electronics makers often create needs via iterative product releases—e.g., Apple's marketing can make consumers feel they *need* the latest smartphone camera features for better life experiences, even if their current phone is adequate. This need is artificially amplified by marketing that equates product ownership with lifestyle or creative potential.
 
-### *Hypothetical:* Fitness tech startup and novel metric
+### Fitness tech startup and novel metric (Hypothetical)
 
-A fitness tech startup markets a new wearable that tracks a novel metric (say, "hydration level"). Most people never thought about needing real-time hydration monitoring. Through influencer campaigns and pseudo-scientific content, the startup convinces athletes and health enthusiasts that this metric is the missing key to performance. Demand for a product measuring something no one cared about before suddenly spikes -- an artificial need has been born.
+A fitness tech startup markets a new wearable that tracks a novel metric (say, "hydration level"). Most people never thought about needing real-time hydration monitoring. Through influencer campaigns and pseudo-scientific content, the startup convinces athletes and health enthusiasts that this metric is the missing key to performance. Demand for a product measuring something no one cared about before suddenly spikes—an artificial need has been born.
 
 ## 🚦 **When to Use / When to Avoid**
 
--  **Use when:** You have a new product that solves a problem consumers don't know they have, or you're in a saturated market and want to open a new category. It's effective to **unlock new markets** or upsells by shifting consumer mindset (e.g. convincing users they need yearly upgrades, or accessories, etc.).
+<Assessment strategyName="Creating Artificial Needs">
+  <MapSignals>
+    <li>Our map shows a component with little or no existing demand.</li>
+    <li>We have identified a gap between current user behavior and a new product/service offering.</li>
+    <li>Competitors are not addressing this "need" or category.</li>
+    <li>There is potential to associate the offer with strong emotional or social drivers.</li>
+    <li>Market signals show openness to new trends or status symbols.</li>
+  </MapSignals>
+  <Readiness>
+    <li>We have strong marketing and narrative-building capabilities.</li>
+    <li>We can leverage influencers or social proof effectively.</li>
+    <li>We have processes for monitoring and responding to public sentiment.</li>
+    <li>We are prepared to manage ethical and reputational risks.</li>
+    <li>We can iterate quickly based on feedback and adoption rates.</li>
+  </Readiness>
+</Assessment>
 
--  **Avoid when:** It veers into unethical (manipulating vulnerable audiences) -- there's reputational risk. Also avoid if your product truly provides no value; creating demand for junk might get initial sales but eventually causes customer backlash. Today's consumers are more informed and skeptical.
+### Use when
 
-## ⚠️ **Common Pitfalls and Warning Signs**
+You have a new product that solves a problem consumers don't know they have, or you're in a saturated market and want to open a new category. It's effective to **unlock new markets** or upsells by shifting consumer mindset (e.g. convincing users they need yearly upgrades, or accessories, etc.).
 
-### **Perceived Manipulation and Backlash**
-If consumers perceive the "need" as entirely fabricated for profit and offering little real value, it can lead to significant backlash, accusations of manipulation, and damage to brand reputation. This is especially true if the strategy exploits insecurities.
+### Avoid when
 
-### **Short-Lived Fads vs. Sustainable Needs**
-An artificially created need might only result in a temporary fad. If it's not grounded in some genuine underlying value or utility that persists after the initial novelty or marketing push fades, demand will collapse.
-
-### **Ethical Scrutiny and Regulatory Risk**
-Strategies that are seen as overly aggressive in manufacturing needs, especially those related to health, safety, or financial well-being, can attract negative attention from consumer advocacy groups and regulators.
-
-### **Difficulty in Scaling Authenticity**
-The initial success of creating an artificial need might rely on niche appeal or a sense of exclusivity. As the company tries to scale, maintaining the perceived authenticity or desirability that fueled the initial adoption can be challenging.
-
-## 🔀 **Related Strategies**
-
-- **Brand & Marketing** (central to creating needs via messaging)
-- **Education** (a more genuine way to create need by informing why something is important -- though in artificial needs, the education might be closer to propaganda)
-- **Signal Distortion** (hype can distort signals about what people should care about, contributing to false needs)
+It veers into unethical (manipulating vulnerable audiences)—there's reputational risk. Also avoid if your product truly provides no value; creating demand for junk might get initial sales but eventually causes customer backlash. Today's consumers are more informed and skeptical.
 
 ## 🎯 **Leadership**
 
 ### Core challenge
+
 The core leadership challenge in creating artificial needs is to innovate and generate new market demand in a way that is perceived as valuable and desirable by consumers, rather than manipulative or exploitative. Leaders must navigate the ethical tightrope of shaping desires into perceived needs, ensuring that the "artificial" need ultimately connects to some underlying human aspiration or solves a problem the customer may not have articulated, all while fostering long-term trust and avoiding societal backlash against perceived consumerism or unsustainable practices.
 
 ### Key leadership skills required
+
 - **Ethical Foresight:** Anticipating and mitigating the potential negative consequences of creating new "needs."
 - **Market Intuition & Research:** Deeply understanding latent consumer desires, societal trends, and psychological triggers.
 - **Brand Storytelling & Persuasion:** Crafting compelling narratives that resonate with consumers and associate the product/service with a desired identity or outcome.
@@ -71,15 +84,16 @@ The core leadership challenge in creating artificial needs is to innovate and ge
 - **Long-term Vision:** Focusing on sustainable value creation rather than short-lived fads.
 
 ### Ethical considerations
+
 This strategy is fraught with ethical considerations. Creating needs can easily become manipulative if it preys on insecurities, promotes unhealthy consumption patterns, or misleads consumers about the true value or necessity of a product. There's a significant difference between identifying a latent, unarticulated need and fabricating one purely for profit, especially if the product offers little intrinsic value or contributes to societal problems like excessive consumerism or environmental waste. Leaders must prioritize genuine value creation and transparency, ensuring that the "artificial" need leads to positive outcomes for the user and society.
 
 ## 📋 **How to Execute**
 
-1.  **Identify Latent Desires or Emerging Trends:** Research customer aspirations, pain points they may not consciously recognize, or emerging cultural or technological trends that could form the basis of a new "need."
-2.  **Develop a Compelling Narrative:** Craft a story around the product/service that links it to a desirable outcome, status, identity, or solution to a previously unacknowledged problem. This narrative is key to shaping perception.
-3.  **Leverage Influence and Social Proof:** Utilize marketing campaigns, influencers, early adopters, and media to demonstrate the value and desirability of fulfilling this new "need." Show, don't just tell.
-4.  **Associate with Existing Values or Aspirations:** Connect the artificial need to deeper, pre-existing human desires such as belonging, security, self-improvement, or status to make it more compelling.
-5.  **Reinforce and Normalize:** Continuously reinforce the message through consistent marketing and product evolution, aiming to make the new "need" a widely accepted norm or expectation.
+1. **Identify Latent Desires or Emerging Trends:** Research customer aspirations, pain points they may not consciously recognize, or emerging cultural or technological trends that could form the basis of a new "need."
+2. **Develop a Compelling Narrative:** Craft a story around the product/service that links it to a desirable outcome, status, identity, or solution to a previously unacknowledged problem. This narrative is key to shaping perception.
+3. **Leverage Influence and Social Proof:** Utilize marketing campaigns, influencers, early adopters, and media to demonstrate the value and desirability of fulfilling this new "need." Show, don't just tell.
+4. **Associate with Existing Values or Aspirations:** Connect the artificial need to deeper, pre-existing human desires such as belonging, security, self-improvement, or status to make it more compelling.
+5. **Reinforce and Normalize:** Continuously reinforce the message through consistent marketing and product evolution, aiming to make the new "need" a widely accepted norm or expectation.
 
 ## 📈 **Measuring Success**
 
@@ -91,16 +105,20 @@ This strategy is fraught with ethical considerations. Creating needs can easily 
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
 
-### **Perceived Manipulation and Backlash**
+### Perceived Manipulation and Backlash
+
 If consumers perceive the "need" as entirely fabricated for profit and offering little real value, it can lead to significant backlash, accusations of manipulation, and damage to brand reputation. This is especially true if the strategy exploits insecurities.
 
-### **Short-Lived Fads vs. Sustainable Needs**
+### Short-Lived Fads vs. Sustainable Needs
+
 An artificially created need might only result in a temporary fad. If it's not grounded in some genuine underlying value or utility that persists after the initial novelty or marketing push fades, demand will collapse.
 
-### **Ethical Scrutiny and Regulatory Risk**
+### Ethical Scrutiny and Regulatory Risk
+
 Strategies that are seen as overly aggressive in manufacturing needs, especially those related to health, safety, or financial well-being, can attract negative attention from consumer advocacy groups and regulators.
 
-### **Difficulty in Scaling Authenticity**
+### Difficulty in Scaling Authenticity
+
 The initial success of creating an artificial need might rely on niche appeal or a sense of exclusivity. As the company tries to scale, maintaining the perceived authenticity or desirability that fueled the initial adoption can be challenging.
 
 ## 🧠 **Strategic Insights**
@@ -120,7 +138,12 @@ Counter-strategies often involve education, promoting conscious consumerism, or 
 - **Ethical Line:** Where is the line between clever marketing that highlights a product's benefits and unethical manipulation that creates anxiety or false desires?
 - **Alternative Strategies:** Could we achieve similar market success by focusing on identifying and serving existing, perhaps latent or unarticulated, customer needs rather than creating new ones?
 
+## 🔀 **Related Strategies**
+
+- [Brand & Marketing](/strategies/user-perception/brand-marketing) - Central to creating needs via messaging.
+- [Education](/strategies/user-perception/education) - A more genuine way to create need by informing why something is important; in artificial needs, the education might be closer to propaganda.
+- [Signal Distortion](/strategies/user-perception/signal-distortion) - Hype can distort signals about what people should care about, contributing to false needs.
+
 ## 📚 **Further Reading & References**
 
--  Wardley Maps Forum -- *Examples of Creating Artificial Needs* . Includes the "worthless stones to big bucks" diamond marketing campaign and other illustrations of manufactured demand.
--  HowStuffWorks -- *"How Advertising Invented the Diamond Engagement Ring"* . Explores the De Beers case, showing how marketing created a long-lasting social norm (a need where none existed before).
+- [HowStuffWorks – "How Advertising Invented the Diamond Engagement Ring"](https://money.howstuffworks.com/african-diamond-trade.htm) – Explores the De Beers case, showing how marketing created a long-lasting social norm (a need where none existed before).

--- a/docs/strategies/user-perception/creating-artificial-needs/index.md
+++ b/docs/strategies/user-perception/creating-artificial-needs/index.md
@@ -1,50 +1,126 @@
 ---
-tags: [user perception, demand generation, marketing, consumers, influence]
+title: Creating Artificial Needs
+description: Generating demand by inventing or amplifying a need that did not previously exist.
+tags: [user perception, demand generation, marketing, consumers, influence, creating-artificial-needs]
 ---
 
 # Creating artificial needs
 
-:::warning
+**Generating demand by inventing or amplifying a need that did not previously exist.**
 
-This is an **early draft** and isn't yet up to our standard.
-You can [contribute improvements](https://github.com/dave1010/wardley-leadership-strategies).
+> Creating and elevating an artificial need through marketing and behavioural influence. Take a rock and make it a pet etc.
+>
+> - Simon Wardley
 
-:::
+## 🤔 **Explanation**
 
+### What is Creating Artificial Needs?
 
+In this strategy, through marketing and influence, a company makes consumers believe they require something new or additional -- essentially shaping desires into perceived needs. The origin of this play is classic consumer marketing: if natural demand is insufficient, create it. The purpose is to **drive new consumption** where none was before. Key principles include clever marketing narratives, social proof, and sometimes psychological triggers (status, fear of missing out, etc.). As one Wardley example humorously notes, "take a rock and make it a pet" -- meaning even a useless object can be sold if you create a need for it in consumers' minds. Often these "needs" attach to emotions or identity (e.g. the need to belong, to appear trendy, to feel secure).
 
-### **Creating Artificial Needs**
+## 🗺️ **Real-World Examples**
 
-**Definition & Summary:** Generating demand by **inventing or amplifying a need that did not previously exist** . In this strategy, through marketing and influence, a company makes consumers believe they require something new or additional -- essentially shaping desires into perceived needs.
+### *Historical:* De Beers and the diamond engagement ring
 
-**Detailed Explanation:** The origin of this play is classic consumer marketing: if natural demand is insufficient, create it. The purpose is to **drive new consumption** where none was before. Key principles include clever marketing narratives, social proof, and sometimes psychological triggers (status, fear of missing out, etc.). As one Wardley example humorously notes, "take a rock and make it a pet" -- meaning even a useless object can be sold if you create a need for it in consumers' minds. Often these "needs" attach to emotions or identity (e.g. the need to belong, to appear trendy, to feel secure).
+**De Beers and the diamond engagement ring** is a textbook case . Early 20th century, diamond rings weren't a widespread necessity for engagement. De Beers launched a marketing campaign ("A diamond is forever") that effectively **created an artificial need** -- convincing people that a marriage proposal isn't complete without a diamond ring. Decades later, this invented need persists and De Beers profited immensely .
 
-**Real-World Examples:**
+### *Contemporary:* High-end electronics makers
 
--  *Historical:* **De Beers and the diamond engagement ring** is a textbook case . Early 20th century, diamond rings weren't a widespread necessity for engagement. De Beers launched a marketing campaign ("A diamond is forever") that effectively **created an artificial need** -- convincing people that a marriage proposal isn't complete without a diamond ring. Decades later, this invented need persists and De Beers profited immensely .
+High-end electronics makers often create needs via iterative product releases -- e.g., Apple's marketing can make consumers feel they *need* the latest smartphone camera features for better life experiences, even if their current phone is adequate. This need is artificially amplified by marketing that equates product ownership with lifestyle or creative potential.
 
--  *Contemporary:* High-end electronics makers often create needs via iterative product releases -- e.g., Apple's marketing can make consumers feel they *need* the latest smartphone camera features for better life experiences, even if their current phone is adequate. This need is artificially amplified by marketing that equates product ownership with lifestyle or creative potential.
+### *Hypothetical:* Fitness tech startup and novel metric
 
--  *Hypothetical:* A fitness tech startup markets a new wearable that tracks a novel metric (say, "hydration level"). Most people never thought about needing real-time hydration monitoring. Through influencer campaigns and pseudo-scientific content, the startup convinces athletes and health enthusiasts that this metric is the missing key to performance. Demand for a product measuring something no one cared about before suddenly spikes -- an artificial need has been born.
+A fitness tech startup markets a new wearable that tracks a novel metric (say, "hydration level"). Most people never thought about needing real-time hydration monitoring. Through influencer campaigns and pseudo-scientific content, the startup convinces athletes and health enthusiasts that this metric is the missing key to performance. Demand for a product measuring something no one cared about before suddenly spikes -- an artificial need has been born.
 
-**When to Use / When to Avoid:**
+## 🚦 **When to Use / When to Avoid**
 
 -  **Use when:** You have a new product that solves a problem consumers don't know they have, or you're in a saturated market and want to open a new category. It's effective to **unlock new markets** or upsells by shifting consumer mindset (e.g. convincing users they need yearly upgrades, or accessories, etc.).
 
 -  **Avoid when:** It veers into unethical (manipulating vulnerable audiences) -- there's reputational risk. Also avoid if your product truly provides no value; creating demand for junk might get initial sales but eventually causes customer backlash. Today's consumers are more informed and skeptical.
 
-**Common Pitfalls:**
+## ⚠️ **Common Pitfalls and Warning Signs**
 
--  **Sustainability:** An artificially created need may be a fad. If it's not grounded in some real value, demand might collapse once novelty or marketing fades.
+### **Perceived Manipulation and Backlash**
+If consumers perceive the "need" as entirely fabricated for profit and offering little real value, it can lead to significant backlash, accusations of manipulation, and damage to brand reputation. This is especially true if the strategy exploits insecurities.
 
--  **Consumer trust:** If people realize they were "sold" a non-need (like fad diets or gadgets that end up unused), they may feel cheated, harming brand loyalty.
+### **Short-Lived Fads vs. Sustainable Needs**
+An artificially created need might only result in a temporary fad. If it's not grounded in some genuine underlying value or utility that persists after the initial novelty or marketing push fades, demand will collapse.
 
--  **Competitor response:** If you prove a market exists for something, fast followers can jump in with better or cheaper versions, so the window of advantage may be short.
+### **Ethical Scrutiny and Regulatory Risk**
+Strategies that are seen as overly aggressive in manufacturing needs, especially those related to health, safety, or financial well-being, can attract negative attention from consumer advocacy groups and regulators.
 
-**Related Strategies:** **Brand & Marketing** (central to creating needs via messaging), **Education** (a more genuine way to create need by informing why something is important -- though in artificial needs, the education might be closer to propaganda), **Signal Distortion** (hype can distort signals about what people should care about, contributing to false needs).
+### **Difficulty in Scaling Authenticity**
+The initial success of creating an artificial need might rely on niche appeal or a sense of exclusivity. As the company tries to scale, maintaining the perceived authenticity or desirability that fueled the initial adoption can be challenging.
 
-**Further Reading & References:**
+## 🔀 **Related Strategies**
+
+- **Brand & Marketing** (central to creating needs via messaging)
+- **Education** (a more genuine way to create need by informing why something is important -- though in artificial needs, the education might be closer to propaganda)
+- **Signal Distortion** (hype can distort signals about what people should care about, contributing to false needs)
+
+## 🎯 **Leadership**
+
+### Core challenge
+The core leadership challenge in creating artificial needs is to innovate and generate new market demand in a way that is perceived as valuable and desirable by consumers, rather than manipulative or exploitative. Leaders must navigate the ethical tightrope of shaping desires into perceived needs, ensuring that the "artificial" need ultimately connects to some underlying human aspiration or solves a problem the customer may not have articulated, all while fostering long-term trust and avoiding societal backlash against perceived consumerism or unsustainable practices.
+
+### Key leadership skills required
+- **Ethical Foresight:** Anticipating and mitigating the potential negative consequences of creating new "needs."
+- **Market Intuition & Research:** Deeply understanding latent consumer desires, societal trends, and psychological triggers.
+- **Brand Storytelling & Persuasion:** Crafting compelling narratives that resonate with consumers and associate the product/service with a desired identity or outcome.
+- **Innovation Management:** Driving product or service development that genuinely delivers on the promise of the newly created need.
+- **Long-term Vision:** Focusing on sustainable value creation rather than short-lived fads.
+
+### Ethical considerations
+This strategy is fraught with ethical considerations. Creating needs can easily become manipulative if it preys on insecurities, promotes unhealthy consumption patterns, or misleads consumers about the true value or necessity of a product. There's a significant difference between identifying a latent, unarticulated need and fabricating one purely for profit, especially if the product offers little intrinsic value or contributes to societal problems like excessive consumerism or environmental waste. Leaders must prioritize genuine value creation and transparency, ensuring that the "artificial" need leads to positive outcomes for the user and society.
+
+## 📋 **How to Execute**
+
+1.  **Identify Latent Desires or Emerging Trends:** Research customer aspirations, pain points they may not consciously recognize, or emerging cultural or technological trends that could form the basis of a new "need."
+2.  **Develop a Compelling Narrative:** Craft a story around the product/service that links it to a desirable outcome, status, identity, or solution to a previously unacknowledged problem. This narrative is key to shaping perception.
+3.  **Leverage Influence and Social Proof:** Utilize marketing campaigns, influencers, early adopters, and media to demonstrate the value and desirability of fulfilling this new "need." Show, don't just tell.
+4.  **Associate with Existing Values or Aspirations:** Connect the artificial need to deeper, pre-existing human desires such as belonging, security, self-improvement, or status to make it more compelling.
+5.  **Reinforce and Normalize:** Continuously reinforce the message through consistent marketing and product evolution, aiming to make the new "need" a widely accepted norm or expectation.
+
+## 📈 **Measuring Success**
+
+- **New Market Segment Adoption Rate:** Tracking the speed and volume of adoption among the target audience for whom the "need" was created.
+- **Shift in Consumer Vocabulary/Behavior:** Observing if consumers start incorporating the new "need" or related product category into their regular conversations and purchasing habits.
+- **Premium Pricing Tolerance:** The extent to which customers are willing to pay a premium for products or services that address the newly created "need."
+- **Brand Association Strength:** Measuring how strongly the brand is associated with the new "need" it has cultivated.
+- **Media and Social Media Sentiment:** Analyzing public discourse to gauge whether the created need is seen as a genuine improvement or a manipulative marketing ploy.
+
+## ⚠️ **Common Pitfalls and Warning Signs**
+
+### **Perceived Manipulation and Backlash**
+If consumers perceive the "need" as entirely fabricated for profit and offering little real value, it can lead to significant backlash, accusations of manipulation, and damage to brand reputation. This is especially true if the strategy exploits insecurities.
+
+### **Short-Lived Fads vs. Sustainable Needs**
+An artificially created need might only result in a temporary fad. If it's not grounded in some genuine underlying value or utility that persists after the initial novelty or marketing push fades, demand will collapse.
+
+### **Ethical Scrutiny and Regulatory Risk**
+Strategies that are seen as overly aggressive in manufacturing needs, especially those related to health, safety, or financial well-being, can attract negative attention from consumer advocacy groups and regulators.
+
+### **Difficulty in Scaling Authenticity**
+The initial success of creating an artificial need might rely on niche appeal or a sense of exclusivity. As the company tries to scale, maintaining the perceived authenticity or desirability that fueled the initial adoption can be challenging.
+
+## 🧠 **Strategic Insights**
+
+Creating artificial needs is a high-stakes, high-reward strategy that walks a fine line between visionary market creation and cynical manipulation. When successful, it can redefine markets and establish powerful brand legacies, as seen with De Beers' diamond engagement rings or the ongoing cycle of tech gadget upgrades. The core of this strategy lies in deeply understanding and then shaping user perception, often by associating a product with powerful emotional drivers like status, security, identity, or fear of missing out (FOMO). It's not just about selling a product, but about selling a new normal, a new expectation. This often requires significant investment in marketing, brand building, and creating a narrative that resonates with societal values or aspirations, effectively making the "artificial" feel essential.
+
+The lifecycle of an artificially created need is delicate. Maintenance requires continuous reinforcement through marketing, social proof, and product iterations that appear to validate the ongoing necessity of the product. However, these needs can fade if the underlying value proposition is weak, if societal values shift away from the manufactured desire (e.g., towards minimalism or sustainability, countering consumerism), or if competitors effectively deconstruct the artificial need by offering simpler, more authentic alternatives or by exposing the manufactured nature of the demand. Consumer awareness and access to information also play a crucial role; a more informed public is less susceptible to overtly manipulative tactics.
+
+Counter-strategies often involve education, promoting conscious consumerism, or championing "de-marketing" of such needs. For businesses, a more sustainable approach might involve identifying and amplifying latent needs—problems or desires customers have but haven't articulated—rather than fabricating needs from whole cloth. This still involves shaping perception but starts from a foundation of potential genuine value. The ethical dimension is paramount: leadership must constantly question whether they are genuinely adding value to customers' lives or merely exploiting psychological triggers for short-term gain, which can have long-term repercussions on brand trust and societal well-being.
+
+## ❓ **Key Questions to Ask**
+
+- **Genuine Value:** Does this "new need" ultimately connect to or enhance a genuine human value or solve a previously unarticulated but real problem for the customer?
+- **Societal Impact:** What are the potential long-term societal consequences of successfully manufacturing this need (e.g., on consumer debt, environmental sustainability, mental well-being)?
+- **Transparency:** How transparent are we being about the motivations and mechanisms behind the creation of this need? Would customers feel betrayed if they understood the strategy?
+- **Lifecycle & Sustainability:** How will this created need be maintained over time, and is it vulnerable to shifting consumer values or competitor de-positioning?
+- **Ethical Line:** Where is the line between clever marketing that highlights a product's benefits and unethical manipulation that creates anxiety or false desires?
+- **Alternative Strategies:** Could we achieve similar market success by focusing on identifying and serving existing, perhaps latent or unarticulated, customer needs rather than creating new ones?
+
+## 📚 **Further Reading & References**
 
 -  Wardley Maps Forum -- *Examples of Creating Artificial Needs* . Includes the "worthless stones to big bucks" diamond marketing campaign and other illustrations of manufactured demand.
-
 -  HowStuffWorks -- *"How Advertising Invented the Diamond Engagement Ring"* . Explores the De Beers case, showing how marketing created a long-lasting social norm (a need where none existed before).

--- a/docs/strategies/user-perception/education/index.md
+++ b/docs/strategies/user-perception/education/index.md
@@ -135,8 +135,8 @@ The effectiveness of education strategies often varies with market and product e
 
 ## 🔀 **Related Strategies**
 
-- [Brand & Marketing](/strategies/user-perception/brand-marketing) - Amplifies the educated message and builds trust.
-- [Fear, Uncertainty & Doubt (FUD)](/strategies/user-perception/fud) - The "dark side" alternative of influencing perception with fear.
+- [Brand & Marketing](/strategies/user-perception/brand-and-marketing) - Amplifies the educated message and builds trust.
+- [Fear, Uncertainty & Doubt (FUD)](/strategies/user-perception/fear-uncertainty-and-doubt) - The "dark side" alternative of influencing perception with fear.
 - [Open Approaches](/strategies/accelerators/open-approaches) - Sometimes educating about an open standard to drive its adoption.
 
 ## 📚 **Further Reading & References**

--- a/docs/strategies/user-perception/education/index.md
+++ b/docs/strategies/user-perception/education/index.md
@@ -4,8 +4,6 @@ description: Educating the market or users to overcome their inertia to change b
 tags: [education, user-perception, inertia, adoption, awareness, information, training]
 ---
 
-# Education
-
 **Educating the market or users to overcome their inertia to change by informing them of benefits or risks.**
 
 > Overcoming user inertia to a change through education. There are 16 different forms of inertia and many can be overcome directly with education. Don't underestimate this.
@@ -16,94 +14,113 @@ tags: [education, user-perception, inertia, adoption, awareness, information, tr
 
 ### What is Education?
 
-In essence, it's using truthful information and training to create demand or reduce resistance for a new idea. Originating from the observation that there are many forms of resistance to change, education addresses those by raising awareness. The purpose is to **enable adoption** -- for example, teaching customers why a new technology matters so they are willing to try it. Key principles include clarity, credibility, and relevance: the message must resonate with user needs. Education can be morally positive (e.g. public health campaigns) or strategically self-serving (preparing customers for your product) . It often precedes or accompanies the introduction of change.
+In essence, education is using truthful information and training to create demand or reduce resistance for a new idea. Originating from the observation that there are many forms of resistance to change, education addresses those by raising awareness. The purpose is to **enable adoption** -- for example, teaching customers why a new technology matters so they are willing to try it. Key principles include clarity, credibility, and relevance: the message must resonate with user needs. Education can be morally positive (e.g. public health campaigns) or strategically self-serving (preparing customers for your product). It often precedes or accompanies the introduction of change.
+
+### Why use Education?
+
+- To overcome user or market inertia that blocks adoption of a new product, service, or idea.
+- To build trust and credibility as an authority in the domain.
+- To reduce support costs and improve customer satisfaction by increasing user competence.
+- To shape market perception and create demand for a new category or approach.
+
+### How does Education affect the landscape?
+
+Education can shift user expectations, reduce resistance, and accelerate adoption. It can also inoculate against competitor FUD or, if poorly executed, inadvertently benefit competitors.
 
 ## 🗺️ **Real-World Examples**
 
-### *Historical:* European banks' online security campaigns
+### European banks' online security campaigns
 
-Banks in Europe ran campaigns about online security, teaching customers not to share passwords. Ostensibly "for public good," this also cut into fintech upstarts like Sofort by **educating users on risks** of those new services . By the time fintechs caught on, users were wary -- a defensive education play.
+Banks in Europe ran campaigns about online security, teaching customers not to share passwords. Ostensibly "for public good," this also cut into fintech upstarts like Sofort by **educating users on risks** of those new services. By the time fintechs caught on, users were wary -- a defensive education play.
 
-### *Hypothetical:* Renewable energy firm community education
+### Renewable energy firm community education (Hypothetical)
 
 A renewable energy firm educates communities on the harms of coal and the benefits of solar via workshops and free courses. This **creates a knowledgeable customer base** that later supports and adopts the firm's solar solutions, overcoming "status quo" bias.
 
 ## 🚦 **When to Use / When to Avoid**
 
--  **Use when:** Customers lack awareness or have misconceptions that block adoption of your offering. Education is ideal if your solution is genuinely better but inertia or ignorance holds the market back . Also use it to build trust as an authority.
+<Assessment strategyName="Education">
+  <MapSignals>
+    <li>Our map shows user or market inertia as a key blocker to adoption.</li>
+    <li>There are widespread misconceptions or lack of awareness about our solution or its category.</li>
+    <li>Competitors are using FUD or misinformation to slow adoption.</li>
+    <li>Adoption rates are low despite strong product/market fit.</li>
+    <li>Support or onboarding costs are high due to lack of user understanding.</li>
+  </MapSignals>
+  <Readiness>
+    <li>We have the capability to produce high-quality, accessible educational content.</li>
+    <li>We can commit to a long-term, sustained education effort.</li>
+    <li>We have channels to reach and engage our target audience effectively.</li>
+    <li>We are able to measure and iterate on educational impact.</li>
+    <li>We can maintain objectivity and credibility in our messaging.</li>
+  </Readiness>
+</Assessment>
 
--  **Avoid when:** The value proposition is weak -- educating won't help if your product doesn't actually meet user needs (it may even backfire by raising difficult questions). Also avoid if time-to-market is critical and lengthy education would slow you too much.
+### Use when
 
-## ⚠️ **Common Pitfalls and Warning Signs**
+Customers lack awareness or have misconceptions that block adoption of your offering. Education is ideal if your solution is genuinely better but inertia or ignorance holds the market back. Also use it to build trust as an authority.
 
-### **Preaching without Engagement**
-Simply dumping information on users without making it relatable, interactive, or interesting will likely result in low engagement and minimal impact. Content needs to be tailored to how the audience learns.
+### Avoid when
 
-### **Slow Impact and Impatience**
-Market education is often a long-term play. Expecting immediate results or a direct, short-term ROI can lead to premature abandonment of the strategy. Leadership must be patient.
-
-### **Loss of Credibility**
-If educational content is perceived as overly biased, inaccurate, or merely a veiled sales pitch, it will quickly lose credibility and can damage the organization's reputation. Maintaining objectivity is key.
-
-### **Educating for Competitors**
-Generic industry education, while potentially growing the overall market, might inadvertently benefit competitors equally, especially if your own offerings don't have clear differentiators that the education subtly highlights.
-
-## 🔀 **Related Strategies**
-
-- **Brand & Marketing** (to amplify the educated message)
-- **Fear, Uncertainty & Doubt (FUD)** (the "dark side" alternative of influencing perception with fear)
-- **Open Approaches** (sometimes educating about an open standard to drive its adoption)
+The value proposition is weak -- educating won't help if your product doesn't actually meet user needs (it may even backfire by raising difficult questions). Also avoid if time-to-market is critical and lengthy education would slow you too much.
 
 ## 🎯 **Leadership**
 
 ### Core challenge
+
 The core challenge for leadership in employing an education strategy is committing to a potentially long-term investment with uncertain or indirect ROI, while ensuring the educational content remains objective, accurate, and genuinely valuable to the audience, rather than devolving into mere product marketing. Leaders must champion the creation of high-quality, accessible information that empowers users or the market, and resist pressures to prematurely measure direct sales impact or overly bias the content.
 
 ### Key leadership skills required
-- **Patience and Long-term Vision:** Understanding that market education is often a gradual process with delayed payoffs.
-- **Commitment to Transparency:** Ensuring educational content is genuinely informative and not perceived as biased propaganda.
-- **Communication Prowess:** Ability to simplify complex topics and articulate value in a way that resonates with the target audience.
-- **Curriculum Development Oversight:** Guiding the creation of logical, effective learning pathways for the audience.
-- **Thought Leadership:** Establishing the organization as a credible, authoritative source of information in its domain.
+
+- Patience and long-term vision
+- Commitment to transparency
+- Communication prowess
+- Curriculum development oversight
+- Thought leadership
 
 ### Ethical considerations
-Education as a strategy must be approached with a strong ethical compass. The primary ethical imperative is to provide accurate, truthful, and comprehensive information. It becomes problematic if "education" is used as a guise for spreading misinformation, FUD (Fear, Uncertainty, and Doubt) about competitors, or subtly manipulating users towards a specific commercial outcome without their full awareness. Transparency about sponsorship or a company's role in educational initiatives is crucial. The goal should be genuine empowerment of the user or market, not indoctrination.
+
+Education as a strategy must be approached with a strong ethical compass. The primary ethical imperative is to provide accurate, truthful, and comprehensive information. It becomes problematic if "education" is used as a guise for spreading misinformation, FUD about competitors, or subtly manipulating users towards a specific commercial outcome without their full awareness. Transparency about sponsorship or a company's role in educational initiatives is crucial. The goal should be genuine empowerment of the user or market, not indoctrination.
 
 ## 📋 **How to Execute**
 
-1.  **Identify Knowledge Gaps or Inertia Points:** Determine what specific lack of understanding, misconceptions, or ingrained habits are preventing market adoption or desired user behaviors.
-2.  **Define Learning Objectives and Target Audience:** Clearly state what you want the audience to know, believe, or be able to do after the educational initiative. Segment the audience to tailor content effectively.
-3.  **Develop High-Quality, Accessible Content:** Create engaging and informative materials (e.g., tutorials, white papers, webinars, workshops, certifications) that address the identified knowledge gaps. Ensure content is easy to understand and access.
-4.  **Choose Appropriate Channels for Dissemination:** Select channels that will effectively reach your target audience (e.g., industry conferences, online learning platforms, company website, social media, academic partnerships).
-5.  **Measure Effectiveness and Iterate:** Track metrics to assess the impact of the education (e.g., content engagement, knowledge retention, observed behavior changes, adoption rates). Use feedback to refine and improve educational materials and delivery.
+1. Identify knowledge gaps or inertia points.
+2. Define learning objectives and target audience.
+3. Develop high-quality, accessible content.
+4. Choose appropriate channels for dissemination.
+5. Measure effectiveness and iterate.
 
 ## 📈 **Measuring Success**
 
-- **Adoption Rates of New Practices/Products:** Increased uptake of desired behaviors or products after educational interventions.
-- **Changes in Customer Vocabulary and Understanding:** Customers begin using correct terminology and demonstrating a better understanding of key concepts.
-- **Quality of Customer Feedback/Leads:** Educational efforts can lead to more informed questions and higher-quality leads, as customers better understand their own needs and how the offering fits.
-- **Reduction in Misinformation or FUD:** Observable decrease in the prevalence of common misconceptions within the market or user base.
-- **Website Traffic to Educational Resources & Support Ticket Reduction:** High engagement with educational content and a potential decrease in basic support queries as users become more knowledgeable.
+- Adoption rates of new practices/products
+- Changes in customer vocabulary and understanding
+- Quality of customer feedback/leads
+- Reduction in misinformation or FUD
+- Website traffic to educational resources & support ticket reduction
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
 
-### **Preaching without Engagement**
+### Preaching without Engagement
+
 Simply dumping information on users without making it relatable, interactive, or interesting will likely result in low engagement and minimal impact. Content needs to be tailored to how the audience learns.
 
-### **Slow Impact and Impatience**
+### Slow Impact and Impatience
+
 Market education is often a long-term play. Expecting immediate results or a direct, short-term ROI can lead to premature abandonment of the strategy. Leadership must be patient.
 
-### **Loss of Credibility**
+### Loss of Credibility
+
 If educational content is perceived as overly biased, inaccurate, or merely a veiled sales pitch, it will quickly lose credibility and can damage the organization's reputation. Maintaining objectivity is key.
 
-### **Educating for Competitors**
+### Educating for Competitors
+
 Generic industry education, while potentially growing the overall market, might inadvertently benefit competitors equally, especially if your own offerings don't have clear differentiators that the education subtly highlights.
 
 ## 🧠 **Strategic Insights**
 
-Education as a strategic play is a powerful tool for shaping markets and user behavior over the long term. By investing in the knowledge and understanding of potential customers or the broader ecosystem, organizations can cultivate higher-quality demand. An educated market is more likely to appreciate nuanced value propositions, make informed decisions, and potentially become more loyal, reducing the need for aggressive sales tactics and lowering support costs as users become more self-sufficient. Furthermore, an educated user base can become a valuable source of feedback and co-creation, driving innovation that is well-aligned with genuine needs. This strategy is particularly effective in nascent markets where a new technology or paradigm needs to be understood before it can be widely adopted, or in mature markets where an incumbent seeks to reinforce the value of its ecosystem against simpler, disruptive alternatives.
+Education as a strategic play is a powerful tool for shaping markets and user behavior over the long term. By investing in the knowledge and understanding of potential customers or the broader ecosystem, organizations can cultivate higher-quality demand. An educated market is more likely to appreciate nuanced value propositions, make informed decisions, and potentially become more loyal, reducing the need for aggressive sales tactics and lowering support costs as users become more self-sufficient. Furthermore, an educated user base can become a valuable source of feedback and co-creation, driving innovation that is well-aligned with genuine needs.
 
-Education can be wielded both defensively and offensively. Defensively, it can inoculate a market against competitor FUD by providing clear, factual information, or it can reinforce the value of an established ecosystem by highlighting the complexities and risks of switching or adopting piecemeal solutions. For instance, a company might educate users on the security benefits of its integrated platform. Offensively, education can shape new market categories by defining problems users didn't realize they had and positioning a new type of solution as essential. It can also subtly highlight competitor weaknesses by educating the market on criteria where the educating company excels. The interplay between education and trust is critical; consistently providing valuable, objective information builds an organization's reputation as a thought leader and trusted advisor, which is a significant competitive advantage.
+Education can be wielded both defensively and offensively. Defensively, it can inoculate a market against competitor FUD by providing clear, factual information, or it can reinforce the value of an established ecosystem by highlighting the complexities and risks of switching or adopting piecemeal solutions. Offensively, education can shape new market categories by defining problems users didn't realize they had and positioning a new type of solution as essential. It can also subtly highlight competitor weaknesses by educating the market on criteria where the educating company excels. The interplay between education and trust is critical; consistently providing valuable, objective information builds an organization's reputation as a thought leader and trusted advisor, which is a significant competitive advantage.
 
 The effectiveness of education strategies often varies with market and product evolution. In early stages, education is crucial for explaining the "why" and "what" of a new offering. As a market matures, education might shift towards "how-to" advanced usage, or differentiating based on deeper technical understanding. However, the risk of "educating for competitors" is real if the knowledge imparted is too generic and does not subtly steer towards the unique advantages of the educator's solutions. Therefore, successful education strategies often involve layered content, from broad conceptual knowledge to more specific, solution-oriented information, carefully guiding the audience without overtly selling.
 
@@ -116,8 +133,11 @@ The effectiveness of education strategies often varies with market and product e
 - **Competitive Angle:** How does our education strategy differentiate us or address competitive threats? Are we inadvertently educating the market for our competitors?
 - **Long-Term Commitment:** Are we prepared for the sustained effort and investment required for a successful education strategy, even if tangible results take time to materialize?
 
-## 📚 **Further Reading & References**
+## 🔀 **Related Strategies**
 
--  Wardley, S. -- *On user inertia and education as a gameplay* . Describes how education can overcome the 16 forms of resistance to change.
--  *"Public campaigns and hidden agendas"* -- Example case of banks educating users for security (Wardley Maps Forum) .
+- [Brand & Marketing](/strategies/user-perception/brand-marketing) - Amplifies the educated message and builds trust.
+- [Fear, Uncertainty & Doubt (FUD)](/strategies/user-perception/fud) - The "dark side" alternative of influencing perception with fear.
+- [Open Approaches](/strategies/accelerators/open-approaches) - Sometimes educating about an open standard to drive its adoption.
+
+## 📚 **Further Reading & References**
 

--- a/docs/strategies/user-perception/education/index.md
+++ b/docs/strategies/user-perception/education/index.md
@@ -1,47 +1,123 @@
 ---
+title: Education
+description: Educating the market or users to overcome their inertia to change by informing them of benefits or risks.
 tags: [education, user-perception, inertia, adoption, awareness, information, training]
 ---
 
 # Education
 
-:::warning
+**Educating the market or users to overcome their inertia to change by informing them of benefits or risks.**
 
-This is an **early draft** and isn't yet up to our standard.
-You can [contribute improvements](https://github.com/dave1010/wardley-leadership-strategies).
+> Overcoming user inertia to a change through education. There are 16 different forms of inertia and many can be overcome directly with education. Don't underestimate this.
+>
+> - Simon Wardley
 
-:::
+## 🤔 **Explanation**
 
+### What is Education?
 
-### **Education**
+In essence, it's using truthful information and training to create demand or reduce resistance for a new idea. Originating from the observation that there are many forms of resistance to change, education addresses those by raising awareness. The purpose is to **enable adoption** -- for example, teaching customers why a new technology matters so they are willing to try it. Key principles include clarity, credibility, and relevance: the message must resonate with user needs. Education can be morally positive (e.g. public health campaigns) or strategically self-serving (preparing customers for your product) . It often precedes or accompanies the introduction of change.
 
-**Definition & Summary:** Educating the market or users to overcome their **inertia to change** by informing them of benefits or risks . In essence, it's using truthful information and training to create demand or reduce resistance for a new idea.
+## 🗺️ **Real-World Examples**
 
-**Detailed Explanation:** Originating from the observation that there are many forms of resistance to change, education addresses those by raising awareness. The purpose is to **enable adoption** -- for example, teaching customers why a new technology matters so they are willing to try it. Key principles include clarity, credibility, and relevance: the message must resonate with user needs. Education can be morally positive (e.g. public health campaigns) or strategically self-serving (preparing customers for your product) . It often precedes or accompanies the introduction of change.
+### *Historical:* European banks' online security campaigns
 
-**Real-World Examples:**
+Banks in Europe ran campaigns about online security, teaching customers not to share passwords. Ostensibly "for public good," this also cut into fintech upstarts like Sofort by **educating users on risks** of those new services . By the time fintechs caught on, users were wary -- a defensive education play.
 
--  *Historical:* Banks in Europe ran campaigns about online security, teaching customers not to share passwords. Ostensibly "for public good," this also cut into fintech upstarts like Sofort by **educating users on risks** of those new services . By the time fintechs caught on, users were wary -- a defensive education play.
+### *Hypothetical:* Renewable energy firm community education
 
--  *Hypothetical:* A renewable energy firm educates communities on the harms of coal and the benefits of solar via workshops and free courses. This **creates a knowledgeable customer base** that later supports and adopts the firm's solar solutions, overcoming "status quo" bias.
+A renewable energy firm educates communities on the harms of coal and the benefits of solar via workshops and free courses. This **creates a knowledgeable customer base** that later supports and adopts the firm's solar solutions, overcoming "status quo" bias.
 
-**When to Use / When to Avoid:**
+## 🚦 **When to Use / When to Avoid**
 
 -  **Use when:** Customers lack awareness or have misconceptions that block adoption of your offering. Education is ideal if your solution is genuinely better but inertia or ignorance holds the market back . Also use it to build trust as an authority.
 
 -  **Avoid when:** The value proposition is weak -- educating won't help if your product doesn't actually meet user needs (it may even backfire by raising difficult questions). Also avoid if time-to-market is critical and lengthy education would slow you too much.
 
-**Common Pitfalls:**
+## ⚠️ **Common Pitfalls and Warning Signs**
 
--  **Preaching without engagement:** Dumping information on users without making it relatable or interesting will be ignored.
+### **Preaching without Engagement**
+Simply dumping information on users without making it relatable, interactive, or interesting will likely result in low engagement and minimal impact. Content needs to be tailored to how the audience learns.
 
--  **Slow impact:** Education campaigns take time; you might educate the market only for a competitor to swoop in.
+### **Slow Impact and Impatience**
+Market education is often a long-term play. Expecting immediate results or a direct, short-term ROI can lead to premature abandonment of the strategy. Leadership must be patient.
 
--  **Credibility risk:** If users suspect your "education" is just marketing spin, trust erodes (e.g. a biased whitepaper could be seen as propaganda).
+### **Loss of Credibility**
+If educational content is perceived as overly biased, inaccurate, or merely a veiled sales pitch, it will quickly lose credibility and can damage the organization's reputation. Maintaining objectivity is key.
 
-**Related Strategies:** **Brand & Marketing** (to amplify the educated message), **Fear, Uncertainty & Doubt (FUD)** (the "dark side" alternative of influencing perception with fear), **Open Approaches** (sometimes educating about an open standard to drive its adoption).
+### **Educating for Competitors**
+Generic industry education, while potentially growing the overall market, might inadvertently benefit competitors equally, especially if your own offerings don't have clear differentiators that the education subtly highlights.
 
-**Further Reading & References:**
+## 🔀 **Related Strategies**
+
+- **Brand & Marketing** (to amplify the educated message)
+- **Fear, Uncertainty & Doubt (FUD)** (the "dark side" alternative of influencing perception with fear)
+- **Open Approaches** (sometimes educating about an open standard to drive its adoption)
+
+## 🎯 **Leadership**
+
+### Core challenge
+The core challenge for leadership in employing an education strategy is committing to a potentially long-term investment with uncertain or indirect ROI, while ensuring the educational content remains objective, accurate, and genuinely valuable to the audience, rather than devolving into mere product marketing. Leaders must champion the creation of high-quality, accessible information that empowers users or the market, and resist pressures to prematurely measure direct sales impact or overly bias the content.
+
+### Key leadership skills required
+- **Patience and Long-term Vision:** Understanding that market education is often a gradual process with delayed payoffs.
+- **Commitment to Transparency:** Ensuring educational content is genuinely informative and not perceived as biased propaganda.
+- **Communication Prowess:** Ability to simplify complex topics and articulate value in a way that resonates with the target audience.
+- **Curriculum Development Oversight:** Guiding the creation of logical, effective learning pathways for the audience.
+- **Thought Leadership:** Establishing the organization as a credible, authoritative source of information in its domain.
+
+### Ethical considerations
+Education as a strategy must be approached with a strong ethical compass. The primary ethical imperative is to provide accurate, truthful, and comprehensive information. It becomes problematic if "education" is used as a guise for spreading misinformation, FUD (Fear, Uncertainty, and Doubt) about competitors, or subtly manipulating users towards a specific commercial outcome without their full awareness. Transparency about sponsorship or a company's role in educational initiatives is crucial. The goal should be genuine empowerment of the user or market, not indoctrination.
+
+## 📋 **How to Execute**
+
+1.  **Identify Knowledge Gaps or Inertia Points:** Determine what specific lack of understanding, misconceptions, or ingrained habits are preventing market adoption or desired user behaviors.
+2.  **Define Learning Objectives and Target Audience:** Clearly state what you want the audience to know, believe, or be able to do after the educational initiative. Segment the audience to tailor content effectively.
+3.  **Develop High-Quality, Accessible Content:** Create engaging and informative materials (e.g., tutorials, white papers, webinars, workshops, certifications) that address the identified knowledge gaps. Ensure content is easy to understand and access.
+4.  **Choose Appropriate Channels for Dissemination:** Select channels that will effectively reach your target audience (e.g., industry conferences, online learning platforms, company website, social media, academic partnerships).
+5.  **Measure Effectiveness and Iterate:** Track metrics to assess the impact of the education (e.g., content engagement, knowledge retention, observed behavior changes, adoption rates). Use feedback to refine and improve educational materials and delivery.
+
+## 📈 **Measuring Success**
+
+- **Adoption Rates of New Practices/Products:** Increased uptake of desired behaviors or products after educational interventions.
+- **Changes in Customer Vocabulary and Understanding:** Customers begin using correct terminology and demonstrating a better understanding of key concepts.
+- **Quality of Customer Feedback/Leads:** Educational efforts can lead to more informed questions and higher-quality leads, as customers better understand their own needs and how the offering fits.
+- **Reduction in Misinformation or FUD:** Observable decrease in the prevalence of common misconceptions within the market or user base.
+- **Website Traffic to Educational Resources & Support Ticket Reduction:** High engagement with educational content and a potential decrease in basic support queries as users become more knowledgeable.
+
+## ⚠️ **Common Pitfalls and Warning Signs**
+
+### **Preaching without Engagement**
+Simply dumping information on users without making it relatable, interactive, or interesting will likely result in low engagement and minimal impact. Content needs to be tailored to how the audience learns.
+
+### **Slow Impact and Impatience**
+Market education is often a long-term play. Expecting immediate results or a direct, short-term ROI can lead to premature abandonment of the strategy. Leadership must be patient.
+
+### **Loss of Credibility**
+If educational content is perceived as overly biased, inaccurate, or merely a veiled sales pitch, it will quickly lose credibility and can damage the organization's reputation. Maintaining objectivity is key.
+
+### **Educating for Competitors**
+Generic industry education, while potentially growing the overall market, might inadvertently benefit competitors equally, especially if your own offerings don't have clear differentiators that the education subtly highlights.
+
+## 🧠 **Strategic Insights**
+
+Education as a strategic play is a powerful tool for shaping markets and user behavior over the long term. By investing in the knowledge and understanding of potential customers or the broader ecosystem, organizations can cultivate higher-quality demand. An educated market is more likely to appreciate nuanced value propositions, make informed decisions, and potentially become more loyal, reducing the need for aggressive sales tactics and lowering support costs as users become more self-sufficient. Furthermore, an educated user base can become a valuable source of feedback and co-creation, driving innovation that is well-aligned with genuine needs. This strategy is particularly effective in nascent markets where a new technology or paradigm needs to be understood before it can be widely adopted, or in mature markets where an incumbent seeks to reinforce the value of its ecosystem against simpler, disruptive alternatives.
+
+Education can be wielded both defensively and offensively. Defensively, it can inoculate a market against competitor FUD by providing clear, factual information, or it can reinforce the value of an established ecosystem by highlighting the complexities and risks of switching or adopting piecemeal solutions. For instance, a company might educate users on the security benefits of its integrated platform. Offensively, education can shape new market categories by defining problems users didn't realize they had and positioning a new type of solution as essential. It can also subtly highlight competitor weaknesses by educating the market on criteria where the educating company excels. The interplay between education and trust is critical; consistently providing valuable, objective information builds an organization's reputation as a thought leader and trusted advisor, which is a significant competitive advantage.
+
+The effectiveness of education strategies often varies with market and product evolution. In early stages, education is crucial for explaining the "why" and "what" of a new offering. As a market matures, education might shift towards "how-to" advanced usage, or differentiating based on deeper technical understanding. However, the risk of "educating for competitors" is real if the knowledge imparted is too generic and does not subtly steer towards the unique advantages of the educator's solutions. Therefore, successful education strategies often involve layered content, from broad conceptual knowledge to more specific, solution-oriented information, carefully guiding the audience without overtly selling.
+
+## ❓ **Key Questions to Ask**
+
+- **Primary Goal:** What specific inertia, misconception, or lack of awareness are we trying to address with this education initiative?
+- **Target Audience & Channels:** Who exactly are we trying to educate, and what are the most effective channels and formats to reach and engage them?
+- **Content Objectivity:** How will we ensure our educational content is perceived as credible and valuable, rather than just marketing material? What is our process for maintaining accuracy?
+- **Measuring Impact:** What are the key leading and lagging indicators we will use to measure the success of our education strategy, beyond direct sales?
+- **Competitive Angle:** How does our education strategy differentiate us or address competitive threats? Are we inadvertently educating the market for our competitors?
+- **Long-Term Commitment:** Are we prepared for the sustained effort and investment required for a successful education strategy, even if tangible results take time to materialize?
+
+## 📚 **Further Reading & References**
 
 -  Wardley, S. -- *On user inertia and education as a gameplay* . Describes how education can overcome the 16 forms of resistance to change.
-
 -  *"Public campaigns and hidden agendas"* -- Example case of banks educating users for security (Wardley Maps Forum) .
+

--- a/docs/strategies/user-perception/fear-uncertainty-and-doubt/index.md
+++ b/docs/strategies/user-perception/fear-uncertainty-and-doubt/index.md
@@ -1,14 +1,12 @@
 ---
 title: Fear, Uncertainty and Doubt
 description: A classic tactic of spreading fear, uncertainty, and doubt to slow adoption of a competitor's innovation or to dissuade customers from switching.
-tags: [fear-uncertainty-and-doubt, user-perception, fud, competition, messaging, risk perception, slowing adoption]
+tags: [user-perception, fud, competition, messaging, risk perception, slowing adoption]
 ---
-
-# Fear, uncertainty and doubt
 
 **A classic tactic of spreading fear, uncertainty, and doubt to slow adoption of a competitor's innovation or to dissuade customers from switching.**
 
-> Creating fear, uncertainty and doubt over a change in order to slow it down.
+> *"Creating fear, uncertainty and doubt over a change in order to slow it down."*
 >
 > - Simon Wardley
 
@@ -16,114 +14,139 @@ tags: [fear-uncertainty-and-doubt, user-perception, fud, competition, messaging,
 
 ### What is Fear, Uncertainty, and Doubt (FUD)?
 
-FUD leverages negative messaging -- often subtle insinuations -- to exploit customer anxieties. Pioneered by IBM and famously used by Microsoft , FUD creates hesitation. The purpose is to **protect the status quo** by making potential buyers question the reliability, security, or longevity of a new alternative. Key principles: you don't have to lie outright (often you pose "questions" or highlight uncertainties). By seeding doubt, you impose a psychological switching cost. FUD is tactical "marketing" with a negative bent -- a means-ends leadership strategy to stall competitors' momentum . It's most effective when customers lack expertise and crave safety, playing into "no one got fired for choosing [incumbent]" thinking .
+FUD leverages negative messaging—often subtle insinuations—to exploit customer anxieties. Pioneered by IBM and famously used by Microsoft, FUD creates hesitation. The purpose is to **protect the status quo** by making potential buyers question the reliability, security, or longevity of a new alternative.
+
+- You don't have to lie outright; often you pose "questions" or highlight uncertainties.
+- By seeding doubt, you impose a psychological switching cost.
+- FUD is tactical "marketing" with a negative bent—a means-ends leadership strategy to stall competitors' momentum.
+- It's most effective when customers lack expertise and crave safety, playing into "no one got fired for choosing [incumbent]" thinking.
+
+### Why use FUD?
+
+- To slow down adoption of a competitor's innovation.
+- To maintain customer inertia and protect market share.
+- To buy time for your own organization to respond to competitive threats.
+
+### How to use FUD?
+
+- Subtly raise concerns about competitors' stability, security, or future.
+- Use insinuation and ambiguity rather than direct falsehoods.
+- Disseminate through informal channels or proxies for plausible deniability.
 
 ## 🗺️ **Real-World Examples**
 
-### *Historical:* IBM's "Nobody ever got fired..."
+### IBM's "Nobody ever got fired..."
 
-IBM's slogan "Nobody ever got fired for buying IBM" is quintessential FUD . It implied that choosing other vendors is career-risking because they're unproven or risky. This **slowed customers from trying smaller competitors**, reinforcing IBM's dominance in its era.
+IBM's slogan "Nobody ever got fired for buying IBM" is quintessential FUD. It implied that choosing other vendors is career-risking because they're unproven or risky, slowing customers from trying smaller competitors and reinforcing IBM's dominance.
 
-### *Historical:* Microsoft on Linux
+### Microsoft on Linux
 
-In the Linux vs. Windows rivalry, Microsoft at times spread FUD about Linux ("Linux is not free; it's controlled by Red Hat") . This message injected doubt among businesses considering Linux by suggesting a hidden dependence on a single vendor.
+In the Linux vs. Windows rivalry, Microsoft at times spread FUD about Linux ("Linux is not free; it's controlled by Red Hat"), injecting doubt among businesses considering Linux by suggesting a hidden dependence on a single vendor.
 
-### *Hypothetical:* Cloud incumbent on new entrant
+### Hypothetical: Cloud incumbent on new entrant
 
-A market leader in cloud services whispers about a new entrant: "Sure, their service is cheap, but **will they be around in 2 years?**" -- sowing doubt about the startup's stability, causing cautious enterprise customers to stick with the safe choice.
+A market leader in cloud services whispers about a new entrant: "Sure, their service is cheap, but **will they be around in 2 years?**"—sowing doubt about the startup's stability, causing cautious enterprise customers to stick with the safe choice.
 
 ## 🚦 **When to Use / When to Avoid**
 
--  **Use when:** You're an incumbent facing a threatening new competitor or technology, and you need to **buy time** . It's a defensive play to maintain customer inertia. Also used in competitive sales situations to sway undecided clients by raising concerns about rivals.
+<Assessment strategyName="Fear, Uncertainty and Doubt">
+  <MapSignals>
+    <li>Our map shows a competitor's offering in an early or unproven stage.</li>
+    <li>Customers express anxiety about change or new entrants.</li>
+    <li>We have a strong incumbent position with high customer inertia.</li>
+    <li>There is significant information asymmetry in the market.</li>
+    <li>Switching costs are psychological or reputational, not just technical.</li>
+  </MapSignals>
+  <Readiness>
+    <li>We have disciplined, consistent messaging across sales and marketing.</li>
+    <li>Our team understands the ethical and legal boundaries of competitive messaging.</li>
+    <li>We can monitor and respond to market sentiment quickly.</li>
+    <li>We have a crisis communication plan in place.</li>
+    <li>We are prepared to counter FUD if it is used against us.</li>
+  </Readiness>
+</Assessment>
 
--  **Avoid when:** Ethical or cultural standards won't tolerate it (FUD can damage your reputation if customers or media call you out). Also avoid if the claims are easily disproven -- savvy customers will fact-check and you'll lose credibility. New entrants should avoid using FUD against incumbents (it's usually a tool of the powerful defending ground).
+### Use when
 
-## ⚠️ **Common Pitfalls and Warning Signs**
+- You're an incumbent facing a threatening new competitor or technology and need to buy time.
+- In competitive sales situations to sway undecided clients by raising concerns about rivals.
 
-### **Backfiring and Loss of Credibility**
-If FUD is too aggressive, easily disproven, or seen through by savvy customers (especially in technical markets), it can severely damage the instigator's credibility and brand trust.
+### Avoid when
 
-### **Legal and PR Consequences**
-Spreading information that is demonstrably false can lead to legal action for defamation or unfair competition, resulting in costly lawsuits and significant public relations crises.
-
-### **Inviting Reciprocal Attacks**
-Employing FUD often invites competitors to respond in kind, leading to a negative market environment where customers become cynical about all players.
-
-### **Damaging Overall Market Growth**
-Excessive FUD can create so much uncertainty that it stifles adoption of new technologies or market growth altogether, harming all participants, including potentially the FUD instigator in the long run.
-
-## 🔀 **Related Strategies**
-
-- **Signal Distortion** (manipulating market signals is similar in spirit)
-- **Misdirection** (another deceptive tactic)
-- **Lobbying** (using fear-based arguments in regulatory affairs is essentially FUD toward policymakers)
+- Ethical or cultural standards won't tolerate it (FUD can damage your reputation if called out).
+- Claims are easily disproven—savvy customers will fact-check and you'll lose credibility.
+- New entrants should avoid using FUD against incumbents (it's usually a tool of the powerful defending ground).
 
 ## 🎯 **Leadership**
 
 ### Core challenge
-The core leadership challenge in using FUD is navigating the treacherous ethical terrain and managing the significant risks of reputational damage and loss of trust, even if the FUD is subtly deployed or framed as "raising legitimate concerns." Deciding whether to employ FUD, to what extent, and how to control the narrative requires careful consideration of long-term consequences versus short-term competitive gains. For leaders whose organizations are targeted by FUD, the challenge is to effectively counter it without amplifying the FUD itself or appearing overly defensive.
+
+Navigating the ethical terrain and managing the risks of reputational damage and loss of trust, even if FUD is subtly deployed or framed as "raising legitimate concerns." Leaders must weigh short-term gains against long-term consequences.
 
 ### Key leadership skills required
-- **Ethical Judgment:** Discerning the fine line between highlighting genuine risks and spreading misleading information.
-- **Competitive Analysis:** Accurately identifying competitor vulnerabilities that FUD might exploit, or understanding the FUD tactics used by rivals.
-- **Risk Assessment & Management:** Evaluating the potential for FUD to backfire, damage brand reputation, or invite legal challenges.
-- **Crisis Communication:** Preparing to respond effectively if FUD tactics are exposed or if the organization itself is a target of FUD.
-- **Strategic Communication:** Crafting messages that subtly sow doubt if employing FUD, or clearly and credibly refute it if countering FUD.
+
+- Ethical judgment: discerning the line between highlighting genuine risks and spreading misleading information.
+- Competitive analysis: identifying vulnerabilities or understanding FUD tactics used by rivals.
+- Risk assessment & management: evaluating the potential for FUD to backfire.
+- Crisis communication: responding if FUD tactics are exposed or if targeted by FUD.
+- Strategic communication: crafting subtle messages or credibly refuting FUD.
 
 ### Ethical considerations
-FUD inherently operates in a gray ethical area. While companies have a right to compete vigorously, intentionally spreading misleading or false information to create fear, uncertainty, and doubt in customers' minds about a competitor's products or viability is deceptive and harmful. It can stifle innovation by creating undue hesitation around new technologies and can manipulate customers into making decisions not based on merit. Leaders must weigh the competitive desire to win against the ethical responsibility to engage truthfully with the market. Using FUD can also foster a cynical internal culture.
+
+FUD operates in a gray ethical area. While companies have a right to compete, intentionally spreading misleading or false information is deceptive and harmful. It can stifle innovation and manipulate customers into decisions not based on merit.
 
 ## 📋 **How to Execute**
 
 **If deploying FUD (use with extreme caution):**
 
-1.  **Identify Competitor Vulnerability or Market Anxiety:** Pinpoint areas where a competitor is perceived as weak (e.g., newness, financial stability, security model) or where customers already have underlying anxieties (e.g., data privacy, technological complexity).
-2.  **Craft Subtle Messaging:** Develop talking points, questions, or "concerns" that allude to these vulnerabilities without making direct, easily disprovable false statements. Focus on insinuation and ambiguity.
-3.  **Selective Dissemination:** Spread the FUD through informal channels, third-party proxies (e.g., "independent" consultants, anonymous online comments), or sales teams trained to raise these "concerns" during customer interactions.
-4.  **Plausible Deniability:** Maintain a distance from the direct dissemination of FUD to avoid direct attribution and reputational damage if the tactic is exposed.
+1. Identify competitor vulnerability or market anxiety.
+2. Craft subtle messaging that alludes to these vulnerabilities without direct false statements.
+3. Selectively disseminate through informal channels or proxies.
+4. Maintain plausible deniability.
 
 **If countering FUD:**
 
-1.  **Monitor and Identify FUD:** Actively listen to market chatter, customer feedback, and sales team reports to detect FUD being spread about your organization or products.
-2.  **Prepare Transparent Rebuttals:** Develop clear, concise, and evidence-based responses to the FUD. Focus on facts, customer testimonials, third-party validations, and guarantees.
-3.  **Educate and Reassure:** Proactively educate your customers, partners, and the market about the points being targeted by FUD. Reassure them of your stability, security, and value proposition.
-4.  **Consider Strategic Silence or Direct Confrontation:** Depending on the FUD's impact, choose to either ignore it (to avoid amplifying it) or directly address and debunk it. Highlighting your strengths can be more effective than just refuting claims.
-5.  **Inoculate the Market:** Build strong brand trust and transparency over time, making your customer base less susceptible to FUD in the first place.
+1. Monitor and identify FUD in the market.
+2. Prepare transparent, evidence-based rebuttals.
+3. Educate and reassure customers and partners.
+4. Choose between strategic silence or direct confrontation.
+5. Inoculate the market through brand trust and transparency.
 
 ## 📈 **Measuring Success**
 
-**If deploying FUD:**
-- **Slowed Competitor Adoption:** Observable lag in the market uptake of a competitor's product or service that was targeted by FUD.
-- **Increased Customer Inquiries Expressing Rival Concerns:** Sales or support channels report more customers citing doubts about competitors (related to the FUD points) as a reason for choosing your offering or delaying a switch.
-- **Shift in Market Sentiment/Analyst Reports:** Market analysts or media begin to echo the "uncertainties" or "risks" highlighted by the FUD campaign.
-- **Competitor Forced to Respond:** The target of the FUD feels compelled to issue public statements or change their marketing to address the doubts raised.
-
-**If countering FUD:**
-- **Stabilized or Increased Adoption Rates:** Your product adoption rates remain steady or improve despite FUD campaigns against you.
-- **Positive Customer Testimonials and Case Studies:** Increased public sharing of positive experiences that directly counter FUD narratives.
-- **Reduced Inquiries about FUD-related Concerns:** Fewer customers or prospects raise the specific doubts being spread by competitors.
+- Slowed competitor adoption.
+- Increased customer inquiries expressing rival concerns.
+- Shift in market sentiment or analyst reports echoing FUD points.
+- Competitor forced to respond.
+- Stabilized or increased adoption rates (if countering FUD).
+- Positive customer testimonials and case studies.
+- Reduced inquiries about FUD-related concerns.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
 
-### **Backfiring and Loss of Credibility**
-If FUD is too aggressive, easily disproven, or seen through by savvy customers (especially in technical markets), it can severely damage the instigator's credibility and brand trust.
+### Backfiring and Loss of Credibility
 
-### **Legal and PR Consequences**
-Spreading information that is demonstrably false can lead to legal action for defamation or unfair competition, resulting in costly lawsuits and significant public relations crises.
+If FUD is too aggressive or easily disproven, it can severely damage credibility and brand trust.
 
-### **Inviting Reciprocal Attacks**
-Employing FUD often invites competitors to respond in kind, leading to a negative market environment where customers become cynical about all players.
+### Legal and PR Consequences
 
-### **Damaging Overall Market Growth**
-Excessive FUD can create so much uncertainty that it stifles adoption of new technologies or market growth altogether, harming all participants, including potentially the FUD instigator in the long run.
+Spreading demonstrably false information can lead to legal action and PR crises.
+
+### Inviting Reciprocal Attacks
+
+Employing FUD often invites competitors to respond in kind, leading to a negative market environment.
+
+### Damaging Overall Market Growth
+
+Excessive FUD can stifle adoption of new technologies or market growth, harming all participants.
 
 ## 🧠 **Strategic Insights**
 
-FUD, at its core, is a strategy of information warfare that exploits uncertainty and information asymmetry. Its sustainability is often limited; while it can be a potent short-term tactic to slow a competitor or protect an incumbent's market share, it rarely works as a long-term defensive shield if the targeted innovation offers genuine value. Over time, truth tends to emerge, and superior products or services often overcome doubt, especially in markets with increasing transparency. The primary risk for the FUD instigator is severe damage to brand perception and trust. Once a company is known for deploying FUD, its credibility in all communications can be compromised, making future product launches or legitimate competitive distinctions harder to message.
+FUD is a strategy of information warfare exploiting uncertainty and information asymmetry. It is potent short-term but rarely works as a long-term shield if the targeted innovation offers genuine value. Over time, truth tends to emerge, and superior products often overcome doubt, especially in transparent markets. The main risk for the FUD instigator is severe damage to brand perception and trust. Once known for deploying FUD, credibility in all communications is compromised.
 
-Countering FUD effectively requires a multi-pronged approach. Direct rebuttal can be necessary but must be handled carefully to avoid amplifying the original FUD. A more powerful long-term strategy is "inoculation" through consistent transparency, strong customer relationships, and proactive education that addresses potential concerns before they are exploited by competitors. Building a strong, trusted brand is perhaps the best defense. In the digital age, FUD tactics have evolved, leveraging social media for rapid dissemination of rumors, astroturfing (creating fake grassroots support or concern), and using complex technical jargon to confuse non-expert audiences. This makes monitoring and responding to FUD more challenging but also more critical.
+Countering FUD requires a multi-pronged approach: direct rebuttal, inoculation through transparency, and building strong customer relationships. In the digital age, FUD tactics have evolved, leveraging social media and astroturfing, making monitoring and response more critical.
 
-The ethical spectrum of FUD is broad. At one end, simply highlighting a competitor's known weaknesses or genuinely questioning the readiness of a new, unproven technology might be considered aggressive but legitimate competition. At the other extreme lies the deliberate fabrication of falsehoods, a practice that is not only unethical but also legally perilous. The challenge for strategists is that FUD often operates in the murky middle, using insinuation, selective presentation of facts, and leading questions to create doubt without making easily refutable false statements. This is where ethical leadership and a clear company code of conduct become paramount.
+The ethical spectrum of FUD is broad, from aggressive but legitimate competition to outright fabrication. Most FUD operates in the murky middle, using insinuation and selective facts. Ethical leadership and a clear code of conduct are paramount.
 
 ## ❓ **Key Questions to Ask**
 
@@ -134,7 +157,12 @@ The ethical spectrum of FUD is broad. At one end, simply highlighting a competit
 - **Ethical Line:** Where do we draw the line between responsible competitive differentiation and unethical FUD? Does this action align with our company values?
 - **Information Environment:** How does the current level of information asymmetry in our market affect the potential effectiveness or risk of FUD tactics?
 
+## 🔀 **Related Strategies**
+
+- [Signal Distortion](/strategies/user-perception/signal-distortion) – Manipulating market signals is similar in spirit.
+- [Misdirection](/strategies/user-perception/misdirection) – Another deceptive tactic.
+- [Lobbying](/strategies/market/lobbying) – Using fear-based arguments in regulatory affairs is essentially FUD toward policymakers.
+
 ## 📚 **Further Reading & References**
 
--  Wired (1999) -- *"FUD, Counter-FUD"* . Explains FUD's origins with IBM/Microsoft and how insinuating rival tech is "untrustworthy" became a go-to strategy.
--  Wardley Maps Forum -- *Examples of FUD* . Lists instances like IBM's famous phrase and how FUD's **purpose is to slow down change** by exploiting customer fear.
+- [Wired (1999) – "FUD, Counter-FUD"](https://www.wired.com/1999/04/fud-counter-fud/) – Explains FUD's origins with IBM/Microsoft and how insinuating rival tech is "untrustworthy" became a go-to strategy.

--- a/docs/strategies/user-perception/fear-uncertainty-and-doubt/index.md
+++ b/docs/strategies/user-perception/fear-uncertainty-and-doubt/index.md
@@ -1,49 +1,140 @@
 ---
+title: Fear, Uncertainty and Doubt
+description: A classic tactic of spreading fear, uncertainty, and doubt to slow adoption of a competitor's innovation or to dissuade customers from switching.
 tags: [fear-uncertainty-and-doubt, user-perception, fud, competition, messaging, risk perception, slowing adoption]
 ---
 
 # Fear, uncertainty and doubt
 
-:::warning
+**A classic tactic of spreading fear, uncertainty, and doubt to slow adoption of a competitor's innovation or to dissuade customers from switching.**
 
-This is an **early draft** and isn't yet up to our standard.
-You can [contribute improvements](https://github.com/dave1010/wardley-leadership-strategies).
+> Creating fear, uncertainty and doubt over a change in order to slow it down.
+>
+> - Simon Wardley
 
-:::
+## 🤔 **Explanation**
 
+### What is Fear, Uncertainty, and Doubt (FUD)?
 
-### **Fear, Uncertainty, and Doubt (FUD)**
+FUD leverages negative messaging -- often subtle insinuations -- to exploit customer anxieties. Pioneered by IBM and famously used by Microsoft , FUD creates hesitation. The purpose is to **protect the status quo** by making potential buyers question the reliability, security, or longevity of a new alternative. Key principles: you don't have to lie outright (often you pose "questions" or highlight uncertainties). By seeding doubt, you impose a psychological switching cost. FUD is tactical "marketing" with a negative bent -- a means-ends leadership strategy to stall competitors' momentum . It's most effective when customers lack expertise and crave safety, playing into "no one got fired for choosing [incumbent]" thinking .
 
-**Definition & Summary:** A classic tactic of **spreading fear, uncertainty, and doubt** to slow adoption of a competitor's innovation or to dissuade customers from switching . FUD leverages negative messaging -- often subtle insinuations -- to exploit customer anxieties.
+## 🗺️ **Real-World Examples**
 
-**Detailed Explanation:** Pioneered by IBM and famously used by Microsoft , FUD creates hesitation. The purpose is to **protect the status quo** by making potential buyers question the reliability, security, or longevity of a new alternative. Key principles: you don't have to lie outright (often you pose "questions" or highlight uncertainties). By seeding doubt, you impose a psychological switching cost. FUD is tactical "marketing" with a negative bent -- a means-ends leadership strategy to stall competitors' momentum . It's most effective when customers lack expertise and crave safety, playing into "no one got fired for choosing [incumbent]" thinking .
+### *Historical:* IBM's "Nobody ever got fired..."
 
-**Real-World Examples:**
+IBM's slogan "Nobody ever got fired for buying IBM" is quintessential FUD . It implied that choosing other vendors is career-risking because they're unproven or risky. This **slowed customers from trying smaller competitors**, reinforcing IBM's dominance in its era.
 
--  *Historical:* IBM's slogan "Nobody ever got fired for buying IBM" is quintessential FUD . It implied that choosing other vendors is career-risking because they're unproven or risky. This **slowed customers from trying smaller competitors**, reinforcing IBM's dominance in its era.
+### *Historical:* Microsoft on Linux
 
--  *Historical:* In the Linux vs. Windows rivalry, Microsoft at times spread FUD about Linux ("Linux is not free; it's controlled by Red Hat") . This message injected doubt among businesses considering Linux by suggesting a hidden dependence on a single vendor.
+In the Linux vs. Windows rivalry, Microsoft at times spread FUD about Linux ("Linux is not free; it's controlled by Red Hat") . This message injected doubt among businesses considering Linux by suggesting a hidden dependence on a single vendor.
 
--  *Hypothetical:* A market leader in cloud services whispers about a new entrant: "Sure, their service is cheap, but **will they be around in 2 years?**" -- sowing doubt about the startup's stability, causing cautious enterprise customers to stick with the safe choice.
+### *Hypothetical:* Cloud incumbent on new entrant
 
-**When to Use / When to Avoid:**
+A market leader in cloud services whispers about a new entrant: "Sure, their service is cheap, but **will they be around in 2 years?**" -- sowing doubt about the startup's stability, causing cautious enterprise customers to stick with the safe choice.
+
+## 🚦 **When to Use / When to Avoid**
 
 -  **Use when:** You're an incumbent facing a threatening new competitor or technology, and you need to **buy time** . It's a defensive play to maintain customer inertia. Also used in competitive sales situations to sway undecided clients by raising concerns about rivals.
 
 -  **Avoid when:** Ethical or cultural standards won't tolerate it (FUD can damage your reputation if customers or media call you out). Also avoid if the claims are easily disproven -- savvy customers will fact-check and you'll lose credibility. New entrants should avoid using FUD against incumbents (it's usually a tool of the powerful defending ground).
 
-**Common Pitfalls:**
+## ⚠️ **Common Pitfalls and Warning Signs**
 
--  **Backfire with savvy customers:** Technologists, for example, might see through FUD and lose respect for the source.
+### **Backfiring and Loss of Credibility**
+If FUD is too aggressive, easily disproven, or seen through by savvy customers (especially in technical markets), it can severely damage the instigator's credibility and brand trust.
 
--  **Legal/PR consequences:** If FUD crosses into falsehood, it can lead to libel or slander issues and PR crises.
+### **Legal and PR Consequences**
+Spreading information that is demonstrably false can lead to legal action for defamation or unfair competition, resulting in costly lawsuits and significant public relations crises.
 
--  **Self-deception:** Relying on FUD may blind you to real improvements competitors are making -- dismissing them as "hype" could mean you **underestimate a serious threat** .
+### **Inviting Reciprocal Attacks**
+Employing FUD often invites competitors to respond in kind, leading to a negative market environment where customers become cynical about all players.
 
-**Related Strategies:** **Signal Distortion** (manipulating market signals is similar in spirit), **Misdirection** (another deceptive tactic), **Lobbying** (using fear-based arguments in regulatory affairs is essentially FUD toward policymakers).
+### **Damaging Overall Market Growth**
+Excessive FUD can create so much uncertainty that it stifles adoption of new technologies or market growth altogether, harming all participants, including potentially the FUD instigator in the long run.
 
-**Further Reading & References:**
+## 🔀 **Related Strategies**
+
+- **Signal Distortion** (manipulating market signals is similar in spirit)
+- **Misdirection** (another deceptive tactic)
+- **Lobbying** (using fear-based arguments in regulatory affairs is essentially FUD toward policymakers)
+
+## 🎯 **Leadership**
+
+### Core challenge
+The core leadership challenge in using FUD is navigating the treacherous ethical terrain and managing the significant risks of reputational damage and loss of trust, even if the FUD is subtly deployed or framed as "raising legitimate concerns." Deciding whether to employ FUD, to what extent, and how to control the narrative requires careful consideration of long-term consequences versus short-term competitive gains. For leaders whose organizations are targeted by FUD, the challenge is to effectively counter it without amplifying the FUD itself or appearing overly defensive.
+
+### Key leadership skills required
+- **Ethical Judgment:** Discerning the fine line between highlighting genuine risks and spreading misleading information.
+- **Competitive Analysis:** Accurately identifying competitor vulnerabilities that FUD might exploit, or understanding the FUD tactics used by rivals.
+- **Risk Assessment & Management:** Evaluating the potential for FUD to backfire, damage brand reputation, or invite legal challenges.
+- **Crisis Communication:** Preparing to respond effectively if FUD tactics are exposed or if the organization itself is a target of FUD.
+- **Strategic Communication:** Crafting messages that subtly sow doubt if employing FUD, or clearly and credibly refute it if countering FUD.
+
+### Ethical considerations
+FUD inherently operates in a gray ethical area. While companies have a right to compete vigorously, intentionally spreading misleading or false information to create fear, uncertainty, and doubt in customers' minds about a competitor's products or viability is deceptive and harmful. It can stifle innovation by creating undue hesitation around new technologies and can manipulate customers into making decisions not based on merit. Leaders must weigh the competitive desire to win against the ethical responsibility to engage truthfully with the market. Using FUD can also foster a cynical internal culture.
+
+## 📋 **How to Execute**
+
+**If deploying FUD (use with extreme caution):**
+
+1.  **Identify Competitor Vulnerability or Market Anxiety:** Pinpoint areas where a competitor is perceived as weak (e.g., newness, financial stability, security model) or where customers already have underlying anxieties (e.g., data privacy, technological complexity).
+2.  **Craft Subtle Messaging:** Develop talking points, questions, or "concerns" that allude to these vulnerabilities without making direct, easily disprovable false statements. Focus on insinuation and ambiguity.
+3.  **Selective Dissemination:** Spread the FUD through informal channels, third-party proxies (e.g., "independent" consultants, anonymous online comments), or sales teams trained to raise these "concerns" during customer interactions.
+4.  **Plausible Deniability:** Maintain a distance from the direct dissemination of FUD to avoid direct attribution and reputational damage if the tactic is exposed.
+
+**If countering FUD:**
+
+1.  **Monitor and Identify FUD:** Actively listen to market chatter, customer feedback, and sales team reports to detect FUD being spread about your organization or products.
+2.  **Prepare Transparent Rebuttals:** Develop clear, concise, and evidence-based responses to the FUD. Focus on facts, customer testimonials, third-party validations, and guarantees.
+3.  **Educate and Reassure:** Proactively educate your customers, partners, and the market about the points being targeted by FUD. Reassure them of your stability, security, and value proposition.
+4.  **Consider Strategic Silence or Direct Confrontation:** Depending on the FUD's impact, choose to either ignore it (to avoid amplifying it) or directly address and debunk it. Highlighting your strengths can be more effective than just refuting claims.
+5.  **Inoculate the Market:** Build strong brand trust and transparency over time, making your customer base less susceptible to FUD in the first place.
+
+## 📈 **Measuring Success**
+
+**If deploying FUD:**
+- **Slowed Competitor Adoption:** Observable lag in the market uptake of a competitor's product or service that was targeted by FUD.
+- **Increased Customer Inquiries Expressing Rival Concerns:** Sales or support channels report more customers citing doubts about competitors (related to the FUD points) as a reason for choosing your offering or delaying a switch.
+- **Shift in Market Sentiment/Analyst Reports:** Market analysts or media begin to echo the "uncertainties" or "risks" highlighted by the FUD campaign.
+- **Competitor Forced to Respond:** The target of the FUD feels compelled to issue public statements or change their marketing to address the doubts raised.
+
+**If countering FUD:**
+- **Stabilized or Increased Adoption Rates:** Your product adoption rates remain steady or improve despite FUD campaigns against you.
+- **Positive Customer Testimonials and Case Studies:** Increased public sharing of positive experiences that directly counter FUD narratives.
+- **Reduced Inquiries about FUD-related Concerns:** Fewer customers or prospects raise the specific doubts being spread by competitors.
+
+## ⚠️ **Common Pitfalls and Warning Signs**
+
+### **Backfiring and Loss of Credibility**
+If FUD is too aggressive, easily disproven, or seen through by savvy customers (especially in technical markets), it can severely damage the instigator's credibility and brand trust.
+
+### **Legal and PR Consequences**
+Spreading information that is demonstrably false can lead to legal action for defamation or unfair competition, resulting in costly lawsuits and significant public relations crises.
+
+### **Inviting Reciprocal Attacks**
+Employing FUD often invites competitors to respond in kind, leading to a negative market environment where customers become cynical about all players.
+
+### **Damaging Overall Market Growth**
+Excessive FUD can create so much uncertainty that it stifles adoption of new technologies or market growth altogether, harming all participants, including potentially the FUD instigator in the long run.
+
+## 🧠 **Strategic Insights**
+
+FUD, at its core, is a strategy of information warfare that exploits uncertainty and information asymmetry. Its sustainability is often limited; while it can be a potent short-term tactic to slow a competitor or protect an incumbent's market share, it rarely works as a long-term defensive shield if the targeted innovation offers genuine value. Over time, truth tends to emerge, and superior products or services often overcome doubt, especially in markets with increasing transparency. The primary risk for the FUD instigator is severe damage to brand perception and trust. Once a company is known for deploying FUD, its credibility in all communications can be compromised, making future product launches or legitimate competitive distinctions harder to message.
+
+Countering FUD effectively requires a multi-pronged approach. Direct rebuttal can be necessary but must be handled carefully to avoid amplifying the original FUD. A more powerful long-term strategy is "inoculation" through consistent transparency, strong customer relationships, and proactive education that addresses potential concerns before they are exploited by competitors. Building a strong, trusted brand is perhaps the best defense. In the digital age, FUD tactics have evolved, leveraging social media for rapid dissemination of rumors, astroturfing (creating fake grassroots support or concern), and using complex technical jargon to confuse non-expert audiences. This makes monitoring and responding to FUD more challenging but also more critical.
+
+The ethical spectrum of FUD is broad. At one end, simply highlighting a competitor's known weaknesses or genuinely questioning the readiness of a new, unproven technology might be considered aggressive but legitimate competition. At the other extreme lies the deliberate fabrication of falsehoods, a practice that is not only unethical but also legally perilous. The challenge for strategists is that FUD often operates in the murky middle, using insinuation, selective presentation of facts, and leading questions to create doubt without making easily refutable false statements. This is where ethical leadership and a clear company code of conduct become paramount.
+
+## ❓ **Key Questions to Ask**
+
+- **Truthfulness:** Are the concerns we are raising (or that are being raised against us) based on verifiable facts, or are they speculative, misleading, or false?
+- **Customer Perception:** How will our target customers likely perceive these messages? Will they see them as helpful warnings or as manipulative tactics?
+- **Brand Impact:** What is the potential long-term impact on our brand reputation and customer trust if we deploy FUD, or if we fail to effectively counter FUD from competitors?
+- **Competitive Dynamics:** Is this FUD likely to achieve its short-term goal of slowing a competitor? What are the likely retaliatory responses?
+- **Ethical Line:** Where do we draw the line between responsible competitive differentiation and unethical FUD? Does this action align with our company values?
+- **Information Environment:** How does the current level of information asymmetry in our market affect the potential effectiveness or risk of FUD tactics?
+
+## 📚 **Further Reading & References**
 
 -  Wired (1999) -- *"FUD, Counter-FUD"* . Explains FUD's origins with IBM/Microsoft and how insinuating rival tech is "untrustworthy" became a go-to strategy.
-
 -  Wardley Maps Forum -- *Examples of FUD* . Lists instances like IBM's famous phrase and how FUD's **purpose is to slow down change** by exploiting customer fear.

--- a/docs/strategies/user-perception/fear-uncertainty-and-doubt/index.md
+++ b/docs/strategies/user-perception/fear-uncertainty-and-doubt/index.md
@@ -159,9 +159,8 @@ The ethical spectrum of FUD is broad, from aggressive but legitimate competition
 
 ## 🔀 **Related Strategies**
 
-- [Signal Distortion](/strategies/user-perception/signal-distortion) – Manipulating market signals is similar in spirit.
-- [Misdirection](/strategies/user-perception/misdirection) – Another deceptive tactic.
-- [Lobbying](/strategies/market/lobbying) – Using fear-based arguments in regulatory affairs is essentially FUD toward policymakers.
+- [Misdirection](/strategies/competitor/misdirection) – Another deceptive tactic.
+- [Lobbying](/strategies/user-perception/lobbying) – Using fear-based arguments in regulatory affairs is essentially FUD toward policymakers.
 
 ## 📚 **Further Reading & References**
 


### PR DESCRIPTION
Five strategy pages in the
docs/strategies/user-perception/ directory:

- bundling
- confusion-of-choice
- creating-artificial-needs
- education
- fear-uncertainty-and-doubt

