### PR TITLE
Update User Perception strategy category page

### DIFF
--- a/docs/strategies/user-perception/index.md
+++ b/docs/strategies/user-perception/index.md
@@ -1,12 +1,81 @@
 ---
-description: Influencing how users and markets perceive value, choice, and change
+description: Influencing how users and markets perceive value, choice, and change.
 ---
 
-# User Perception
+# User Perception Strategies
 
-User perception strategies shape how users see value, choice and change.
+User Perception strategies in Wardley Mapping focus on influencing how users, customers, and the broader market see and interpret value, choice, change, and risk. These plays acknowledge that the objective reality of a product, service, or situation is often less important than what people *believe* to be true. By shaping these beliefs, organizations can steer behavior, create or dampen demand, build loyalty, manage resistance, or impede competitors.
 
-You use *education* to overcome inertia or *FUD* to slow others. You can manipulate behaviour with *bundling*, *artificial needs*, or by *confusing choice*. These are subtle but powerful. Often the battle isn’t over what’s better, but what users *believe* is better.
+These strategies range from ethically sound approaches like transparent education and value-driven branding to more manipulative tactics such as spreading Fear, Uncertainty, and Doubt (FUD) or deliberately creating confusion. Understanding the nuances and ethical implications of these plays is crucial for both deploying them effectively and defending against them when used by others. The core idea is that perception itself is a landscape that can be mapped, understood, and strategically navigated.
+
+## 🤔 **What are User Perception Strategies?**
+
+User Perception strategies are a set of plays designed to deliberately mold the cognitive and emotional landscape of your target audience. This isn't just about superficial marketing messages; it's about fundamentally altering how users understand, feel about, and react to your offerings, your competitors, and the market itself. These strategies recognize that perception is a powerful lever for competitive advantage, influencing decisions from individual purchases and adoption rates to broad market trends and even regulatory frameworks.
+
+The primary goal is to create a reality in the minds of users that aligns with your strategic objectives. This might involve making your product seem indispensable, a competitor's offering risky, a complex choice simple (or a simple choice complex), or a new behavior normal.
+
+Key approaches within this category include:
+
+*   **[Artificial Competition](/strategies/user-perception/artificial-competition)**: Involves creating the illusion of a competitive market by establishing or supporting entities that appear to compete but are ultimately under your control or influence. This tactic can deflect monopoly concerns, manage customer perceptions of choice, and absorb competitive energy that might otherwise target your core offerings.
+*   **[Brand and Marketing](/strategies/user-perception/brand-and-marketing)**: Leverages traditional and digital marketing techniques, cohesive branding, and compelling storytelling to create an emotional connection, build enduring loyalty, and differentiate offerings based on perceived qualities, values, and identity alignment, rather than solely on functional features or price points. Effective branding can make a product feel like the only natural choice for a specific group.
+*   **[Bundling](/strategies/user-perception/bundling)**: Consists of packaging a less desirable product, service, or change with a more desirable one to encourage adoption of the entire package. This often serves to obscure the less attractive element or make its acceptance a prerequisite for obtaining the more valued component, thereby driving uptake of strategically important but potentially unpopular items.
+*   **[Confusion of Choice](/strategies/user-perception/confusion-of-choice)**: Aims to overwhelm users with an excessive number of options, overly complex product configurations, or opaque pricing structures. This makes rational, comparative decision-making difficult and can lead to customer inertia (sticking with the known), or suboptimal choices that inadvertently favor the provider.
+*   **[Creating Artificial Needs](/strategies/user-perception/creating-artificial-needs)**: Focuses on generating demand by inventing or significantly amplifying a "need" that did not previously exist or was latent in the user's mind. This is often achieved by associating a product with status, identity, solving a newly highlighted problem, or alleviating a manufactured anxiety.
+*   **[Education](/strategies/user-perception/education)**: Involves informing the market or specific user groups to overcome inertia, clearly explain the benefits of a change or new offering, clarify risks associated with alternatives (or inaction), or build foundational trust and credibility. This can be a transparent and constructive way to accelerate adoption or counter prevailing misinformation.
+*   **[Fear, Uncertainty, and Doubt (FUD)](/strategies/user-perception/fear-uncertainty-and-doubt)**: A classic tactic of spreading negative information—often through subtle insinuation, questioning, or highlighting potential risks—about a competitor's products, financial stability, security, or future intentions. The goal is to slow their adoption and make users hesitant to switch or try the alternative.
+*   **[Lobbying](/strategies/user-perception/lobbying)**: Entails influencing governmental bodies, regulators, standards organizations, or other influential groups to shape policies, regulations, or industry standards in a way that favors your offerings, creates barriers for competitors, or aligns public perception with your strategic goals.
+
+These strategies often work by tapping into cognitive biases (like confirmation bias or loss aversion), emotional responses (fear, aspiration, belonging), or by exploiting information asymmetries where one party knows more than the other.
+
+## 💡 **Why Employ User Perception Strategies?**
+
+Employing User Perception strategies can provide significant and diverse strategic advantages, allowing organizations to proactively shape their competitive environment:
+
+*   **Shape and Create Market Demand:** Go beyond passively responding to existing needs by actively cultivating new desires or highlighting unmet needs, thereby creating entirely new markets or significantly increasing demand for existing products and services.
+*   **Build Deep Brand Loyalty and Trust:** Develop strong, resonant emotional connections with customers, fostering a sense of identity and community around your brand. This makes them less price-sensitive, more forgiving of occasional missteps, and more resistant to competitor offerings.
+*   **Achieve Meaningful Differentiation in Crowded Markets:** Stand out from a sea of similar competitors not just on tangible features or price, but on perceived value, status, alignment with user identity, or a unique brand promise.
+*   **Accelerate Adoption of Innovations and Change:** Overcome natural user inertia and resistance to new ways of doing things by clearly communicating benefits and value (Education), or by subtly encouraging uptake through clever packaging (Bundling) or by normalizing the new.
+*   **Defend and Strengthen Market Position:** Protect your existing market share by slowing down competitors (e.g., through FUD), by making direct comparisons difficult (Confusion of Choice), or by creating an environment where your solution is perceived as the safest or most logical choice.
+*   **Influence Regulatory and Policy Environments:** Proactively shape the rules of the game to create favorable conditions for your business model, erect barriers to entry for potential rivals, or secure preferential treatment (Lobbying).
+*   **Manage Crises and Protect Reputation:** Proactively shape public and stakeholder narratives to mitigate negative perceptions during challenging times, rebuild trust, and maintain business continuity.
+*   **Increase Switching Costs (Perceived or Real):** Make users *believe* that moving to a competitor is riskier, more difficult, more costly, or less beneficial than it might objectively be, thereby locking them into your ecosystem.
+
+Ultimately, these strategies are about mastering the human element of the market. They acknowledge that decisions are often driven by emotion, bias, and incomplete information, and that perception, once formed, can be a powerful and enduring reality.
+
+## ⚖️ **Ethical Considerations in User Perception**
+
+The power to shape perception carries significant ethical responsibilities. Many User Perception strategies operate in ethically grey areas, and their application can range from beneficial to manipulative. While some approaches, like transparent Education or authentic Brand and Marketing that highlights genuine value, are generally positive, others like spreading FUD, creating purely artificial needs for exploitative gain, or deliberately confusing customers to prevent informed choice, can be profoundly harmful.
+
+Key ethical questions organizations and leaders must constantly ask include:
+
+*   **Transparency and Honesty:** Are we being truthful and open about our intentions, the information we provide, and the nature of our products or services? Are there hidden agendas or misleading claims?
+*   **Manipulation vs. Legitimate Persuasion:** Are we genuinely persuading potential customers based on the merits of our offering and their actual needs, or are we exploiting cognitive biases, emotional vulnerabilities, and information gaps for unfair advantage?
+*   **Potential for User Harm:** Could our strategy lead to users making decisions that are not in their best interest? Could it cause financial loss, undue stress, health risks, or other negative outcomes for individuals or society?
+*   **Fairness in Competition:** Are our tactics aimed at outperforming competitors through superior value, innovation, and service, or are they designed to unfairly undermine them through misinformation, distortion of market realities, or anti-competitive practices?
+*   **Long-term Trust and Reputation:** While a manipulative tactic might offer short-term gains, what is the likely long-term impact on our brand's reputation, customer trust, and employee morale?
+*   **Impact on Vulnerable Groups:** Are certain perception strategies disproportionately affecting or targeting vulnerable populations who may be less able to discern manipulation or make informed choices?
+
+Organizations must establish clear ethical guidelines, foster a culture of responsible communication, and critically evaluate the potential impact of these strategies on all stakeholders. A reputation for deceptive or manipulative practices can be incredibly damaging in the long run, eroding customer loyalty, attracting regulatory scrutiny, and making it difficult to attract and retain talent.
+
+## 🛡️ **Countering User Perception Tactics**
+
+Being aware of these strategies is the first and most crucial step to defending your organization and your customers if they are used by competitors:
+
+*   **Recognize the Play:** Develop the ability to identify the common patterns of FUD, artificial needs creation, or deliberate confusion. If a competitor's messaging seems designed to create undue anxiety, makes simple things overly complex, or promotes needs that feel manufactured, they may be employing these tactics.
+*   **Champion Transparency and Clarity:** Counter FUD and confusion with clear, factual, easily verifiable, and readily accessible information. Make your offerings, pricing, and terms simple to understand and compare.
+*   **Educate Your Audience Proactively:** Invest in educating your customers, partners, and the broader market about the value you provide, how to evaluate solutions in your space objectively, and the common pitfalls or misleading tactics to watch out for. This builds collective resilience against misinformation.
+*   **Build and Nurture Direct Trust:** Focus on cultivating strong, authentic relationships with your customers. Loyal customers who genuinely trust your brand and believe in your integrity are far less likely to be swayed by competitor FUD or manipulative narratives.
+*   **Expose Unethical Behavior (Strategically and Carefully):** In some situations, publicly and credibly exposing manipulative or deceptive tactics can be effective. However, this must be done carefully, backed by evidence, and without stooping to similar behavior, to avoid appearing overly aggressive or hypocritical.
+*   **Focus Relentlessly on Genuine Value and Superiority:** The best and most sustainable long-term defense is to consistently offer a superior, undeniable value proposition. If your product or service is clearly and demonstrably better, perception tactics from competitors will have limited and diminishing impact over time.
+*   **Foster Critical Thinking:** Encourage critical thinking both internally and among your user base. A more discerning audience is less susceptible to manipulation.
+
+By deeply understanding the landscape of user perception, organizations can not only choose their own strategies wisely and ethically but also build robust resilience against those tactics when deployed by others, fostering a more informed and fair marketplace.
+
+## ✨ **Conclusion: The Power and Responsibility of Shaping Beliefs**
+
+User Perception strategies are a testament to the idea that markets are not just about products and services, but about people, psychology, and narratives. The ability to influence what people believe can be more powerful than having the best technology or the lowest price. However, this power comes with a profound responsibility.
+
+While these strategies can be used to drive innovation, educate consumers, and build strong brands, they can also be misused to deceive, manipulate, and stifle fair competition. The most successful and sustainable organizations will be those that wield these tools ethically, focusing on creating genuine value and building long-term trust. Understanding these plays – both to use them constructively and to defend against their misuse – is an essential part of strategic literacy in today's complex world.
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';


### PR DESCRIPTION
Expands the content of the User Perception category page (`docs/strategies/user-perception/index.md`) to align with the structure and depth of other category pages like Accelerators and Toxicity.

The updated page includes:
- A refined definition of User Perception strategies.
- Detailed descriptions and links to all sub-strategies within the category.
- Sections on why to employ these strategies, crucial ethical considerations (a key theme for this category), and how to counter such tactics if used by competitors.
- A concluding summary on the power and responsibility of shaping beliefs.