### PR TITLE
Update Strategic Insights for 'Designed to Fail' strategy

### DIFF
--- a/docs/strategies/poison/designed-to-fail/index.md
+++ b/docs/strategies/poison/designed-to-fail/index.md
@@ -127,20 +127,25 @@ Maintaining a deceptive initiative may consume more resources than planned.
 ## 🧠 **Strategic Insights**
 
 ### Governance Vacuum is Key
+This strategy thrives where no one yet has control. A lack of established standards, dominant players, or clear leadership in an emerging market allows a "Designed to Fail" initiative to more easily shape perceptions and create confusion. The ambiguity of a nascent space is the fertile ground for such a ploy.
 
-This strategy thrives where no one yet has control. Lack of standards or leadership allows you to shape the narrative and expectations.
+### Narrative Dominance is Crucial
+The success of a "Designed to Fail" initiative hinges on controlling the narrative. The flawed project must be marketed with enough credibility and fanfare to appear legitimate, occupy mindshare, and influence competitor or ecosystem behavior. Without a convincing story, the flaws become obvious too quickly, and the strategic intent is lost.
 
-### Short Half-life by Design
+### The "Osborne Effect" Multiplier
+A well-publicized "Designed to Fail" initiative can generate an "Osborne Effect" in the targeted market. By hinting at a superior (but ultimately undelivered) future product, it can deter customers from purchasing existing, viable solutions from competitors, effectively freezing demand and poisoning the market by creating widespread purchasing hesitation.
 
-Plan for decay. If it persists, it’s probably failing as a denial tactic. The goal is to fragment, not build a lasting presence.
+### Ecosystem Contamination and Resource Burn
+Beyond direct competitors, a sophisticated "Designed to Fail" play can contaminate the adjacent ecosystem. By launching a flawed standard or platform, it can entice third-party developers, integrators, and investors to commit resources. The inevitable collapse wastes their investment and creates disillusionment, making the entire field appear barren and raising barriers for future legitimate efforts.
 
-### Requires Narrative Dominance
+### Strategic Misdirection: The "Empty Fort" or "False Scapegoat"
+"Designed to Fail" initiatives can serve as powerful misdirection. Like an "Empty Fort," a visible but hollow show of occupying a space can make competitors overestimate your commitment, causing them to hesitate or misallocate resources. Alternatively, it can be a "False Scapegoat," providing a public reason for retreating from a market due to the initiative's "failure," masking deeper strategic shifts or internal weaknesses.
 
-The strategy fails without credible messaging. You must control the narrative to ensure the initiative is seen as *legitimate*, even if it’s fundamentally flawed.
+### Short Half-Life by Design
+These initiatives are not meant to last. Their purpose is to occupy space, create temporary distortion, or achieve a specific signaling effect. If a "Designed to Fail" project persists too long or, worse, accidentally becomes viable (perhaps through community fixes), it risks failing in its strategic objective of denial or delay. Plan for its eventual, controlled collapse.
 
-### Best as a Side-Play
-
-Avoid making it core to your roadmap. It’s a blocking move, not a winning move. A well-aimed denial move can delay a threat by years but if you’re always poisoning, you’re never building.
+### Best as a Tactical Side-Play
+"Designed to Fail" should generally be a tactical, peripheral move rather than core to a company's primary strategy. Its utility lies in specific, often defensive, contexts. Over-reliance on such "poisoning" tactics can distract from genuine value creation, damage reputation if discovered, and foster a cynical internal culture.
 
 ## ❓ **Key Questions to Ask**
 


### PR DESCRIPTION
Adds new, valuable, expert content to the Strategic Insights section of the 'Designed to Fail' strategy page.

The new insights provide additional depth and explore various facets of this strategy, including:
- The 'Osborne Effect' Multiplier
- Ecosystem Contamination and Resource Burn
- Strategic Misdirection (Empty Fort/False Scapegoat)

Existing insights have been refined and reordered for clarity and impact.