### PR TITLE
Expand Decelerators strategy category page content

### DIFF
--- a/docs/strategies/decelerators/index.md
+++ b/docs/strategies/decelerators/index.md
@@ -1,12 +1,84 @@
 ---
-description: Slow down evolution
+description: Strategically slow down market evolution to protect revenue, buy time, or control competitive dynamics.
 ---
 
 # Decelerators
 
-Decelerators (or **De-accelerators**) are used to slow evolution: buying time or protecting revenue.
+Decelerators (or **De-accelerators**) are strategic plays in Wardley Mapping designed to intentionally slow down the evolution of components, services, or entire market segments. Unlike Accelerators that aim to speed up change, Decelerators focus on imposing constraints, increasing friction, or leveraging inertia to manage the pace of development. The primary goals often include protecting existing revenue streams from mature offerings, buying crucial time for an organization to adapt to shifts or build new capabilities, shaping market evolution to better align with an organization's strengths, or creating significant barriers to entry or advancement for competitors.
 
-These strategies impose constraints or drag on change to maintain advantage or prepare the ground on your terms. These are often defensive but can be offensive when used to trap others. Use them carefully. If overused, they can create fragility or provoke regulatory pushback.
+These strategies are particularly relevant when an organization benefits from the current state of the market, needs to manage the decline of a legacy component gracefully, or seeks to control the competitive landscape by hindering the progress of rivals. While often defensive in nature, Decelerators can also be used offensively to trap competitors or dictate the terms of engagement. However, they must be employed with caution, as overuse or misapplication can lead to organizational stagnation, attract regulatory attention, or damage ecosystem health.
+
+## 🤔 **What are Decelerators?**
+
+Decelerators are tactical maneuvers aimed at reducing the speed of change or development in a specific area of a Wardley Map. They work by actively introducing or amplifying factors that resist the natural evolutionary pressures towards commoditization and utility. This can involve making things more complex, more expensive, or harder to access for others, thereby slowing down the progression of a component from early, less evolved stages (like Genesis or Custom-Built) to more mature states (like Product/Rental or Commodity/Utility).
+
+The core idea is to manipulate the environment to create a strategic advantage. This might mean preserving a profitable status quo, giving your organization breathing room to catch up or pivot, or actively hindering the progress of competitors who might benefit from faster evolution.
+
+Several distinct sub-strategies can be employed to achieve this deceleration:
+
+*   **[Creating Constraints](/strategies/decelerators/creating-constraints)**: This involves actively manufacturing new bottlenecks or limitations where none previously existed. This could be through controlling supply chains, influencing regulations to be more restrictive, or establishing proprietary standards that are difficult for others to adopt.
+*   **[Exploiting Existing Constraint](/strategies/decelerators/exploiting-constraint)**: Instead of creating new ones, this strategy focuses on identifying and amplifying constraints that already exist in the market or for a competitor. This could mean increasing demand on a competitor's limited resource or further restricting access to something they rely on.
+*   **[Patents & Intellectual Property Rights (IPR)](/strategies/decelerators/ipr)**: Leveraging legal mechanisms like patents, copyrights, or trademarks to create exclusive rights over an innovation. This legally prevents or slows down competitors from using, building upon, or further evolving similar technologies or components.
+
+Each of these approaches offers a different method to strategically apply brakes to the evolutionary process, allowing an organization to influence the tempo of the landscape.
+
+## 🐌 **Why Use Decelerators?**
+
+Employing Decelerator strategies can provide significant strategic advantages by allowing organizations to actively manage and influence the pace of change within their competitive landscape. Rather than passively reacting to evolutionary pressures, Decelerators offer a means to exert control. Key reasons to use these strategies include:
+
+*   **Protecting Mature Revenue Streams:** For components or services that are highly evolved and profitable (often in the Product/Rental or even Commodity/Utility stages), decelerators can help maintain their profitability for longer by slowing down disruptive innovations or the entry of lower-cost alternatives.
+*   **Buying Time for Adaptation:** When faced with rapid market shifts or the emergence of disruptive technologies, organizations may need time to develop new capabilities, adjust their business models, or pivot their strategies. Decelerators can create that crucial breathing room.
+*   **Creating and Reinforcing Barriers to Entry:** By making it more difficult, costly, or legally risky for new entrants or existing competitors to advance, decelerators can protect an organization's market position and profitability. This is often achieved by controlling critical resources, intellectual property, or regulatory landscapes.
+*   **Managing Risk from Uncontrolled Change:** Sometimes, rapid evolution can introduce instability or unforeseen risks. Decelerators can be used to manage the pace of change, ensuring that the organization and the broader ecosystem can adapt in a more controlled manner.
+*   **Influencing Market Evolution to Favor Strengths:** Organizations can use decelerators to guide market development in directions that play to their existing strengths or established positions, making it harder for competitors with different advantages to gain traction.
+*   **Countering Competitor Advances:** If a competitor is aggressively trying to accelerate a market or component in a way that is disadvantageous, decelerators can be deployed as a counter-measure to slow their progress and neutralize their offensive plays.
+*   **Graceful Exit or Transition:** For legacy systems or offerings that are being phased out, decelerators can help manage the decline, ensuring a smoother transition for customers and the organization, and maximizing any remaining value.
+
+Ultimately, Decelerators are about strategic control over the tempo of evolution. They enable organizations to act defensively to protect assets or offensively to hinder rivals, all with the aim of improving their strategic outcomes in a dynamic environment.
+
+## ⚖️ **Decelerators vs. Accelerators**
+
+Understanding Decelerators is enhanced when comparing them directly with their counterparts: **[Accelerators](/strategies/accelerators/)**. These two categories of strategies represent the opposing, yet often complementary, forces organizations can deploy to manipulate the speed and direction of evolution within their Wardley Maps.
+
+**Accelerators** are, as their name suggests, focused on speeding up the evolutionary process. They aim to:
+*   Hasten the commoditization of components.
+*   Encourage widespread adoption and standardization.
+*   Reduce friction for innovation and the development of higher-order systems.
+*   Enable markets and foster network effects.
+Examples include open-sourcing a technology, promoting industry standards, or investing to rapidly scale a new service. The goal is to move components quickly towards more mature, stable, and cost-effective states, thereby unlocking new value and opportunities.
+
+**Decelerators**, conversely, are employed to slow down this evolutionary march. Their objectives often include:
+*   Protecting existing, profitable revenue streams tied to less evolved (and often higher margin) components.
+*   Buying time for the organization to adapt, catch up, or prepare for future changes.
+*   Creating barriers to entry or progress for competitors.
+*   Managing risks associated with overly rapid or uncontrolled evolution.
+Examples include filing defensive patents, creating complex regulatory hurdles, or locking in customers with proprietary ecosystems.
+
+**The Strategic Choice:**
+
+The decision to accelerate or decelerate is highly contextual and depends on:
+*   **An organization's current market position:** Incumbents with profitable legacy systems might favor deceleration for those systems, while simultaneously accelerating new ventures.
+*   **Strategic goals:** Is the aim to disrupt an established market (favoring acceleration of new models) or protect a dominant position (favoring deceleration of threats)?
+*   **The specific component in question:** A company might accelerate the commoditization of a complementary component that drives demand for its core, differentiated product, while decelerating any threats to that core product.
+*   **Competitive dynamics:** The actions of competitors might necessitate an accelerative or decelerative response.
+
+It's not uncommon for organizations to employ a **mixed approach**, strategically accelerating certain parts of their value chain while decelerating others. For instance, a company might accelerate the adoption of its new platform (an Accelerator play) while using IPR (a Decelerator play) to slow down competitors trying to copy its core innovations.
+
+Mastering both sets of strategies allows for a more nuanced and effective approach to navigating and shaping the competitive landscape.
+
+## ⚠️ **Risks and Considerations**
+
+While Decelerator strategies can be powerful tools for achieving specific strategic objectives, they are not without significant risks and require careful consideration. Employing them unwisely can lead to unintended negative consequences:
+
+*   **Stifling Internal Innovation and Creating Inertia:** Over-reliance on protecting the old can create a culture that resists new ideas and change. This internal inertia can make the organization slow to adapt when market conditions inevitably shift, potentially leading to its own obsolescence.
+*   **Provoking Regulatory Scrutiny or Antitrust Actions:** Aggressive deceleration tactics, especially those that create significant barriers to entry, exploit constraints unfairly, or abuse intellectual property rights, can attract the attention of regulators. This can lead to investigations, fines, or forced changes in business practices.
+*   **Damaging Ecosystem Relationships:** Strategies that overly restrict partners, suppliers, or customers can damage trust and goodwill. A healthy ecosystem often relies on a degree of openness and mutual benefit; overly defensive or exploitative decelerators can alienate key players and encourage them to seek alternatives.
+*   **Competitors Bypassing Deceleration Tactics:** Determined competitors will actively seek ways around the obstacles created. They might innovate to find alternative solutions, challenge IPR in court, lobby for regulatory changes, or find new routes to market, rendering the deceleration efforts ineffective or even counterproductive.
+*   **Becoming Too Defensive and Missing Opportunities:** A strong focus on deceleration can lead to a defensive mindset, causing the organization to miss out on new growth opportunities or fail to invest in future innovations. The market landscape is always evolving, and purely defensive postures rarely lead to long-term success.
+*   **Ethical Concerns and Reputational Damage:** Some deceleration tactics can be perceived as unethical or anti-competitive, even if technically legal. This can lead to reputational damage, loss of customer loyalty, and difficulty attracting talent.
+*   **Sustainability of the Deceleration:** The effort and cost required to maintain a decelerating strategy can be substantial. Market forces, technological advancements, and competitor actions constantly challenge these artificial brakes. What works today might be unsustainable or irrelevant tomorrow.
+
+Therefore, the decision to use Decelerator strategies should be made with a clear understanding of these potential downsides. It requires a careful balance, a strong ethical compass, and a continuous assessment of the evolving landscape to ensure that the benefits outweigh the risks and that the strategy remains aligned with long-term organizational health and goals.
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';


### PR DESCRIPTION
Updated the Decelerators strategy category page (`docs/strategies/decelerators/index.md`) to provide a comprehensive overview of the category.

Key changes:
- Added detailed introduction to Decelerator strategies.
- Created 'What are Decelerators?' section explaining the concept and sub-strategies.
- Created 'Why Use Decelerators?' section outlining strategic advantages.
- Created 'Decelerators vs. Accelerators' section for comparison.
- Created 'Risks and Considerations' section discussing potential downsides.

The content now aligns with other well-developed category pages like Accelerators and Toxicity, and follows guidelines from CONTRIBUTING.md and authoritative content notes.