### PR TITLE
Feat: Add new strategic insights to Sweat & Dump strategy

### DIFF
--- a/docs/strategies/dealing-with-toxicity/sweat-and-dump/index.md
+++ b/docs/strategies/dealing-with-toxicity/sweat-and-dump/index.md
@@ -105,14 +105,26 @@ Transfers and layoffs can undermine morale among remaining staff.
 
 ## 🧠 **Strategic Insights**
 
-### Focus Leverage
-Delegating non-core operations frees leadership bandwidth for innovation.
+### The "Good Parent" vs. "Pragmatic Executor" Dilemma
+Successfully initiating a Sweat & Dump often requires a significant psychological shift. Assets, even declining ones, frequently have "good parents"—teams or leaders emotionally invested in their history and perceived potential. This attachment can hinder objective assessment. The Sweat & Dump strategy demands a transition to a "pragmatic executor" mindset, focusing on data-driven value extraction and timely exit, rather than indefinite life support. Leadership must actively manage this shift, acknowledging the emotional labor, clearly communicating the strategic necessity, and framing the decision as evolution, not failure. This contrasts with "Disposal of Liability," where an asset's pure toxicity might make the exit emotionally simpler, though still organizationally challenging.
 
-### Ecosystem Creation
-Sweat & Dump can foster a specialized market of legacy operators, reshaping the industry landscape.
+### The Art of Selecting the "Sweat" Partner: Beyond Cost
+Choosing the right third-party operator for the "sweat" phase is critical and extends beyond finding the lowest-cost provider. While efficiency is key, the ideal partner possesses specialized expertise in managing mature assets, maintaining essential service levels with minimal investment, and navigating end-of-life scenarios with finesse, thereby protecting your brand during the transition. Key selection criteria include a proven track record, robust processes for managing declining assets, financial stability (to avoid their premature collapse), and alignment on the "dump" timeline. A misaligned partner can accelerate brand damage or create operational crises. This external partnership focus is a key differentiator from "Refactoring," which involves internal repurposing of resources and talent.
 
-### Risk Transference
-While operational risk is offloaded, reputational risk becomes concentrated and must be managed.
+### Strategic Timing of the "Dump": Reading Market Currents
+The "dump" phase—the final exit—isn't merely a reaction to dwindling cash flow; it's a proactive, strategic decision. Optimal timing is informed by active market sensing: monitoring declining returns from the sweat partner, the emergence of disruptive replacement technologies, shifts in the regulatory landscape, or even aligning the exit with your own next-generation product launches to create a clear "out with the old, in with the new" narrative. Waiting too long risks the asset becoming truly unsalvageable or causing reputational harm if service collapses. Dumping prematurely forgoes extractable value. This strategic calendar management, based on a confluence of signals, is vital.
+
+### Catalyst for Renewal: The Phoenix from the Ashes
+A well-executed Sweat & Dump strategy can be a powerful catalyst for organizational renewal. Beyond shedding a burdensome asset, the process liberates significant resources—financial capital, leadership attention, and skilled personnel—that can be explicitly redeployed towards innovation and future growth. This decisive act can break down internal inertia and foster a more agile, forward-looking culture. Leadership can frame Sweat & Dump not as an admission of failure, but as a strategic pruning essential for overall vitality, potentially even improving investor perception by demonstrating disciplined capital reallocation. This transparent, future-focused approach contrasts sharply with the opacity of a "Pig in a Poke" strategy.
+
+### Unlocking Hidden Value in "Sweat" Data: Intelligence from the End-Game
+While extracting residual financial value is the primary goal of the "sweat" phase, the operational and customer data generated during this period is a frequently overlooked asset. This "exhaust data" can offer unfiltered insights into late-stage customer behavior, minimum viable service levels under real-world constraints, and specific pain points that emerge as an offering degrades. Such intelligence, potentially more honest than traditional market research, can inform the development of next-generation products or reveal niche opportunities. Crucially, data-sharing clauses should be structured into the initial agreement with the "sweat" operator, allowing the original company to transform the end of one asset's lifecycle into valuable intelligence for future innovation.
+
+### Secondary Effects: Ecosystem Specialization
+Repeated application of Sweat & Dump strategies across an industry can foster the emergence of a specialized market of third-party operators. These firms become adept at managing legacy assets efficiently, creating a new niche within the broader business ecosystem and potentially offering more sophisticated "sweating" services over time.
+
+### Managing Transferred Risks
+While operational burdens are offloaded to the "sweat" partner, significant reputational risk remains with the original company. Poor performance, service failures, or unethical behavior by the partner can directly tarnish the original brand. Vigilant oversight, clear contractual service levels, and robust partner governance are essential to mitigate this concentrated risk.
 
 ## ❓ **Key Questions to Ask**
 


### PR DESCRIPTION
Expanded the 'Strategic Insights' section for the 'Sweat & Dump' strategy with five new detailed subsections covering:
- Psychological aspects of asset disposal
- Nuances of selecting a third-party operator
- Strategic timing for the 'dump' phase
- Organizational renewal catalyzed by the strategy
- Unlocking hidden data value from the 'sweat' phase

Refined and retained two existing insights concerning ecosystem specialization and managing transferred risks. Removed one redundant insight. This aligns with the goal of providing more valuable, expert content.