### PR TITLE
Expand and update Competitor strategy category page

### DIFF
--- a/docs/strategies/competitor/index.md
+++ b/docs/strategies/competitor/index.md
@@ -1,8 +1,75 @@
+---
+title: Competitor
+description: Engaging rivals to erode their advantages, waste resources, or neutralize threats.
+---
+
 # Competitor
 
-These are strategies for dealing with rivals you can't ignore or strategically absorb.
+This category of strategies encompasses a diverse array of tactical and strategic actions aimed at directly or indirectly engaging with rivals. These approaches come into play when a competitor's presence is too significant to ignore, or when strategic absorption isn't feasible or desirable. The core objectives often revolve around diminishing a rival's competitive edge, misdirecting their strategic focus, depleting their valuable resources, maneuvering them into strategically unfavorable circumstances, or otherwise shaping the competitive landscape to your advantage.
 
-The aim is to erode their advantage, waste their resources, or trap them in bad bets. If you're too small to confront directly, these indirect plays can level the field.
+This might involve exploiting a competitor's known weaknesses, turning their apparent strengths into liabilities, or subtly altering market conditions. The ultimate aim is to improve your own strategic position, often by constraining the options available to your rivals. These strategies are particularly potent for organizations that might lack the scale or resources for a direct, sustained confrontation with larger, more entrenched competitors. Through astute, often indirect plays, a company can endeavor to level the playing field, engineer strategic openings, or neutralize specific threats.
+
+## 🤔 **What are Competitor Strategies?**
+
+At their core, competitor strategies are about moving beyond a purely internal focus to actively understanding and influencing the competitive landscape. They involve viewing a competitor as a system that can be analyzed, predicted, and ultimately influenced. Key characteristics and goals include:
+
+*   **Eroding Competitive Advantage:** Identifying and targeting the sources of a competitor's strength – be it technology, market share, talent, or brand – and taking actions to weaken or neutralize that advantage.
+*   **Resource Depletion:** Designing plays that force a competitor to expend resources (time, money, attention) in areas that are non-core to their strategy or in ways that yield minimal returns for them. This can include forcing them to react to your moves, defend unprofitable segments, or invest in countermeasures.
+*   **Strategic Misdirection:** Leading competitors towards incorrect assumptions about your intentions or market trends, causing them to invest in the wrong areas or prepare for the wrong scenarios.
+*   **Creating Decision Dilemmas:** Engineering situations where any move a competitor makes comes with significant downsides, effectively trapping them or forcing them into suboptimal choices.
+*   **Exploiting Inertia:** Capitalizing on a competitor's unwillingness or inability to change due to past successes, established processes, or cultural resistance.
+*   **Shaping the Playing Field:** Actively working to alter the "rules of the game" in a market, such as influencing standards, creating new channels, or disrupting existing networks in ways that favor your position.
+
+These strategies often require a deep understanding of a competitor's psychology, organizational structure, decision-making processes, and market dependencies.
+
+## 🚀 **Why Use Competitor Strategies?**
+
+Employing competitor-focused strategies can be essential for survival and growth in contested markets. They offer several strategic advantages:
+
+*   **Leveling the Playing Field:** Smaller or newer entrants can use these strategies to negate some of the scale advantages of larger incumbents, creating space for themselves to grow.
+*   **Responding to Aggression:** When a competitor makes aggressive moves, these strategies provide a toolkit for responding effectively, rather than simply ceding ground.
+*   **Creating Market Opportunities:** By disrupting a competitor's plans or weakening their hold on a market segment, new opportunities can be created for your own offerings.
+*   **Defending Market Share:** These tactics can be used defensively to protect your existing market position from encroaching rivals.
+*   **Preemptive Action:** Anticipating a competitor's likely moves and taking action to preempt them or reduce their impact.
+*   **Improving Negotiating Positions:** Demonstrating an ability to impact a competitor can strengthen your position in potential partnerships, supplier relationships, or even co-opetition scenarios.
+*   **Accelerating Market Shifts:** Certain competitor strategies can help accelerate underlying market trends that are favorable to your long-term position, particularly if competitors are resistant to those trends.
+
+While a strong focus on customer value and internal excellence is paramount, a sophisticated understanding and selective application of competitor strategies can provide a crucial edge in achieving strategic objectives. They are about playing the whole game, not just your own part of it.
+
+## ♟️ **Types of Competitor Strategies**
+
+Here are several approaches for engaging with competitors, each with a distinct focus:
+
+*   **[Ambush](/strategies/competitor/ambush)**: Exploiting a competitor's marketing efforts or public presence to gain visibility and market share, often by associating your brand with an event or message they initiated.
+*   **[Circling and Probing](/strategies/competitor/circling-and-probing)**: Systematically testing a competitor's defenses, responses, and capabilities across different areas to identify weaknesses and unexploited opportunities.
+*   **[Fragmentation Play](/strategies/competitor/fragmentation-play)**: Breaking up a larger, dominant competitor or market by targeting niche segments, supporting competing standards, or fostering a diverse ecosystem that collectively chips away at their position.
+*   **[Misdirection](/strategies/competitor/misdirection)**: Leading a competitor to believe you are pursuing one course of action while you are actually implementing another, causing them to misallocate resources or focus.
+*   **[Reinforcing Competitor Inertia](/strategies/competitor/reinforcing-competitor-inertia)**: Subtly encouraging a competitor to continue with their existing, suboptimal strategies or to double down on outdated practices, thereby hindering their adaptation.
+*   **[Restriction of Movement](/strategies/competitor/restriction-of-movement)**: Limiting a competitor's strategic options by securing key resources, channels, partnerships, or by creating dependencies that constrain their ability to maneuver.
+*   **[Sapping](/strategies/competitor/sapping)**: Gradually draining a competitor's strength, resources, or morale through sustained, often low-intensity actions that individually seem minor but collectively have a significant impact.
+*   **[Talent Raid](/strategies/competitor/talent-raid)**: Systematically hiring key personnel from a competitor to acquire their expertise, disrupt their operations, and gain market intelligence.
+
+Each of these strategies offers a different method for engaging with and potentially neutralizing competitor actions, requiring careful consideration of the context and potential consequences.
+
+## ⚖️ **Ethical Considerations and Risks**
+
+While competitor-focused strategies can be effective, they also carry significant risks and ethical considerations that must be carefully weighed:
+
+*   **Retaliation:** Aggressive moves can provoke strong responses from competitors, potentially leading to costly battles that harm all parties involved.
+*   **Reputational Damage:** Strategies perceived as unethical, underhanded, or overly aggressive can damage a company's reputation with customers, partners, and the wider industry.
+*   **Legal Challenges:** Some tactics, if not carefully implemented, can stray into anti-competitive behavior, intellectual property infringement, or other legal pitfalls.
+*   **Internal Focus Erosion:** An excessive focus on competitors can distract from innovation and customer needs, leading to a reactive rather than proactive strategy.
+*   **Moral Hazard:** Certain tactics might create a culture that prioritizes winning at any cost, potentially leading to unethical decision-making internally.
+*   **Market Instability:** Some competitor strategies, especially those aimed at broad disruption, can create instability that negatively impacts the entire market ecosystem.
+*   **Short-Term Gains vs. Long-Term Value:** Aggressive tactics might yield short-term advantages but could undermine long-term trust and sustainable growth if they alienate stakeholders or are built on unsustainable premises.
+
+It's crucial to align competitor strategies with the company's overall values and ethical guidelines, ensuring that actions taken are defensible and contribute to a healthy competitive environment where possible. A clear understanding of legal boundaries and potential market perceptions is essential.
+
+## ✨ **Conclusion**
+
+Understanding and strategically applying competitor-focused strategies is a vital component of a comprehensive approach to navigating the business landscape. These strategies are not about mindless aggression but about informed, calculated actions designed to shape the competitive environment to your advantage, neutralize threats, and create opportunities for growth.
+
+However, they must be used judiciously, with a keen awareness of the potential risks, ethical implications, and the broader impact on the market. The most effective long-term strategies often blend a strong customer focus with a sophisticated understanding of competitive dynamics, allowing organizations to adapt, innovate, and thrive in even the most challenging environments. The key is to integrate these plays into a coherent overall strategy that is both effective and sustainable.
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';


### PR DESCRIPTION
This commit significantly expands the content of the 'Competitor' strategy category page (docs/strategies/competitor/index.md).

The changes include:
- Adding a comprehensive introduction to competitor strategies.
- Defining what competitor strategies are and why they are used.
- Listing and briefly describing all sub-strategies within the Competitor category, with links to their individual pages.
- Including a section on ethical considerations and risks associated with these strategies.
- Ensuring the content aligns with the style and depth of other category pages like 'Accelerators' and 'Dealing with Toxicity'.
- Updating front matter and H1 to 'Competitor' for consistency.