### PR TITLE
Add Vercel Speed Insights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@docusaurus/preset-classic": "~3.8.1",
         "@docusaurus/theme-mermaid": "~3.8.1",
         "@mdx-js/react": "^3.0.0",
+        "@vercel/speed-insights": "^1.2.0",
         "clsx": "^2.0.0",
         "docusaurus-lunr-search": "^3.6.0",
         "lucide-react": "^0.523.0",
@@ -7130,6 +7131,41 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.2.0.tgz",
+      "integrity": "sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@docusaurus/preset-classic": "~3.8.1",
     "@docusaurus/theme-mermaid": "~3.8.1",
     "@mdx-js/react": "^3.0.0",
+    "@vercel/speed-insights": "^1.2.0",
     "clsx": "^2.0.0",
     "docusaurus-lunr-search": "^3.6.0",
     "lucide-react": "^0.523.0",

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import type {Props} from '@theme/Root';
+import OriginalRoot from '@theme-original/Root';
+import { SpeedInsights } from '@vercel/speed-insights/react';
+
+export default function Root(props: Props): JSX.Element {
+  return (
+    <>
+      <OriginalRoot {...props} />
+      <SpeedInsights />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add `@vercel/speed-insights` dependency
- render `<SpeedInsights/>` from new theme Root component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ef87697cc832b8139bd09a0884bf0