### PR TITLE
feat: Enhance Strategic Insights for Pig in a Poke

### DIFF
--- a/docs/strategies/dealing-with-toxicity/pig-in-a-poke/index.md
+++ b/docs/strategies/dealing-with-toxicity/pig-in-a-poke/index.md
@@ -105,14 +105,17 @@ Performance-based earn-outs can leave you on the hook if the asset fails post-sa
 
 ## 🧠 **Strategic Insights**
 
-### Timing Is Crucial
-The value window closes quickly; delays can expose the asset’s true condition.
+### The "Known Unknown" Buyer Gambit
+While "Pig in a Poke" often implies deceiving a naive buyer, a more nuanced version involves a buyer who is partially aware of potential issues—a "known unknown." Such buyers might possess specific expertise, believe they have unique turnaround capabilities, or see potential synergies that could neutralize the asset's toxicity or unlock value others cannot perceive. The seller's strategy here is not pure misdirection but rather a subtle highlighting of "untapped potential" or framing the asset as a "diamond in the rough" that requires a special kind of vision or capability. This shifts the dynamic from outright deception to a calculated gamble by the buyer, who hopes their unique strengths can overcome the inherent risks they partially perceive. The seller facilitates this by providing just enough positive framing to encourage the buyer's optimistic self-assessment.
 
-### Market Psychology
-Bubbles or fads amplify buy-side eagerness, making Pig in a Poke more feasible.
+### Exploiting Narrative Asymmetry and Cognitive Biases
+The core of a successful "Pig in a Poke" strategy often lies in the skillful exploitation of narrative asymmetry and the buyer's inherent cognitive biases. The seller, by virtue of possessing more information (or artfully curating it), establishes the dominant narrative framework. This framework acts as an anchor, influencing all subsequent perceptions and discussions around the asset. Buyers, particularly those eager for growth, under pressure to deploy capital, or operating in a hyped market, are susceptible to confirmation bias. They may subconsciously seek out data points that validate the seller's optimistic narrative while downplaying or rationalizing clear warning signs. A savvy seller can feed this bias by selectively presenting information, using compelling and urgent language ("once in a lifetime opportunity"), and creating an environment of competitive tension that discourages deep, skeptical due diligence. The goal is to make the crafted narrative more compelling and easier to accept than the complex, potentially negative reality.
 
-### Ecosystem Effects
-Repeated use of this tactic can spawn a market for distressed asset specialists.
+### The "Last Hot Potato" in Declining Markets
+In industries or market segments facing secular decline, the "Pig in a Poke" strategy can manifest as a game of "last hot potato." Multiple players might be holding similarly deteriorating assets, all aware that the long-term prospects are bleak. The strategic imperative shifts from merely offloading one's own "pig" to doing so before competitors flood the limited pool of potential (and perhaps less informed) buyers, or before a market-wide realization of the pervasive toxicity triggers a firesale environment. Speed, timing, and a keen sense of market sentiment become paramount. The win lies not just in selling the asset, but in avoiding being one of the last few still holding on when the music stops and the true lack of value becomes undeniable to everyone. This dynamic creates intense pressure to find a buyer quickly, even if it means accepting a slightly lower price than initially hoped.
+
+### Reputation Laundering via Intermediaries
+Executing a "Pig in a Poke" directly can inflict significant, long-lasting reputational damage upon the seller. To mitigate this, sophisticated actors may employ intermediaries to obscure the asset's trail and their connection to it. This can involve transferring the toxic asset to a newly created subsidiary with a clean slate, using specialized brokers known for handling distressed or opaque assets, or even embedding the sale within a larger, more complex M&A transaction where the "pig" is a less scrutinized component. The intermediary acts as a buffer, "laundering" the asset by creating distance and complexity. The goal is to break the chain of custody in a way that obscures the seller's intent and the asset's problematic origins. By the time the asset's true nature is revealed, its problematic history and the identity of the original seller aiming to offload a liability are more difficult to trace, thereby protecting the seller's broader market reputation.
 
 ## ❓ **Key Questions to Ask**
 


### PR DESCRIPTION
Replaced the existing Strategic Insights in the "Pig in a Poke" strategy document with new, more in-depth content. The new insights aim to provide greater depth, expert perspectives, and connections to broader business concepts, aligning with the authoritative content guidelines.

New insights include:
- The "Known Unknown" Buyer Gambit
- Exploiting Narrative Asymmetry and Cognitive Biases
- The "Last Hot Potato" in Declining Markets
- Reputation Laundering via Intermediaries