### PR TITLE
Enable previously skipped tests

### DIFF
--- a/src/components/Assessment/parseChildren.test.tsx
+++ b/src/components/Assessment/parseChildren.test.tsx
@@ -9,7 +9,7 @@ const OtherComponent = ({ children }) => React.createElement('div', null, childr
 
 describe('extractStatements', () => {
   // Test 1: Basic Extraction
-  it.skip('should extract string children of TargetTypeComponent instances', () => { // SKIPPED
+  it('should extract string children of TargetTypeComponent instances', () => {
     const children = React.createElement(React.Fragment, null,
       React.createElement(TargetTypeComponent, null,
         React.createElement(WrapperComponent, null, "Statement 1")
@@ -91,7 +91,7 @@ describe('extractStatements', () => {
 
 
   // Test 5: Mixed Child Types
-  it.skip('should extract statements correctly from mixed children types', () => { // SKIPPED
+  it('should extract statements correctly from mixed children types', () => {
     const children = React.createElement(React.Fragment, null,
       React.createElement(OtherComponent, null, "Some other content"),
       React.createElement(TargetTypeComponent, null,
@@ -114,7 +114,7 @@ describe('extractStatements', () => {
     expect(extractStatements(children, TargetTypeComponent)).toEqual([]);
   });
 
-  it.skip('should handle multiple TargetType components with varied internal structures', () => { // SKIPPED
+  it('should handle multiple TargetType components with varied internal structures', () => {
     const children = React.createElement(React.Fragment, null,
       React.createElement(TargetTypeComponent, null,
         React.createElement(WrapperComponent, null, "First")

--- a/src/components/Assessment/parseChildren.tsx
+++ b/src/components/Assessment/parseChildren.tsx
@@ -3,37 +3,39 @@ import { Children, ReactNode, isValidElement } from 'react';
 export const extractStatements = (children: ReactNode, targetType: any): string[] => {
   const items: string[] = [];
   Children.forEach(children, child => {
-    // Lenient type check for testing: check name if direct equality fails - KEEPING THIS FROM PREVIOUS ATTEMPT
-    const isCorrectType = isValidElement(child) &&
-                          (child.type === targetType ||
-                           (typeof child.type === 'function' && typeof targetType === 'function' && (child.type as any).name === (targetType as any).name) ||
-                           (typeof child.type === 'object' && (child.type as any).displayName === (targetType as any).displayName)
-                          );
+    if (!child) return;
 
-    if (!isCorrectType) {
-      return;
-    }
+    const isElement = isValidElement(child);
+    // Lenient type check for testing: check name if direct equality fails
+    const isCorrectType =
+      isElement &&
+      (child.type === targetType ||
+        (typeof child.type === 'function' && typeof targetType === 'function' && (child.type as any).name === (targetType as any).name) ||
+        (typeof child.type === 'object' && (child.type as any).displayName === (targetType as any).displayName));
 
-    const intermediateChildren = child.props.children;
-    const nestedChildren = Array.isArray(intermediateChildren)
-      ? intermediateChildren
-      : [intermediateChildren];
+    if (isCorrectType) {
+      const intermediateChildren = child.props.children;
+      const nestedChildren = Array.isArray(intermediateChildren) ? intermediateChildren : [intermediateChildren];
 
-    nestedChildren.filter(Boolean).forEach(c => {
-      if (isValidElement(c) && c.props && c.props.children !== undefined && c.props.children !== null) {
-        // Attempt to handle if c.props.children is the string itself or an array with the string
-        const grandChildren = c.props.children;
-        if (typeof grandChildren === 'string') {
-          items.push(grandChildren);
-        } else if (Array.isArray(grandChildren) && grandChildren.length > 0 && typeof grandChildren[0] === 'string') {
-          // If it's an array, and the first item is a string, take it.
-          // This handles cases like <Wrapper>{["Text"]}</Wrapper> or <Wrapper>{["Text", <OtherElement/>]}</Wrapper> (takes "Text")
-          items.push(grandChildren[0]);
+      nestedChildren.filter(Boolean).forEach(c => {
+        if (isValidElement(c) && c.props && c.props.children !== undefined && c.props.children !== null) {
+          // Attempt to handle if c.props.children is the string itself or an array with the string
+          const grandChildren = c.props.children;
+          if (typeof grandChildren === 'string') {
+            items.push(grandChildren);
+          } else if (Array.isArray(grandChildren) && grandChildren.length > 0 && typeof grandChildren[0] === 'string') {
+            // If it's an array, and the first item is a string, take it.
+            // This handles cases like <Wrapper>{['Text']}</Wrapper> or <Wrapper>{['Text', <OtherElement/>]}</Wrapper> (takes 'Text')
+            items.push(grandChildren[0]);
+          }
+          // This version does NOT attempt to recursively flatten or concatenate if grandChildren contains mixed elements/strings.
+          // It specifically looks for a string or an array starting with a string.
         }
-        // This version does NOT attempt to recursively flatten or concatenate if grandChildren contains mixed elements/strings.
-        // It specifically looks for a string or an array starting with a string.
-      }
-    });
+      });
+    } else if (isElement && child.props && child.props.children) {
+      // Recursively search nested children for targetType components
+      items.push(...extractStatements(child.props.children, targetType));
+    }
   });
   return items;
 };


### PR DESCRIPTION
## Summary
- unskip `parseChildren` tests for more coverage
- enhance `extractStatements` to search nested children recursively

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c48ee87fc832b87e7f43795d2f12b