### PR TITLE
Update Strategic Insights for Insertion strategy with new expert content

### DIFF
--- a/docs/strategies/poison/insertion/index.md
+++ b/docs/strategies/poison/insertion/index.md
@@ -120,17 +120,41 @@ Target may ignore inserted assets or narratives, wasting resources.
 
 ## 🧠 **Strategic Insights**
 
-### Evolution Stage
+### Evolution Stage and Fluidity
 
-Most effective in mid-evolution domains where decisions are still fluid.
+Insertion tactics are often most potent when applied to components or strategies in the mid-stages of their evolution, specifically transitioning from custom-built to product or even early rental services. During these phases, decisions are still fluid, standards are not yet fully set, and organizations are more susceptible to external narratives or influences that can steer them towards ultimately suboptimal paths before they achieve a more robust, commoditized state. The uncertainty inherent in these evolutionary stages creates fertile ground for doubt and misdirection.
 
-### Counterplay Opportunities
+### The "Insider Threat" Amplification
 
-Competitors may create open forums or transparent processes to mitigate hidden influences.
+Beyond the direct placement of an agent, a more nuanced form of insertion involves identifying and subtly influencing existing individuals within a target organization. These "unwitting agents" might be disgruntled, ideologically aligned with an alternative viewpoint, or simply susceptible to sophisticated social engineering. The process can involve careful grooming, appealing to cognitive biases (like confirmation bias or authority bias), and providing seemingly credible information that steers their actions and advice in a desired direction. This approach is often lower risk and can yield more authentic, and therefore more damaging, internal diversions than deploying an obvious outsider.
 
-### Synergies with Other Tactics
+### Digital Vectors and AI-Driven Narratives
 
-Combining insertion with misdirection and fragmentation increases uncertainty.
+Modern insertion strategies increasingly leverage digital channels. Social media bots, AI-generated content (including deepfakes), and targeted disinformation campaigns can create or amplify misleading narratives at unprecedented scale and speed. The anonymity and complex technical nature of these attacks make attribution difficult, allowing manipulators to shape perceptions or sow discord with relative impunity. Furthermore, data analytics can identify vulnerable demographics or key influencers within a competitor's ecosystem, enabling highly targeted narrative insertion that exploits existing societal or organizational fissures.
+
+### Indirect Strategic Sabotage: The "Second-Order K.O."
+
+Insertion isn't always about directly influencing a major strategic decision. Highly sophisticated plays aim for "second-order" sabotage by targeting crucial enablers of a competitor's strategy. This could involve inserting subtly flawed code into an open-source dependency, influencing technical standards bodies towards specifications that create long-term disadvantages for rivals, or promoting internal policies (e.g., HR, R&D funding criteria) that slowly stifle innovation or misallocate critical resources. These are often long-game strategies where the negative impact accumulates gradually and is harder to trace back to a deliberate external insertion.
+
+### Ecosystem Vulnerabilities and Supply Chain Weakening
+
+Competitors rarely operate in isolation. Insertion can target vulnerabilities within their broader ecosystem, such as key suppliers, distribution partners, or even large customers. By inserting agents or narratives that create friction, sow distrust, or introduce inefficiencies in these relationships, an aggressor can weaken the competitor indirectly. For instance, spreading rumors about a competitor's financial instability to its critical component suppliers might cause them to tighten credit terms or delay shipments, thereby disrupting the competitor's operations without a direct confrontation.
+
+### The "Host Immune Response" and Blowback Dynamics
+
+A detected or even strongly suspected insertion attempt can trigger a powerful "immune response" within the target organization. This might involve heightened security, increased internal scrutiny, and a shift towards a more insular, distrustful culture, which can itself be counterproductive. Ironically, such a response can sometimes strengthen a competitor's resolve or expose the inserter's hand. There's also the significant risk of the inserted asset being identified and "turned" – used to feed disinformation back to the original aggressor. The ethical and reputational fallout from a publicly exposed insertion campaign can far outweigh any strategic gains, potentially leading to severe regulatory penalties or market alienation.
+
+### Cultural Due Diligence and Resilience as Defense
+
+Beyond overt counter-intelligence, a strong defense against insertion lies in fostering a resilient organizational culture. This includes encouraging critical thinking, robust internal debate, and psychological safety that empowers employees to question assumptions and challenge directives, regardless of their source. Implementing practices like "red teaming" for key strategic initiatives, where an internal team actively tries to pick apart a plan, can help uncover vulnerabilities to manipulation. A culture that values transparency and diverse perspectives is inherently harder to infiltrate successfully.
+
+### Counterplay Opportunities: Transparency and Verification
+
+While difficult, competitors can mitigate hidden influences by fostering open forums, transparent decision-making processes, and rigorous third-party verification of critical information or partnerships. Requiring multiple independent sources for strategic intelligence and building a culture that questions "too good to be true" opportunities or narratives can act as a strong deterrent.
+
+### Synergies with Other Disruptive Tactics
+
+Insertion is rarely a standalone play. Its effectiveness is often amplified when combined with other strategies like [Misdirection](/strategies/competitor/misdirection) (to create noise and divert attention from the actual insertion point), [Fragmentation Play](/strategies/competitor/fragmentation-play) (to create internal divisions that an inserted agent can exploit), or even [Designed to Fail](/strategies/poison/designed-to-fail) (where an inserted narrative convinces a competitor to adopt a flawed initiative).
 
 ## ❓ **Key Questions to Ask**
 


### PR DESCRIPTION
Adds new, valuable, expert content to the Strategic Insights section of the Insertion strategy page.

New insights cover:
- The "Insider Threat" Amplification
- Digital Insertion Vectors & AI-Driven Narratives
- Indirect Strategic Sabotage (Second-Order K.O.)
- Ecosystem Vulnerabilities & Supply Chain Insertion
- The "Host Immune Response" & Blowback Dynamics
- Cultural Due Diligence as a Defense

Existing insights on Evolution Stage, Counterplay, and Synergies have been expanded and integrated with the new content for better flow and depth.