### PR TITLE
Expand and enhance Attacking strategy category page

### DIFF
--- a/docs/strategies/attacking/index.md
+++ b/docs/strategies/attacking/index.md
@@ -1,10 +1,73 @@
-# Attacking
+---
+description: Forcing change, breaking inertia, and reshaping the competitive landscape.
+---
 
-Attacking plays are used to force change in the market. You're not waiting for evolution, you're deliberately driving it.
+# Attacking Strategies
 
-This can mean undermining barriers, running experiments, or concentrating talent to trigger gravity.
+Attacking strategies in Wardley Mapping are proactive and often aggressive maneuvers designed to force change in the market, break competitive inertia, and reshape the landscape to your advantage. Unlike defensive or reactive postures, these strategies involve deliberately driving evolution, challenging incumbents, or creating new opportunities by directly confronting or outmaneuvering competitors. They are about seizing the initiative and dictating the pace and direction of change.
 
-Attacking is most useful when you're trying to break inertia, dislodge incumbents, or reposition the landscape. It’s proactive and often high-risk but can yield rapid dominance.
+## ⚔️ **Understanding Attacking Strategies**
+
+Attacking strategies encompass a range of approaches, each tailored to specific competitive situations and objectives. The core intent is to proactively alter the competitive dynamics. Here are the key types of attacking strategies:
+
+*   **[Centre of Gravity](/strategies/attacking/centre-of-gravity)**: Involves concentrating talent, expertise, or resources to become an indispensable hub that naturally attracts others, compelling them to align with your ecosystem or standards.
+*   **[Directed Investment](/strategies/attacking/directed-investment)**: Making bold, focused, venture-capital-style investments in specific future changes or emerging areas to seize a decisive advantage before competitors can react.
+*   **[Experimentation](/strategies/attacking/experimentation)**: Utilizing rapid, small-scale tests—like hackdays, specialist groups, or skunkworks—to quickly uncover and exploit new opportunities and learn faster than rivals.
+*   **[Fool's Mate](/strategies/attacking/fool-s-mate)**: A swift, often uncounterable move that exploits a poorly understood or defended component in an opponent's value chain to cause cascading failure or force its commoditization.
+*   **[Playing Both Sides](/strategies/attacking/playing-both-sides)**: Strategically engaging with two or more opposing sides in a market or standards conflict, ensuring you benefit regardless of which side ultimately prevails.
+*   **[Press Release Process](/strategies/attacking/press-release-process)**: Employing Amazon’s “working backwards” method, starting with the customer-facing press release, to ensure clarity of vision, market fit, and drive towards industrialization of necessary components.
+*   **[Undermining Barriers to Entry](/strategies/attacking/undermining-barriers-to-entry)**: Identifying and systematically dismantling a key barrier (e.g., cost, technology, regulation) that protects an incumbent, thereby opening the market to new competition.
+
+## 🎯 **Why Employ Attacking Strategies?**
+
+Organizations choose attacking strategies to actively shape their future rather than passively responding to market shifts. These strategies are employed to:
+
+*   **Break Inertia:** Both internal organizational inertia and external market stagnation can be overcome by decisive attacking moves that force a new dynamic.
+*   **Dislodge Incumbents:** Attacking strategies can target the vulnerabilities of established players, eroding their market share, neutralizing their advantages, or making their business models obsolete.
+*   **Reshape the Competitive Landscape:** By introducing new technologies, business models, or standards, attackers can fundamentally alter the rules of the game and create a new landscape more favorable to their strengths.
+*   **Gain First-Mover Advantage:** Many attacking strategies, like Directed Investment or effective Experimentation, are designed to get to the future first, capturing market share and setting de facto standards.
+*   **Exploit Competitor Weaknesses:** Thorough mapping and situational awareness can reveal vulnerabilities in competitors' strategies or value chains, which attacking moves can then exploit.
+*   **Create New Market Spaces:** Some attacking moves can open up entirely new markets or customer segments that were previously inaccessible or underserved.
+*   **Force Competitors to React:** A well-executed attack compels competitors to respond, often from a defensive posture, consuming their resources and attention.
+
+In essence, attacking strategies are chosen when a proactive, assertive approach is deemed necessary to achieve significant market shifts or gain a decisive competitive edge, especially in dynamic or contested environments.
+
+## 🔄 **The Attacker's Mindset: Common Themes**
+
+Successfully executing attacking strategies requires more than just selecting a tactic; it demands a particular mindset and an embrace of certain underlying principles. These common themes often distinguish effective attackers:
+
+*   **Proactivity and Initiative:** Attackers don't wait for the future to happen to them; they seek to create it. They are biased towards action and look for opportunities to seize the initiative, forcing others to react to their moves.
+*   **Calculated Risk-Taking:** While some attacking moves can be high-risk, they are rarely reckless. A thorough understanding of the landscape (often through Wardley Mapping) allows attackers to make informed bets where the potential rewards justify the risks. The risk of inaction is often weighed against the risk of action.
+*   **Focus on Asymmetry:** Attackers often look for ways to create or exploit asymmetries. This could be leveraging a unique capability, exploiting a competitor's blind spot, or using a different business model that incumbents struggle to replicate. The goal is to avoid a head-on fight where the incumbent's superior resources might prevail.
+*   **Forcing Uncomfortable Change:** Attacking strategies frequently aim to make competitors uncomfortable by challenging their established norms, undermining their profitable revenue streams, or forcing them to adopt new, less familiar ways of working.
+*   **Speed and Decisiveness:** Many attacking scenarios reward speed. Whether it's being the first to market with an innovation or rapidly exploiting a newly identified weakness, attackers understand that windows of opportunity can close quickly.
+*   **Strong Situational Awareness:** Effective attackers have a deep understanding of the competitive environment, including their own capabilities, competitor vulnerabilities, market dynamics, and the evolution of components in the value chain. This awareness is crucial for identifying attacking opportunities and anticipating responses.
+*   **Willingness to Cannibalize or Disrupt Self:** Sometimes, the most potent attacking move involves disrupting one's own existing products or services before a competitor does. This requires foresight and a long-term perspective.
+
+## ⚠️ **Risks and Considerations in Attacking Moves**
+
+While the rewards of successful attacking strategies can be substantial, they also come with significant risks and important considerations:
+
+*   **High Resource Commitment:** Many attacking strategies, such as Directed Investment or sustained efforts to Undermine Barriers to Entry, can require significant upfront investment in terms of capital, talent, and time.
+*   **Potential for Retaliation:** Incumbents are rarely passive. A direct attack can provoke strong retaliatory measures, including price wars, legal challenges, or counter-attacks on your own core business.
+*   **Market Destabilization and Unintended Consequences:** Attacking moves can destabilize a market in unpredictable ways. While this might be the goal, it can also create openings for other competitors or lead to outcomes that are not entirely favorable to the attacker.
+*   **Reputational Risk:** Aggressive or "ruthless" attacking strategies can damage a company's reputation with customers, partners, or the broader public if they are perceived as unfair, unethical, or overly predatory.
+*   **Risk of Failure and Wasted Effort:** By their nature, many attacking strategies are high-risk. If the assumptions underpinning the strategy are wrong, or if the execution is flawed, the effort can result in significant losses and wasted resources.
+*   **Internal Resistance:** Bold attacking moves can face internal resistance from those comfortable with the status quo or wary of the risks involved. Strong leadership is needed to overcome this inertia.
+*   **Ethical Boundaries:** Leaders must carefully consider the ethical implications of their chosen attacking strategies. While business is competitive, actions that cause undue harm, deceive stakeholders, or exploit vulnerabilities in a malicious way can have long-term negative consequences. For example, a "Fool's Mate" strategy, while effective, might be viewed as underhanded if not carefully considered.
+
+## ⚡ **Attacking Angles in Other Strategies**
+
+The intent to proactively force change and gain advantage isn't limited to strategies explicitly categorized as "Attacking." Several strategies from other categories can be wielded with a distinctly aggressive or attacking intent, or their execution can have significant attacking effects on competitors:
+
+*   **[Land Grab](/strategies/positional/land-grab):** This positional strategy, aimed at rapidly acquiring market share or resources, is inherently aggressive. It seeks to dominate a space quickly, often to preempt competitors or establish a commanding early lead, effectively attacking their potential for growth.
+*   **[Embrace and Extend](/strategies/ecosystem/embrace-and-extend):** While an ecosystem play, its historical application has often been a powerful attacking move. By embracing an open standard or technology and then extending it with proprietary features, companies can neutralize the original standard and lock customers into their ecosystem, attacking the openness that might have benefited competitors.
+*   **[Tower and Moat](/strategies/ecosystem/tower-and-moat):** This strategy involves building a strong, defensible position (the tower) and then creating significant barriers (the moat) to prevent others from attacking it. While defensive in its core, the act of aggressively expanding the moat or using the tower's strength to encroach on adjacent territories can be a form of attack.
+*   **[Innovate, Leverage, Commoditize (ILC)](/strategies/ecosystem/innovate-leverage-commoditize):** The "commoditize" phase of ILC can be a direct attack on competitors who rely on the value of the component being commoditized. By driving down its price or making it openly available, an organization can undermine a rival's profit margins or entire business model.
+*   **[Open Approaches](/strategies/accelerators/open-approaches):** While often used to accelerate evolution for broader benefit, strategically opening up a key technology or platform can be a direct attack on an incumbent who relies on a proprietary, closed system. Google's Android is a classic example of this, attacking Apple's iOS dominance.
+*   **[Standards Game](/strategies/markets/standards-game):** Actively trying to make your technology the dominant standard is an attacking move against competing standards. Success means your rivals are forced to adapt, pay licensing fees, or become irrelevant.
+
+Recognizing the potential attacking intent or effect of these and other strategies provides a more nuanced understanding of the competitive landscape. The key is to look beyond the category label and analyze how a strategy is being deployed and what impact it has on competitors and market dynamics.
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';


### PR DESCRIPTION
This commit significantly expands the content of the Attacking strategy category page (`docs/strategies/attacking/index.md`).

The changes include:
- A more detailed introduction to Attacking strategies.
- Summaries and links to all sub-strategies within the category.
- A new section on "Why Employ Attacking Strategies?".
- A new section exploring "The Attacker's Mindset: Common Themes".
- A new section on "Risks and Considerations in Attacking Moves".
- A new section on "Attacking Angles in Other Strategies".

The expanded content aims to provide a comprehensive and insightful overview of the category, going beyond a simple summary of its constituent pages. The structure and depth are comparable to other well-developed category pages like "Accelerators", aligning with guidelines on creating authoritative content.