### PR TITLE
Fix missing related strategy links

### DIFF
--- a/docs/strategies/accelerators/cooperation/index.md
+++ b/docs/strategies/accelerators/cooperation/index.md
@@ -261,6 +261,7 @@ Use alliances when the goal is ecosystem-level impact or when formality helps se
 - [**Co-creation**](/strategies/ecosystem/co-creation) - a form of cooperation with *users*
 - [**Circling and Probing**](/strategies/competitor/circling-and-probing) - is opposite: testing a competitor rather than working with them.
 
+- [Standards Game](/strategies/markets/standards-game)
 ## 📚 **Further Reading & References**
 
 - [On 61 different forms of gameplay](https://blog.gardeviance.org/2015/05/on-61-different-forms-of-gameplay.html) on Simon Wardley's Blog. *"Cooperation: Working with others... not easy."* . Underscores that while straightforward in concept, the execution of cooperation is challenging.

--- a/docs/strategies/defensive/defensive-regulation/index.md
+++ b/docs/strategies/defensive/defensive-regulation/index.md
@@ -115,3 +115,9 @@ For a deeper understanding of defensive regulation within the context of Wardley
 - [Defense Community Partnerships - NARUC](https://www.naruc.org/core-sectors/critical-infrastructure-and-cybersecurity/defense-community-partnerships/)
 - [Defending Your Brand: How Smart Companies use Defensive Strategy to Deal with Competitive Attacks - Amazon.com](https://www.amazon.com/Defending-Your-Brand-Companies-Competitive/dp/1137278757)
 - [Regulatory Strategy – Everything You Need to Know - Isolocity](https://isolocity.com/regulatory-strategy-everything-you-need-to-know/)
+## 🔀 **Related Strategies**
+- [Limitation of Competition](/strategies/defensive/limitation-of-competition)
+- [Standards Game](/strategies/markets/standards-game)
+- [Lobbying](/strategies/user-perception/lobbying)
+- [raising-barriers-to-entry](/strategies/defensive/raising-barriers-to-entry)
+

--- a/docs/strategies/defensive/raising-barriers-to-entry/index.md
+++ b/docs/strategies/defensive/raising-barriers-to-entry/index.md
@@ -95,3 +95,10 @@ For a comprehensive understanding of raising barriers to entry, the foundational
 - [Read the Book | Wardley Maps](https://www.wardleymaps.com/read)
 - [Wardley Mapping Mondays — Operations Doctrine | Cory Foy](https://blog.coryfoy.com/2020/03/wardley-mapping-mondays-operations-doctrine)
 - [Strategic Thinking with Wardley Maps | Mark Craddock](https://medium.com/ai-created-strategy-reports/strategic-thinking-with-wardley-maps-a-visual-guide-to-business-evolution-and-market-dynamics-for-186d46ae5422)
+
+## 🔀 **Related Strategies**
+- [Limitation of Competition](/strategies/defensive/limitation-of-competition)
+- [Standards Game](/strategies/markets/standards-game)
+- [defensive-regulation](/strategies/defensive/defensive-regulation)
+- [Lobbying](/strategies/user-perception/lobbying)
+


### PR DESCRIPTION
## Summary
- run scripts to add related strategy links
- document related strategy connections for cooperation and defensive strategies

## Testing
- `python3 scripts/check_related_links.py`
- `python3 scripts/add_related_links.py`


------
https://chatgpt.com/codex/tasks/task_e_684460555e28832bb0e2597e3d42bf31