### PR TITLE
Add helper scripts for related strategies

### DIFF
--- a/scripts/add_related_links.py
+++ b/scripts/add_related_links.py
@@ -1,0 +1,107 @@
+import os
+import re
+import csv
+import sys
+
+STRATEGY_DIR = os.path.join('docs', 'strategies')
+link_pattern = re.compile(r'\[[^\]]+\]\((/strategies[^)\s#]+)')
+title_pattern = re.compile(r'^title:\s*(.+)$', re.MULTILINE)
+
+
+def normalize(slug: str) -> str:
+    slug = slug.split('#')[0]
+    return slug.rstrip('/')
+
+
+def slug_to_path(slug: str) -> str:
+    return os.path.join('docs', slug.lstrip('/'), 'index.md')
+
+
+def get_title(slug: str) -> str:
+    path = slug_to_path(slug)
+    with open(path, 'r', encoding='utf-8') as f:
+        text = f.read()
+    m = title_pattern.search(text)
+    if m:
+        return m.group(1).strip('"')
+    return slug.rsplit('/', 1)[-1]
+
+
+def parse_doc(path: str):
+    with open(path, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+    text = ''.join(lines)
+    links = {normalize(m) for m in link_pattern.findall(text)}
+    slug = '/' + os.path.relpath(os.path.dirname(path), 'docs')
+    slug = normalize(slug)
+    links.discard(slug)
+    related = set()
+    section_idx = None
+    for idx, line in enumerate(lines):
+        if 'Related Strategies' in line:
+            section_idx = idx
+            for j in range(idx + 1, len(lines)):
+                l = lines[j]
+                if l.startswith('#'):
+                    break
+                for m in link_pattern.findall(l):
+                    related.add(normalize(m))
+            break
+    return slug, links, related, section_idx is not None
+
+
+def collect_docs():
+    docs = {}
+    related_map = {}
+    section_map = {}
+    for root, dirs, files in os.walk(STRATEGY_DIR):
+        if 'index.md' in files and root.count(os.sep) >= 3:
+            path = os.path.join(root, 'index.md')
+            slug, links, rel, has_sec = parse_doc(path)
+            docs[slug] = links
+            related_map[slug] = rel
+            section_map[slug] = has_sec
+    return docs, related_map, section_map
+
+
+def add_links():
+    docs, related_map, section_map = collect_docs()
+    writer = csv.writer(sys.stdout)
+    writer.writerow(['source', 'target'])
+    count = 0
+    for src, targets in docs.items():
+        missing = [t for t in targets if t in docs and t not in related_map[src]]
+        if not missing:
+            continue
+        path = slug_to_path(src)
+        with open(path, 'r', encoding='utf-8') as f:
+            lines = f.readlines()
+        if section_map[src]:
+            idx = next(i for i, l in enumerate(lines) if 'Related Strategies' in l)
+            insert_idx = idx + 1
+            while insert_idx < len(lines) and not lines[insert_idx].startswith('#'):
+                insert_idx += 1
+            new_lines = [f"- [{get_title(t)}]({t})\n" for t in missing]
+            lines[insert_idx:insert_idx] = new_lines
+        else:
+            header = "## 🔀 **Related Strategies**\n"
+            new_lines = [header] + [f"- [{get_title(t)}]({t})\n" for t in missing] + ["\n"]
+            insert_idx = None
+            for i, l in enumerate(lines):
+                if 'Further Reading & References' in l:
+                    insert_idx = i
+                    break
+            if insert_idx is None:
+                lines.extend(['\n'] + new_lines)
+            else:
+                lines[insert_idx:insert_idx] = new_lines
+        with open(path, 'w', encoding='utf-8') as f:
+            f.writelines(lines)
+        for t in missing:
+            writer.writerow([src, t])
+            count += 1
+    print(count, file=sys.stderr)
+
+
+if __name__ == '__main__':
+    add_links()

--- a/scripts/check_reciprocal_links.py
+++ b/scripts/check_reciprocal_links.py
@@ -1,0 +1,42 @@
+import os
+import re
+import csv
+import sys
+
+STRATEGY_DIR = os.path.join('docs', 'strategies')
+
+link_pattern = re.compile(r'\[[^\]]+\]\((/strategies[^)\s#]+)')
+
+def normalize(slug: str) -> str:
+    slug = slug.split('#')[0]
+    return slug.rstrip('/')
+
+def collect_docs():
+    docs = {}
+    for root, dirs, files in os.walk(STRATEGY_DIR):
+        if 'index.md' in files and root.count(os.sep) >= 3:
+            path = os.path.join(root, 'index.md')
+            slug = '/' + os.path.relpath(root, 'docs')
+            slug = normalize(slug)
+            with open(path, 'r', encoding='utf-8') as f:
+                text = f.read()
+            links = {normalize(m) for m in link_pattern.findall(text)}
+            links.discard(slug)
+            docs[slug] = links
+    return docs
+
+def main():
+    docs = collect_docs()
+    issues = []
+    for src, targets in docs.items():
+        for tgt in targets:
+            if tgt in docs and src not in docs[tgt]:
+                issues.append((src, tgt))
+    writer = csv.writer(sys.stdout)
+    writer.writerow(['source', 'target'])
+    for src, tgt in issues:
+        writer.writerow([src, tgt])
+    print(len(issues), file=sys.stderr)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/check_related_links.py
+++ b/scripts/check_related_links.py
@@ -1,0 +1,70 @@
+import os
+import re
+import csv
+import sys
+
+STRATEGY_DIR = os.path.join('docs', 'strategies')
+
+link_pattern = re.compile(r'\[[^\]]+\]\((/strategies[^)\s#]+)')
+
+
+def normalize(slug: str) -> str:
+    slug = slug.split('#')[0]
+    return slug.rstrip('/')
+
+
+def parse_doc(path: str):
+    with open(path, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+    text = ''.join(lines)
+    links = {normalize(m) for m in link_pattern.findall(text)}
+    slug = '/' + os.path.relpath(os.path.dirname(path), 'docs')
+    slug = normalize(slug)
+    links.discard(slug)
+    # find related section
+    related = set()
+    found = False
+    for idx, line in enumerate(lines):
+        if 'Related Strategies' in line:
+            found = True
+            for j in range(idx + 1, len(lines)):
+                l = lines[j]
+                if l.startswith('#'):
+                    break
+                for m in link_pattern.findall(l):
+                    related.add(normalize(m))
+            break
+    return slug, links, related, found
+
+
+def collect_docs():
+    docs = {}
+    related_map = {}
+    section_map = {}
+    for root, dirs, files in os.walk(STRATEGY_DIR):
+        if 'index.md' in files and root.count(os.sep) >= 3:
+            path = os.path.join(root, 'index.md')
+            slug, links, related, found = parse_doc(path)
+            docs[slug] = links
+            related_map[slug] = related
+            section_map[slug] = found
+    return docs, related_map, section_map
+
+
+def main():
+    docs, related_map, section_map = collect_docs()
+    issues = []
+    for src, targets in docs.items():
+        for tgt in targets:
+            if tgt in docs:
+                if not section_map[src] or tgt not in related_map[src]:
+                    issues.append((src, tgt))
+    writer = csv.writer(sys.stdout)
+    writer.writerow(['source', 'target'])
+    for src, tgt in issues:
+        writer.writerow([src, tgt])
+    print(len(issues), file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/check_unexplained_relations.py
+++ b/scripts/check_unexplained_relations.py
@@ -1,0 +1,52 @@
+import os
+import re
+import csv
+import sys
+
+STRATEGY_DIR = os.path.join('docs', 'strategies')
+link_pattern = re.compile(r'\[[^\]]+\]\((/strategies[^)\s#]+)\)')
+
+def normalize(slug: str) -> str:
+    slug = slug.split('#')[0]
+    return slug.rstrip('/')
+
+
+def parse_related(path: str):
+    with open(path, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+    slug = '/' + os.path.relpath(os.path.dirname(path), 'docs')
+    slug = normalize(slug)
+    issues = []
+    start = None
+    for idx, line in enumerate(lines):
+        if 'Related Strategies' in line:
+            start = idx + 1
+            break
+    if start is None:
+        return issues
+    for i in range(start, len(lines)):
+        line = lines[i]
+        if line.startswith('#'):
+            break
+        for m in link_pattern.finditer(line):
+            rest = line[m.end():].strip()
+            if rest == '' or rest in {'-', '–', '—'}:
+                issues.append((slug, normalize(m.group(1))))
+    return issues
+
+
+def main():
+    issues = []
+    for root, dirs, files in os.walk(STRATEGY_DIR):
+        if 'index.md' in files and root.count(os.sep) >= 3:
+            path = os.path.join(root, 'index.md')
+            issues.extend(parse_related(path))
+    writer = csv.writer(sys.stdout)
+    writer.writerow(['source', 'target'])
+    for src, tgt in issues:
+        writer.writerow([src, tgt])
+    print(len(issues), file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `add_related_links.py` to automatically insert missing related strategies
- add `check_unexplained_relations.py` to report related links without explanations

## Testing
- `npm install`
- `npm test`
- `python3 scripts/add_related_links.py > /tmp/add.csv 2> /tmp/add.err`
- `python3 scripts/check_unexplained_relations.py > /tmp/unexplained.csv 2> /tmp/unexplained.err`


------
https://chatgpt.com/codex/tasks/task_e_684424caf0c4832b8b844334d9532667