### PR TITLE
feat: Add author byline to documentation pages

### DIFF
--- a/data/authors/authors.json
+++ b/data/authors/authors.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "dave-hulbert",
+    "name": "Dave Hulbert",
+    "title": "Contributor",
+    "url": "https://github.com/davehulbert",
+    "image_url": "https://github.com/davehulbert.png"
+  }
+]

--- a/data/authors/authors.json
+++ b/data/authors/authors.json
@@ -2,8 +2,8 @@
   {
     "id": "dave-hulbert",
     "name": "Dave Hulbert",
-    "title": "Contributor",
-    "url": "https://github.com/davehulbert",
-    "image_url": "https://github.com/davehulbert.png"
+    "title": "Builder and maintainer of Wardley Leadership Strategies",
+    "url": "/about",
+    "image_url": "https://github.com/dave1010.png"
   }
 ]

--- a/docs/strategies/index.md
+++ b/docs/strategies/index.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+authors: [dave-hulbert]
 ---
 
 # Strategies & Gameplays

--- a/src/theme/AuthorByline/index.tsx
+++ b/src/theme/AuthorByline/index.tsx
@@ -35,7 +35,7 @@ const AuthorByline: React.FC<AuthorBylineProps> = ({ authorIds }) => {
 
   return (
     <div className={styles.authorBylineContainer}>
-      <h4>Authors</h4>
+      <h4>{authorDetails.length === 1 ? 'Author' : 'Authors'}</h4>
       {authorDetails.map(author => (
         <div key={author.id} className={styles.authorItem}>
           {author.image_url && (

--- a/src/theme/AuthorByline/index.tsx
+++ b/src/theme/AuthorByline/index.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import authors from '@site/data/authors/authors.json'; // Adjust path if necessary
+import styles from './styles.module.css';
+import Link from '@docusaurus/Link';
+
+interface Author {
+  id: string;
+  name: string;
+  title?: string;
+  url?: string;
+  image_url?: string;
+}
+
+interface AuthorBylineProps {
+  authorIds: string[];
+}
+
+const AuthorByline: React.FC<AuthorBylineProps> = ({ authorIds }) => {
+  if (!authorIds || authorIds.length === 0) {
+    return null;
+  }
+
+  const authorDetails = authorIds.map(id => {
+    const foundAuthor = (authors as Author[]).find(author => author.id === id);
+    if (!foundAuthor) {
+      console.warn(`Author with id "${id}" not found.`);
+      return null;
+    }
+    return foundAuthor;
+  }).filter(author => author !== null) as Author[];
+
+  if (authorDetails.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.authorBylineContainer}>
+      <h4>Authors</h4>
+      {authorDetails.map(author => (
+        <div key={author.id} className={styles.authorItem}>
+          {author.image_url && (
+            <img
+              src={author.image_url}
+              alt={author.name}
+              className={styles.authorImage}
+            />
+          )}
+          <div className={styles.authorInfo}>
+            {author.url ? (
+              <Link to={author.url} className={styles.authorName}>
+                {author.name}
+              </Link>
+            ) : (
+              <span className={styles.authorName}>{author.name}</span>
+            )}
+            {author.title && <div className={styles.authorTitle}>{author.title}</div>}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default AuthorByline;

--- a/src/theme/AuthorByline/styles.module.css
+++ b/src/theme/AuthorByline/styles.module.css
@@ -1,0 +1,34 @@
+.authorBylineContainer {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--ifm-color-emphasis-300);
+}
+
+.authorItem {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.authorImage {
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  margin-right: 1rem;
+  object-fit: cover;
+}
+
+.authorInfo {
+  display: flex;
+  flex-direction: column;
+}
+
+.authorName {
+  font-weight: bold;
+  margin-bottom: 0.25rem;
+}
+
+.authorTitle {
+  font-size: 0.9em;
+  color: var(--ifm-color-content-secondary);
+}

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {useWindowSize} from '@docusaurus/theme-common';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import DocItemPaginator from '@theme/DocItem/Paginator';
+import DocVersionBanner from '@theme/DocVersionBanner';
+import DocVersionBadge from '@theme/DocVersionBadge';
+import DocItemFooter from '@theme/DocItem/Footer';
+import DocItemTOCMobile from '@theme/DocItem/TOC/Mobile';
+import DocItemTOCDesktop from '@theme/DocItem/TOC/Desktop';
+import AuthorByline from '@site/src/theme/AuthorByline';
+import DocItemContent from '@theme/DocItem/Content';
+import DocBreadcrumbs from '@theme/DocBreadcrumbs';
+import ContentVisibility from '@theme/ContentVisibility';
+import type {Props} from '@theme/DocItem/Layout';
+
+import styles from './styles.module.css';
+
+/**
+ * Decide if the toc should be rendered, on mobile or desktop viewports
+ */
+function useDocTOC() {
+  const {frontMatter, toc} = useDoc();
+  const windowSize = useWindowSize();
+
+  const hidden = frontMatter.hide_table_of_contents;
+  const canRender = !hidden && toc.length > 0;
+
+  const mobile = canRender ? <DocItemTOCMobile /> : undefined;
+
+  const desktop =
+    canRender && (windowSize === 'desktop' || windowSize === 'ssr') ? (
+      <DocItemTOCDesktop />
+    ) : undefined;
+
+  return {
+    hidden,
+    mobile,
+    desktop,
+  };
+}
+
+export default function DocItemLayout({children}: Props): ReactNode {
+  const docTOC = useDocTOC();
+  const {metadata, frontMatter} = useDoc();
+  return (
+    <div className="row">
+      <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
+        <ContentVisibility metadata={metadata} />
+        <DocVersionBanner />
+        <div className={styles.docItemContainer}>
+          <article>
+            <DocBreadcrumbs />
+            <DocVersionBadge />
+            {docTOC.mobile}
+            <DocItemContent>{children}</DocItemContent>
+            <DocItemFooter />
+            {frontMatter.authors && frontMatter.authors.length > 0 && (
+              <AuthorByline authorIds={frontMatter.authors} />
+            )}
+          </article>
+          <DocItemPaginator />
+        </div>
+      </div>
+      {docTOC.desktop && <div className="col col--3">{docTOC.desktop}</div>}
+    </div>
+  );
+}

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.docItemContainer header + *,
+.docItemContainer article > *:first-child {
+  margin-top: 0;
+}
+
+@media (min-width: 997px) {
+  .docItemCol {
+    max-width: 75% !important;
+  }
+}


### PR DESCRIPTION
This commit introduces an author byline feature for documentation pages.

Key changes:
- Created an `AuthorByline` component to display author information.
- Swizzled the `DocItemLayout` component to include the `AuthorByline`.
- Author data is stored in `data/authors/authors.json`.
- Doc pages can specify authors in their frontmatter using the `authors` key (e.g., `authors: [author-id]`).

The byline will display the author's name, image (if provided), title, and a link to their profile (if provided) at the bottom of the doc page.