### PR TITLE
Update Sweat & Dump strategy page to emphasize externalizing inertia …

### DIFF
--- a/docs/strategies/dealing-with-toxicity/sweat-and-dump/index.md
+++ b/docs/strategies/dealing-with-toxicity/sweat-and-dump/index.md
@@ -1,12 +1,12 @@
 ---
 title: Sweat & Dump
-description: Partner with third parties to extract remaining value from toxic assets and then exit cleanly.
-tags: [dealing-with-toxicity, sweat-and-dump, outsourcing, third-party, exit-strategy, cost-reduction, risk-mitigation]
+description: Outsource operation of a legacy asset to a third party, extract remaining value, and exit before the cost curve turns against you.
+tags: [dealing-with-toxicity, sweat-and-dump, outsourcing, third-party, exit-strategy, cost-reduction, risk-mitigation, capex, inertia]
 ---
 
 # Sweat & Dump
 
-**Outsource the operation of a toxic asset to a third party, milk remaining value, and exit.**
+**Outsource operation of a legacy asset to a third party, extract remaining value, and exit before the cost curve turns against you.**
 
 > *"Exploiting a 3rd party to take over operating the toxic asset whilst you prepare to remove yourself."*
 >
@@ -15,131 +15,137 @@ tags: [dealing-with-toxicity, sweat-and-dump, outsourcing, third-party, exit-str
 ## 🤔 **Explanation**
 
 ### What is Sweat & Dump?
-Sweat & Dump is a two-phase strategy: first, outsource a declining or non-core asset to a specialist who can “sweat” it, maximizing short-term returns, then “dump” by exiting or discontinuing ownership once value is extracted.
+Sweat & Dump is a two-phase strategy for dealing with technology toxicity. First, you sweat the asset: outsource the operation of a legacy system to a third party, ideally one willing to shoulder ongoing investment. Then, once you’ve extracted residual value and built your replacement, you dump — exiting, decommissioning, or walking away.
 
-### Why use Sweat & Dump?
-It enables you to maintain focus on strategic initiatives while a third party handles legacy burdens, extracting residual value and reducing operational drag.
+This tactic transfers capex risk to someone else while you buy time to modernise.
 
-### How to use Sweat & Dump?
-- Identify assets that no longer align with your core strategy but still yield cash flow.
-- Research specialist operators (private equity, managed service providers).
-- Negotiate terms to transfer operations and liabilities.
-- Define clear performance metrics and sweating duration.
-- Plan your exit route: sale, spin-off, or shutdown post-sweating.
+### Why use it?
+- Avoid massive “Death Star” transformation projects.
+- Externalise architectural inertia and capex liability.
+- Free internal resources for building the future.
+- Buy time without being trapped by past systems.
 
 ## 🗺️ **Real-World Examples**
 
 ### Telecom Legacy Infrastructure Outsourcing
-Telecom operators sold their aging copper networks to infrastructure firms that “sweat” the assets with minimal investment, while enabling the operators to focus on fiber and 5G.
+Telecom operators sold their aging copper networks to infrastructure firms that “sweat” the assets with minimal investment, while enabling the operators to focus on fiber and 5G. The infrastructure firms took on the capex of maintaining the copper network.
 
 ### Private Equity Shakeout in Manufacturing
-Conglomerates spin off declining production plants to private equity firms that aggressively cut costs and extract cash until the asset reaches end-of-life.
+Conglomerates spin off declining production plants to private equity firms that aggressively cut costs, manage necessary capex for continued operation, and extract cash until the asset reaches end-of-life.
 
 ### Enterprise Software Support Spin-off
-A legacy on-premises software division is transferred to a specialized support partner that charges premium maintenance fees, enabling the original firm to prioritize its cloud offerings.
+A legacy on-premises software division is transferred to a specialized support partner that charges premium maintenance fees and handles ongoing operational investments, enabling the original firm to prioritize its cloud offerings.
 
 ## 🚦 **When to Use / When to Avoid**
 
 <Assessment strategyName="Sweat & Dump">
   <MapSignals>
     <li>Key components are mature or in decline but still producing revenue.</li>
-    <li>Legacy operations distract from high-priority initiatives.</li>
-    <li>Specialist operators exist who can run down assets cost-effectively.</li>
+    <li>Legacy operations distract from high-priority initiatives and modern system development.</li>
+    <li>Specialist operators exist who will take on capex and run down assets cost-effectively.</li>
     <li>Immediate shutdown would destroy residual value or harm relationships.</li>
+    <li>The cost of maintaining and investing in the legacy system outweighs its strategic value.</li>
   </MapSignals>
   <Readiness>
-    <li>We can identify and contract reliable third parties.</li>
-    <li>We have clear transfer protocols for staff, data, and contracts.</li>
-    <li>We can define exit criteria and performance milestones.</li>
-    <li>We are prepared to handle brand and quality risks externally.</li>
+    <li>We can identify and contract reliable third parties willing to invest.</li>
+    <li>We have clear transfer protocols for staff, data, contracts, and asset ownership/operation.</li>
+    <li>We can define exit criteria and performance milestones related to value extraction and our own modernization efforts.</li>
+    <li>We are prepared to handle brand and quality risks externally while focusing on new systems.</li>
   </Readiness>
 </Assessment>
 
-**Use when:** You need to offload legacy burdens but still want to extract residual value without direct management.
+**Use when:** You need to offload legacy burdens, including capex, and extract residual value, buying time to focus on modernization.
 
-**Avoid when:** Partner performance could damage your brand irreparably, or contractual/regulatory constraints prevent a clean transfer.
+**Avoid when:** Partner performance could damage your brand irreparably, contractual/regulatory constraints prevent a clean transfer, or the asset is too intertwined with strategic future systems to fully decouple.
 
 ## 🎯 **Leadership**
 
 ### Core challenge
-Transitioning control without eroding customer trust or brand integrity while balancing short-term gains against long-term reputation.
+Transitioning control and capex liability without eroding customer trust or brand integrity, while balancing short-term gains against long-term strategic goals and the development of replacement systems.
 
 ### Key leadership skills required
-- Partner selection and negotiation
-- Contract and risk management
-- Change management and stakeholder communication
+- Partner selection and negotiation (emphasizing capex responsibility)
+- Contract and risk management (clear delineation of investment obligations)
+- Change management and stakeholder communication (internal and external)
 - Quality and performance oversight
+- Strategic foresight to plan the "dump" and new system integration
 
 ### Ethical considerations
-Ensure transparent communication with customers about the change and safeguard service levels to avoid harming end users.
+Ensure transparent communication with customers about the change and safeguard service levels to avoid harming end users. Be mindful of the impact on employees of the legacy system and manage the transition humanely. Consider the long-term viability of the partner to avoid sudden service collapse.
 
 ## 📋 **How to Execute**
 
-1. Map legacy assets and evaluate remaining value.
-2. Research and vet specialist operators for compatibility and reliability.
-3. Define service levels, transfer protocols, and exit milestones.
-4. Execute the operational handover and notify stakeholders.
-5. Monitor partner performance and enforce contractual terms.
-6. Conclude the arrangement at end-of-life or upon handing off residuals.
+1. Identify legacy systems with high inertia, ongoing capex demands, and low strategic value.
+2. Shift operations (and ideally capex responsibility) to a partner who will run them as-is (MSP, “enterprise cloud”, specialist operator).
+3. Avoid long-term commitments or refactoring traps that reinvest you in the legacy asset.
+4. Invest liberated resources and focus in the new architecture and co-evolved practices elsewhere.
+5. Exit cleanly (decommission, sell, walk away) once your transition to modern systems is viable. No apologies.
 
 ## 📈 **Measuring Success**
 
-- Cost savings compared to in-house management.
+- Cost savings compared to in-house management, including avoided capex.
 - Revenue extracted during the sweating phase.
 - Customer satisfaction and service continuity post-transfer.
-- Reduction in distractions for core teams.
+- Reduction in distractions for core teams and leadership.
+- Speed and success of modern system development due to freed resources.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
 
-### Partner Insolvency
-If the third party goes bankrupt, you may need to reintegrate operations unexpectedly.
+### Partner Insolvency or Underinvestment
+If the third party goes bankrupt or fails to make necessary operational investments, you may need to reintegrate operations unexpectedly or face service collapse.
 
 ### Brand Contamination
-Poor partner performance can reflect on your organization, damaging customer trust.
+Poor partner performance, especially if driven by underinvestment, can reflect on your organization, damaging customer trust.
 
 ### Contractual Gaps
-Incomplete agreements may leave you liable for unforeseen costs or obligations.
+Incomplete agreements, particularly around capex, service levels, and exit, may leave you liable for unforeseen costs or obligations.
 
 ### Employee Morale Impact
-Transfers and layoffs can undermine morale among remaining staff.
+Transfers and layoffs can undermine morale among remaining staff if not handled well.
+
+### Becoming Trapped
+The partner arrangement becomes so entrenched or complex that "dumping" becomes as hard as the original problem.
 
 ## 🧠 **Strategic Insights**
 
+### Externalising Capex and Inertia for Strategic Agility
+A core tenet of Sweat & Dump is the deliberate transfer of not just operational burden, but also financial liability for ongoing investment—particularly capital expenditure (Capex)—to the third-party operator. Legacy systems often become black holes for investment, demanding upgrades and maintenance that offer diminishing returns. By shifting these to a partner, the organisation frees up significant capital and, crucially, cognitive load. This externalises the system's inherent inertia, allowing internal teams to sidestep the drag of legacy technology and redirect their focus and resources towards developing modern, strategically aligned systems. This buys invaluable time and agility, enabling a smoother transition to the future state without being anchored by past commitments.
+
 ### The "Good Parent" vs. "Pragmatic Executor" Dilemma
-Successfully initiating a Sweat & Dump often requires a significant psychological shift. Assets, even declining ones, frequently have "good parents"—teams or leaders emotionally invested in their history and perceived potential. This attachment can hinder objective assessment. The Sweat & Dump strategy demands a transition to a "pragmatic executor" mindset, focusing on data-driven value extraction and timely exit, rather than indefinite life support. Leadership must actively manage this shift, acknowledging the emotional labor, clearly communicating the strategic necessity, and framing the decision as evolution, not failure. This contrasts with "Disposal of Liability," where an asset's pure toxicity might make the exit emotionally simpler, though still organizationally challenging.
+Successfully initiating a Sweat & Dump often requires a significant psychological shift. Assets, even declining ones, frequently have "good parents"—teams or leaders emotionally invested in their history and perceived potential. This attachment can hinder objective assessment of capex drains and strategic misalignment. The Sweat & Dump strategy demands a transition to a "pragmatic executor" mindset, focusing on data-driven value extraction, capex offloading, and timely exit, rather than indefinite life support. Leadership must actively manage this shift, acknowledging the emotional labor, clearly communicating the strategic necessity, and framing the decision as evolution, not failure.
 
 ### The Art of Selecting the "Sweat" Partner: Beyond Cost
-Choosing the right third-party operator for the "sweat" phase is critical and extends beyond finding the lowest-cost provider. While efficiency is key, the ideal partner possesses specialized expertise in managing mature assets, maintaining essential service levels with minimal investment, and navigating end-of-life scenarios with finesse, thereby protecting your brand during the transition. Key selection criteria include a proven track record, robust processes for managing declining assets, financial stability (to avoid their premature collapse), and alignment on the "dump" timeline. A misaligned partner can accelerate brand damage or create operational crises. This external partnership focus is a key differentiator from "Refactoring," which involves internal repurposing of resources and talent.
+Choosing the right third-party operator for the "sweat" phase is critical and extends beyond finding the lowest-cost provider. While efficiency is key, the ideal partner possesses specialized expertise in managing mature assets, a willingness to take on necessary operational capex, maintaining essential service levels with appropriate investment, and navigating end-of-life scenarios with finesse, thereby protecting your brand during the transition. Key selection criteria include a proven track record, robust processes for managing declining assets, financial stability (to avoid their premature collapse), and alignment on the "dump" timeline and investment expectations. A misaligned partner can accelerate brand damage or create operational crises.
 
-### Strategic Timing of the "Dump": Reading Market Currents
-The "dump" phase—the final exit—isn't merely a reaction to dwindling cash flow; it's a proactive, strategic decision. Optimal timing is informed by active market sensing: monitoring declining returns from the sweat partner, the emergence of disruptive replacement technologies, shifts in the regulatory landscape, or even aligning the exit with your own next-generation product launches to create a clear "out with the old, in with the new" narrative. Waiting too long risks the asset becoming truly unsalvageable or causing reputational harm if service collapses. Dumping prematurely forgoes extractable value. This strategic calendar management, based on a confluence of signals, is vital.
+### Strategic Timing of the "Dump": Reading Market Currents and Internal Readiness
+The "dump" phase—the final exit—isn't merely a reaction to dwindling cash flow; it's a proactive, strategic decision informed by both external market sensing and internal readiness. Optimal timing involves monitoring declining returns from the sweat partner, the maturity of your replacement systems, the emergence of disruptive technologies, shifts in the regulatory landscape, or even aligning the exit with your own next-generation product launches. Waiting too long risks the asset becoming truly unsalvageable or causing reputational harm. Dumping prematurely forgoes extractable value or leaves you without a viable alternative. This strategic calendar management is vital.
 
 ### Catalyst for Renewal: The Phoenix from the Ashes
-A well-executed Sweat & Dump strategy can be a powerful catalyst for organizational renewal. Beyond shedding a burdensome asset, the process liberates significant resources—financial capital, leadership attention, and skilled personnel—that can be explicitly redeployed towards innovation and future growth. This decisive act can break down internal inertia and foster a more agile, forward-looking culture. Leadership can frame Sweat & Dump not as an admission of failure, but as a strategic pruning essential for overall vitality, potentially even improving investor perception by demonstrating disciplined capital reallocation. This transparent, future-focused approach contrasts sharply with the opacity of a "Pig in a Poke" strategy.
+A well-executed Sweat & Dump strategy can be a powerful catalyst for organizational renewal. Beyond shedding a burdensome asset and its associated capex, the process liberates significant resources—financial capital, leadership attention, and skilled personnel—that can be explicitly redeployed towards innovation and future growth. This decisive act can break down internal inertia and foster a more agile, forward-looking culture. Leadership can frame Sweat & Dump not as an admission of failure, but as a strategic pruning essential for overall vitality.
 
 ### Unlocking Hidden Value in "Sweat" Data: Intelligence from the End-Game
-While extracting residual financial value is the primary goal of the "sweat" phase, the operational and customer data generated during this period is a frequently overlooked asset. This "exhaust data" can offer unfiltered insights into late-stage customer behavior, minimum viable service levels under real-world constraints, and specific pain points that emerge as an offering degrades. Such intelligence, potentially more honest than traditional market research, can inform the development of next-generation products or reveal niche opportunities. Crucially, data-sharing clauses should be structured into the initial agreement with the "sweat" operator, allowing the original company to transform the end of one asset's lifecycle into valuable intelligence for future innovation.
-
-### Secondary Effects: Ecosystem Specialization
-Repeated application of Sweat & Dump strategies across an industry can foster the emergence of a specialized market of third-party operators. These firms become adept at managing legacy assets efficiently, creating a new niche within the broader business ecosystem and potentially offering more sophisticated "sweating" services over time.
+While extracting residual financial value and offloading capex are primary goals, the operational and customer data generated during the "sweat" phase is a frequently overlooked asset. This "exhaust data" can offer insights into late-stage customer behavior and minimum viable service levels. Such intelligence can inform the development of next-generation products. Data-sharing clauses should be structured into the agreement with the "sweat" operator.
 
 ### Managing Transferred Risks
-While operational burdens are offloaded to the "sweat" partner, significant reputational risk remains with the original company. Poor performance, service failures, or unethical behavior by the partner can directly tarnish the original brand. Vigilant oversight, clear contractual service levels, and robust partner governance are essential to mitigate this concentrated risk.
+While operational burdens and capex are offloaded, significant reputational risk remains. Poor performance, service failures, or unethical behavior by the partner can directly tarnish the original brand. Vigilant oversight, clear contractual service levels (including investment commitments), and robust partner governance are essential.
 
 ## ❓ **Key Questions to Ask**
 
-- Who can operate this asset more efficiently than us?
-- What incentives align partner profitability with asset care?
-- How will customers perceive the operational handover?
-- What exit triggers and milestones are required?
-- How will we monitor and enforce partner performance?
+- Who can operate this asset (and its capex) more effectively than us?
+- What incentives align partner profitability with asset care and necessary investment?
+- How will customers perceive the operational handover and potential service changes?
+- What are our exit triggers, especially concerning our new system's readiness?
+- How will we monitor partner performance and their fulfillment of capex obligations?
+- Are we truly buying time for modernization, or just delaying an inevitable problem?
 
 ## 🔀 **Related Strategies**
 
-- [Disposal of Liability](/strategies/dealing-with-toxicity/disposal-of-liability) – Direct divestment or shutdown of toxic assets.
-- [Pig in a Poke](/strategies/dealing-with-toxicity/pig-in-a-poke) – Sell liabilities under false pretenses.
-- [Refactoring](/strategies/dealing-with-toxicity/refactoring) – Internally transform or repurpose assets.
+- [Disposal of Liability](/strategies/dealing-with-toxicity/disposal-of-liability) – Direct divestment or shutdown of toxic assets, often without a "sweat" phase.
+- [Pig in a Poke](/strategies/dealing-with-toxicity/pig-in-a-poke) – Sell liabilities under false pretenses (ethically dubious and risky).
+- [Refactoring](/strategies/dealing-with-toxicity/refactoring) – Internally transform or repurpose assets, retaining control and capex.
+- [Innovate-Leverage-Commoditize](/strategies/ecosystem/innovate-leverage-commoditize) - Could be the end-goal that Sweat & Dump enables resources for.
 
 ## 📚 **Further Reading & References**
 
 - Case Study: [Nortel](https://en.wikipedia.org/wiki/Timeline_of_Nortel) Support Spin-offs – Real-world legacy IT sweat & dump scenario.
+- Article: [The Hidden Costs of Legacy Systems](https://www.example.com/hidden-costs-legacy) - (Illustrative link, replace with actual relevant article if known) Discusses the capex drain that Sweat & Dump aims to offload.


### PR DESCRIPTION
…and capex

The Sweat & Dump strategy page has been updated to reflect a revised understanding:

- Focus shifted from mere asset disposal to a strategic pattern for externalizing inertia and capex.
- Highlights how this strategy allows organizations to buy time and resources to invest in modern systems by transferring the burden of legacy system investment to a third party.

Changes include:
- Revised introduction and explanation sections.
- Updated execution steps.
- Added a new strategic insight on 'Externalising Capex and Inertia for Strategic Agility'.
- Tweaked other sections to align with the new emphasis.