### PR TITLE
Update Ecosystem strategy category page content

### DIFF
--- a/docs/strategies/ecosystem/index.md
+++ b/docs/strategies/ecosystem/index.md
@@ -1,8 +1,60 @@
 # Ecosystem
 
-Ecosystem plays are about using others to do the work. You build platforms, form alliances, or encourage co-creation to drive evolution at scale.
+Ecosystem strategies in Wardley Mapping revolve around leveraging the capabilities, resources, and motivations of external entities to achieve your strategic objectives. Instead of solely relying on internal development or direct control, these plays focus on building, shaping, or participating in networks of organizations, users, or components. The core idea is to create a situation where the collective efforts of the ecosystem amplify your own, driving evolution, innovation, or market control in ways that would be difficult or impossible to achieve alone.
 
-A good ecosystem play aligns your goals with the incentives of others. Done right, you gain leverage, sensing capability, and compounding advantage. Done badly, you lose control and carry the cost.
+A well-executed ecosystem strategy aligns your goals with the incentives of other participants, fostering collaboration, co-creation, or co-dependency. This can lead to significant advantages such as increased speed of development, broader market reach, enhanced innovation, and shared risk. However, ecosystem plays also come with challenges, including loss of direct control, increased complexity in coordination, and the potential for ecosystem partners to become future competitors.
+
+## 🤔 **What are Ecosystem Strategies?**
+
+Ecosystem strategies are a diverse set of approaches aimed at influencing or utilizing the interactions between various independent entities in a market or value chain. The primary goal is to create a system that is more valuable or efficient due_to the interplay of its parts, with your organization playing a key role in that system. These strategies often involve creating platforms, fostering communities, establishing standards, or forming alliances.
+
+Key sub-strategies within the Ecosystem category include:
+
+*   **[Alliances](/strategies/ecosystem/alliances)**: Forming partnerships with other organizations, sometimes even competitors, to achieve a common goal, share resources, or enter new markets. Alliances can accelerate progress by pooling expertise and distributing costs.
+*   **[Channel Conflict and Disintermediation](/strategies/ecosystem/channel-conflict-and-disintermediation)**: Strategically altering or bypassing existing channels to market. This can involve creating new direct routes to customers or disrupting established intermediaries, often by leveraging new platform capabilities.
+*   **[Co-Creation](/strategies/ecosystem/co-creation)**: Collaborating with customers, partners, or the wider community to jointly develop products, services, or solutions. This approach can lead to more innovative outcomes that are better aligned with user needs.
+*   **[Co-opting](/strategies/ecosystem/co-opting)**: A strategy where an organization influences a standard, technology, or movement, often initiated by others, to align it with its own strategic interests. This can involve contributing to an open standard in a way that favors your own complementary products.
+*   **[Embrace and Extend](/strategies/ecosystem/embrace-and-extend)**: Initially adopting a widely used standard or platform (embrace) and then adding proprietary features or extensions (extend) to create differentiation and lock-in.
+*   **[Innovate, Leverage, Commoditize (ILC)](/strategies/ecosystem/innovate-leverage-commoditize)**: A powerful cycle involving developing novel components (Innovate), using them to build and dominate higher-order systems (Leverage), and then encouraging the commoditization of those components to undermine competitors or enable new innovations (Commoditize).
+*   **[Tower and Moat](/strategies/ecosystem/tower-and-moat)**: Building a strong, defensible core business (the Tower) and then creating a surrounding ecosystem of complementary products, services, or partners (the Moat) that protect and enhance the core.
+*   **[Two-Factor Markets](/strategies/ecosystem/two-factor-markets)**: Creating value by connecting two distinct groups of users or customers who depend on each other, often subsidizing one side to attract the other (e.g., app stores connecting developers and users).
+
+## 🚀 **Why Use Ecosystem Strategies?**
+
+Employing Ecosystem strategies can offer substantial strategic advantages by enabling organizations to achieve outcomes beyond their individual capacity. These approaches are particularly powerful for:
+
+*   **Scaling Innovation and Development:** By tapping into the creativity and resources of a wider network, companies can accelerate the pace of innovation and bring new offerings to market more quickly. Co-creation and open platforms are prime examples.
+*   **Expanding Market Reach:** Alliances and channel strategies can provide access to new customer segments, geographies, or complementary products, significantly broadening market presence.
+*   **Building Defensible Positions:** Strategies like Tower and Moat or exploiting network effects within an ecosystem can create strong competitive advantages that are difficult for others to replicate.
+*   **Driving Adoption and Standards:** Ecosystem plays can be crucial in establishing new standards or driving the widespread adoption of a particular technology or platform. The more participants in an ecosystem, the stronger its gravitational pull.
+*   **Managing Risk and Uncertainty:** Sharing the costs and risks of development or market entry with partners can make ambitious projects more feasible.
+*   **Sensing and Responding to Change:** A vibrant ecosystem provides valuable feedback loops and insights into market trends, customer needs, and emerging threats, enhancing an organization's ability to adapt.
+*   **Influencing the Evolutionary Landscape:** By encouraging the commoditization of certain components (e.g., via ILC) or by establishing platforms, organizations can strategically shape the direction and speed of evolution for key parts of the value chain.
+
+Ecosystem strategies are about understanding that value creation is often a collaborative or interdependent process. By strategically engaging with external entities, organizations can create more value than they could alone.
+
+## 🌐 **Core Principles of Ecosystem Play**
+
+Successful ecosystem strategies often adhere to several underlying principles:
+
+*   **Value Co-creation:** The ecosystem must offer tangible benefits to all key participants. If the value flows disproportionately or is not clear, engagement will wane.
+*   **Mutual Benefit and Incentives:** Aligning your strategic goals with the motivations and incentives of your ecosystem partners is crucial for sustained collaboration.
+*   **Governance and Rules:** Clear rules of engagement, standards, and governance mechanisms are often necessary to manage complexity, ensure fairness, and resolve conflicts within the ecosystem.
+*   **Interdependence:** Creating a degree of mutual dependency can strengthen the ecosystem, as participants recognize their success is tied to the health of the whole.
+*   **Modularity and Interfaces:** Well-defined interfaces and modular components allow different participants to contribute and innovate independently while ensuring compatibility and integration.
+*   **Trust and Transparency:** Building trust among ecosystem members is vital, often fostered through transparency in operations, decision-making, or data sharing where appropriate.
+*   **Evolutionary Approach:** Ecosystems are not static; they evolve. Strategies must be adaptable, allowing for changes in participants, roles, and the overall environment.
+
+## 🔗 **Ecosystems and Other Strategic Plays**
+
+Ecosystem strategies often interact with and can be amplified by other types of strategic plays. Understanding these connections can lead to more robust and effective overall strategies:
+
+*   **[Accelerators](/strategies/accelerators/)**: Many ecosystem strategies inherently accelerate the evolution of components. For example, [Open Approaches](/strategies/accelerators/open-approaches) can be a cornerstone of building a vibrant development ecosystem that speeds up commoditization. Similarly, [Exploiting Network Effects](/strategies/accelerators/exploiting-network-effects) is often achieved by fostering an ecosystem of users.
+*   **Platform Plays**: While not a distinct category here, building a "platform" is a common way to execute an ecosystem strategy. A platform provides the foundation upon which other ecosystem participants can build products or services, creating a symbiotic relationship (e.g., [Two-Factor Markets](/strategies/ecosystem/two-factor-markets)).
+*   **[Standards Game](/strategies/markets/standards-game)**: Actively participating in or trying to control standards is a key element of many ecosystem strategies, particularly those like [Co-opting](/strategies/ecosystem/co-opting) or [Embrace and Extend](/strategies/ecosystem/embrace-and-extend). The chosen standard becomes the common language or infrastructure for the ecosystem.
+*   **[Defensive Strategies](/strategies/defensive/)**: A strong ecosystem can be a powerful defensive moat. For instance, a large and engaged user base (an ecosystem) can deter new entrants, aligning with [Raising Barriers to Entry](/strategies/defensive/raising-barriers-to-entry).
+
+Recognizing these overlaps and interdependencies allows for a more nuanced application of ecosystem thinking, integrating it into a broader strategic framework. The key is to see the "ecosystem" not just as a standalone tactic, but as a lens through which many other strategic actions can be viewed and enhanced.
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';


### PR DESCRIPTION
Expanded the content of the Ecosystem category page (`docs/strategies/ecosystem/index.md`) to be more comprehensive, similar to other well-developed category pages like Accelerators and Toxicity.

The update includes:
- A detailed definition of Ecosystem strategies in Wardley Mapping.
- Explanation of why and when to use these strategies.
- Discussion of core principles for successful ecosystem plays.
- Listing and brief explanation of sub-strategies within the Ecosystem category.
- Analysis of how Ecosystem strategies interact with other strategic plays.

The content aims to provide a holistic view of the category, going beyond a simple summary of its sub-strategies, and aligns with the site's guidelines for authoritative content.