### PR TITLE
updated the strategy category page for Accelerators.

### DIFF
--- a/docs/strategies/accelerators/index.md
+++ b/docs/strategies/accelerators/index.md
@@ -4,10 +4,70 @@ description: Accelerate evolution and market development
 
 # Accelerators
 
-Accelerators are about pushing components and markets to evolve faster. You’re trying to speed up commoditisation or adoption so that new higher-order systems can emerge. Think of it as clearing the runway for future plays.
+In Wardley Mapping, Accelerators are strategic plays designed to expedite the evolution of components, services, or practices. They focus on increasing the speed of commoditization and adoption, thereby enabling the emergence of new, higher-order systems and capabilities. By reducing friction and building momentum, Accelerators clear the path for future innovations and strategic advancements.
 
-*Open approaches*, *market enablement*, and *network effects* all aim to reduce friction and increase momentum. Use them when you're ready to industrialise or when your strategy depends on shifting others forward.
+These strategies are particularly useful when a component needs to become more widespread or standardized to unlock further value, or when your overall strategy relies on the rapid maturation of other elements in the ecosystem. Accelerators encompass a range of techniques, including leveraging open approaches, enabling markets, and fostering network effects, all aimed at catalyzing change and driving progress across the landscape.
 
+## 🤔 **What are Accelerators?**
+
+Accelerators in Wardley Mapping are proactive measures taken to speed up the natural evolutionary flow of a component or market. The primary goal is to reduce the time it takes for something to move from a nascent, uncertain stage (like Genesis or Custom-Built) towards a more mature, stable, and widespread state (like Product/Rental or Commodity/Utility). By doing so, you not only make the component itself more reliable and cost-effective but also unlock opportunities for new innovations that can be built upon this newly stabilized foundation.
+
+Several distinct sub-strategies can be employed to achieve this acceleration:
+
+*   **[Cooperation](/strategies/accelerators/cooperation)**: Involves working with other parties, even competitors, to standardize and commoditize a component. This shared effort reduces individual investment and risk, speeding up evolution for all involved.
+*   **[Exploiting Network Effects](/strategies/accelerators/exploiting-network-effects)**: Focuses on creating and leveraging the value that increases as more users adopt a component or service. This drives rapid adoption and can quickly push a component towards becoming a de facto standard.
+*   **[Industrial Policy](/strategies/accelerators/industrial-policy)**: Relates to governmental or large-scale organizational interventions designed to encourage the development and adoption of specific industries or technologies, thereby accelerating their evolution.
+*   **[Market Enablement](/strategies/accelerators/market-enablement)**: Involves creating the conditions necessary for a market around a component to thrive. This might include establishing standards, reducing barriers to entry, or fostering trust, all of which help the market mature faster.
+*   **[Open Approaches](/strategies/accelerators/open-approaches)**: Making a component open source or using open standards can dramatically accelerate its adoption and development. It invites broader collaboration, reduces costs for adopters, and speeds up the journey towards commoditization.
+
+Each of these approaches provides a different lever to influence the speed of evolution, helping to strategically shape the landscape to your advantage.
+
+## 🚀 **Why Use Accelerators?**
+
+Employing Accelerator strategies offers significant strategic advantages, allowing organizations to proactively shape their operational landscape rather than merely reacting to it. By intentionally speeding up the evolution of certain components, businesses can:
+
+*   **Gain First-Mover Advantage:** By accelerating a component towards commodity or utility, you can be among the first to leverage it for new innovations, capturing market share before competitors adapt.
+*   **Enable Higher-Order Systems:** Commoditized components become reliable building blocks. Accelerating their availability means you can start developing more complex, valuable systems on top of them sooner. For example, the widespread availability of commodity compute (an accelerated component) enabled the rise of cloud services and big data analytics.
+*   **Respond to Market Dynamics:** In fast-moving environments, the ability to accelerate the adoption of new technologies or standards can be crucial for survival and growth. This allows organizations to pivot quickly and capitalize on emerging trends.
+*   **Drive Down Costs:** Pushing components towards commoditization inherently drives down their costs. This can free up resources for investment in other areas of the value chain, improving overall efficiency and profitability.
+*   **Build and Leverage Ecosystem Momentum:** Accelerators like open approaches or network effects can create a vibrant ecosystem around a component. This shared momentum can lead to further innovation, wider adoption, and a stronger competitive position as the ecosystem co-evolves.
+*   **Reduce Uncertainty:** As components evolve towards more mature states, they become more predictable in terms of performance, cost, and availability. Accelerating this process helps reduce uncertainty in your strategic planning.
+
+Ultimately, Accelerators are about playing an offensive game. They allow you to influence the pace of change, create new opportunities, and build a more resilient and adaptive organization.
+
+## ⚖️ **Accelerators vs. Decelerators**
+
+While Accelerators focus on speeding up evolution, it's important to understand their counterparts: **[Decelerators](/strategies/decelerators/)**. These two types of strategies represent opposing forces that organizations can use to manipulate the speed of change for a component or within a market.
+
+Accelerators, as we've discussed, aim to hasten commoditization, encourage widespread adoption, and pave the way for new innovations by making foundational components more readily available and cost-effective. They are about pushing forward, often by reducing friction or increasing incentives for change.
+
+Decelerators, on the other hand, are employed to slow down this evolutionary process. Organizations might use decelerating tactics to:
+
+*   Protect existing, profitable revenue streams tied to less evolved components.
+*   Buy time to adapt their own capabilities and offerings in the face of rapid market shifts.
+*   Create barriers to entry or slow down the progress of competitors.
+*   Manage the risks associated with too-rapid change before the organization or market is ready.
+
+Understanding both sets of strategies is crucial for a comprehensive approach to Wardley Mapping. The choice to accelerate or decelerate depends heavily on an organization's current position, its strategic goals, and the specific context of the component or market in question. Sometimes, a mixed approach might even be necessary, accelerating certain components while strategically decelerating others.
+
+## ➕ **Identifying Other Potential Accelerators**
+
+The strategies explicitly listed under "Accelerators" are not the only ways to speed up component evolution or market development. Many other strategic plays, while perhaps categorized differently, can have significant accelerating effects. The key is to analyze the *impact* of a strategy on the speed of change.
+
+Look for strategies that exhibit characteristics such as:
+
+*   **Significant Friction Reduction:** Any action that makes a component or service much easier, cheaper, or faster to adopt or use can act as an accelerator.
+*   **Promotion of Standards:** Strategies that establish, promote, or rely on recognized standards often accelerate evolution by ensuring interoperability, reducing uncertainty, and enabling a broader ecosystem.
+*   **Ecosystem and Community Building:** Actions that cultivate a large, active community or a vibrant ecosystem around a component can rapidly drive its development, adoption, and refinement.
+*   **Rapid Capability Enhancement:** Strategies that allow an organization to quickly gain new, critical capabilities (e.g., through partnerships, licensing, or targeted acquisitions) can accelerate their ability to compete or innovate in a market.
+
+Considering these characteristics, other strategies might be viewed through an "accelerator lens":
+
+*   **"[Land Grab](/strategies/positional/land-grab)"**: While primarily a positional play, a successful land grab aims to quickly acquire dominant market share. This rapid expansion can accelerate market development around your offering, pressure competitors, and potentially hasten the commoditization of underlying components as you scale.
+*   **"[Acquisition](/strategies/structural/acquisition)" (Strategic)**: Acquiring a company with key technologies or market access can be a powerful accelerator, allowing the acquirer to bypass slower organic development and rapidly advance its position or offerings. This can speed up the integration of new capabilities and accelerate entry into new evolutionary stages for certain components.
+*   **Platform Plays (Internal or External):** Developing and promoting a platform (e.g., a technical platform, a data platform) can accelerate the development of services and products that build upon it. By providing standardized tools and interfaces, platforms reduce the effort needed for higher-order system creation.
+
+The crucial takeaway is to assess how a strategy influences the evolutionary lifecycle. If its primary effect is to speed up movement towards more evolved states (e.g., from custom-built to product, or product to commodity) for key components, then it's acting as an accelerator, regardless of its formal classification.
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';


### PR DESCRIPTION
- Defined Accelerators in Wardley Mapping.
- Summarized the sub-strategies in this section.
- Explained why you might use Accelerators.
- Contrasted Accelerators with Decelerators.
- Discussed how to identify other strategies with accelerating effects.
