### PR TITLE
Add Doctrines section

### DIFF
--- a/docs/doctrines/.keep
+++ b/docs/doctrines/.keep
@@ -1,0 +1,1 @@
+# This is a placeholder file to ensure the directory is created.

--- a/docs/doctrines/use-a-common-language.md
+++ b/docs/doctrines/use-a-common-language.md
@@ -1,0 +1,11 @@
+---
+title: "Use a common language"
+stage: "Stop Self-Destructive Behavior"
+category: "Communication"
+---
+
+# Use a common language
+
+Using a "common language" in the context of Wardley Mapping means establishing a shared, unambiguous way of describing and discussing strategy, primarily through the use of maps. When everyone in an organization is trained to create, read, and interpret Wardley Maps, it removes ambiguity and enables effective communication about the strategic landscape, proposed changes, and potential challenges.
+
+This shared understanding is crucial because it allows for more effective collaboration and faster, more informed decision-making. Without a common language like Wardley Mapping, discussions about strategy can become muddled by differing assumptions, terminology, and mental models. Maps provide a visual and structured format that ensures everyone is looking at the same picture, facilitating clearer dialogue and a more cohesive strategic execution.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -111,6 +111,10 @@ const config: Config = {
           to: '/strategies',
         },
         {
+          label: 'Doctrines',
+          to: '/doctrines',
+        },
+        {
           label: 'Terms',
           to: '/terms',
         },


### PR DESCRIPTION
Updates the `use-a-common-language.md` doctrine page with a more detailed explanation of what "Use a common language" means in the context of Wardley Mapping and its importance.

This addresses your feedback to replace the placeholder text with relevant copy.