### PR TITLE
feat: Add expert strategic insights to Licensing strategy

### DIFF
--- a/docs/strategies/poison/licensing/index.md
+++ b/docs/strategies/poison/licensing/index.md
@@ -129,17 +129,29 @@ Excessive restrictions may create incompatible ecosystems.
 
 ## 🧠 **Strategic Insights**
 
-### Dual-Licensing Leverage
-
-Dual-licensing can serve as a Trojan horse for commercial adoption.
+### Dual-Licensing Models
+Offering both open source (e.g., GPL) and commercial licenses can be a powerful "Trojan horse." The open version drives adoption and community engagement, while the commercial option captures value from enterprises unwilling or unable to comply with open source terms, effectively segmenting the market.
 
 ### Patent Thickets
-
-Dense patent portfolios deter entry but may slow broader innovation.
+Dense patent portfolios deter entry but may slow broader innovation. This strategy involves creating a web of overlapping patents around a technology area, making it difficult for competitors to innovate without infringing on multiple patents, thus forcing them to license or abandon their efforts.
 
 ### Evolving Commoditization
+Licenses must adapt as technologies become commodities to maintain relevance. As a technology matures and becomes more widespread, overly restrictive licenses can hinder adoption and encourage workarounds. Flexible licensing that reflects the evolutionary stage can prolong value capture.
 
-Licenses must adapt as technologies become commodities to maintain relevance.
+### The Double-Edged Sword of Standards Control
+Strategic licensing around core technologies can be a powerful way to steer an industry standard. By offering favorable terms to early adopters or key partners for components that become integral to a standard, a company can build an ecosystem that inherently favors its technology. However, this control is a double-edged sword. If the licensing is perceived as too restrictive or predatory once the standard gains traction, it can trigger efforts to fork the standard, develop open alternatives, or even invite regulatory scrutiny. The "poison" here is not just in limiting competitors, but potentially in stifling the very ecosystem that gives the standard its power if the licensor becomes too greedy or inflexible. Balancing ecosystem growth with control through licensing is a continuous strategic challenge.
+
+### Licensing as a Defensive Moat Against Commoditization
+As components in a value chain naturally evolve towards becoming commodities, strategic licensing can act as a defensive moat. By embedding patented technology or copyrighted code within a component and then licensing it under terms that prevent easy replication or modification by competitors, a company can slow down the commoditization of its own offerings. For example, a specific performance-enhancing algorithm within a widely used software library could be licensed restrictively. While the library itself might be an open standard, the "secret sauce" is protected. This forces competitors to either license the superior component (creating a revenue stream and dependency) or use inferior alternatives, thus maintaining a differentiation advantage for the licensor even as the surrounding market commoditizes.
+
+### The "Poison Pill" in Ecosystem Partnerships
+Licensing terms can be subtly crafted to act as "poison pills" in partnerships or joint ventures, particularly with larger entities that might eventually become competitors or seek to absorb the smaller partner's IP. For instance, a license might grant broad usage rights for a joint product but include clauses that severely restrict the use of the underlying core technology if the partnership dissolves or if the partner is acquired by a competitor. This ensures that while the technology can be leveraged for mutual benefit within the alliance, it cannot be easily turned against the original licensor. This requires careful legal crafting to be effective and not overly antagonistic, preserving the partnership while safeguarding core assets.
+
+### Graduated Licensing Models for Market Seeding and Capture
+A sophisticated licensing strategy can use graduated models to first seed a market and then capture value. Initial versions of a technology might be offered under very permissive or even open-source-like licenses to encourage widespread adoption, experimentation, and the building of a community (similar to [Open Approaches](/strategies/accelerators/open-approaches)). Once critical mass is achieved and dependencies are established, subsequent versions or advanced features can be introduced under more restrictive, commercial licenses. The "poison" is the dependency created during the open phase, making it difficult for users and businesses to switch away when the terms become less favorable. This requires a long-term view and the ability to manage community expectations through the transition.
+
+### Royalty Stacking and Ecosystem Taxation
+In complex ecosystems where multiple patented technologies are required to create a final product (e.g., smartphones), strategic licensing can lead to "royalty stacking." A company holding key patents can license them in a way that, while seemingly reasonable in isolation, contributes to an overall high cost for manufacturers when combined with licenses from other patent holders. If a single entity controls a significant portion of these essential patents, their licensing strategy can effectively "tax" the entire ecosystem. The "poison" here is the cumulative burden on implementers, which can stifle innovation, raise prices for consumers, and make it difficult for new entrants to compete, thereby reinforcing the power of the dominant patent holder(s). This is a high-stakes game often seen in standards-essential patent disputes.
 
 ## ❓ **Key Questions to Ask**
 


### PR DESCRIPTION
Adds five new detailed strategic insights to the "Licensing" strategy page (`docs/strategies/poison/licensing/index.md`). Also refines the three existing insights for clarity and to better complement the new content.

The new insights cover:
- The Double-Edged Sword of Standards Control
- Licensing as a Defensive Moat Against Commoditization
- The "Poison Pill" in Ecosystem Partnerships
- Graduated Licensing Models for Market Seeding and Capture
- Royalty Stacking and Ecosystem Taxation

These additions aim to provide deeper, expert-level perspectives on the strategic application of licensing, in line with the project's content guidelines.