### PR TITLE
Fix: Standardize 'Further Reading & References' heading format

### DIFF
--- a/docs/strategies/accelerators/industrial-policy/index.md
+++ b/docs/strategies/accelerators/industrial-policy/index.md
@@ -180,7 +180,7 @@ Industrial policies are subject to political winds and can change with new admin
 - [Capital flows to new areas of value](/climatic-patterns/capital-flows-to-new-areas-of-value) – influence: government investment channels funds toward targeted sectors.
 - [Economy has cycles](/climatic-patterns/economy-has-cycles) – trigger: policy support often intensifies during war or wonder phases.
 
-## 📚 **Further Reading**
+## 📚 **Further Reading & References**
 
 - Wardley, S. – *On Industrial Policy and Strategic Climatic Patterns*.  
 - Case Study: *The Rise of Airbus* – European government consortiums and subsidies.  

--- a/docs/strategies/competitor/sapping/index.md
+++ b/docs/strategies/competitor/sapping/index.md
@@ -137,6 +137,6 @@ Sapping should lead to the competitor's collapse in one area or their retreat fr
 -   [**Restriction of Movement**](/strategies/competitor/restriction-of-movement): Sapping can be used to restrict a competitor's movement and limit their ability to respond to attacks.
 -   [**Circling and Probing**](/strategies/competitor/circling-and-probing): Circling and probing can be used to identify weaknesses in a competitor before launching a sapping attack.
 
-## 📚 Further Reading & References
+## 📚 **Further Reading & References**
 
 -   Clayton Christensen - "The Innovator's Dilemma" (for examples of multi-front competition and disruption).

--- a/docs/strategies/dealing-with-toxicity/refactoring/index.md
+++ b/docs/strategies/dealing-with-toxicity/refactoring/index.md
@@ -133,7 +133,7 @@ The primary leadership challenge is **managing the transition sensitively and de
 - [**Disposal of Liability**](/strategies/dealing-with-toxicity/disposal-of-liability) refactoring is an approach to disposal by reuse
 - [**Sweat & Dump**](/strategies/dealing-with-toxicity/sweat-and-dump) as an alternative - instead of third-party, you internally transform
 
-**Further Reading & References:**
+## 📚 **Further Reading & References**
 
 - Agile/DevOps analogies - Many tech companies apply refactoring to processes: e.g., breaking a legacy business process into agile teams. Business literature on **business process re-engineering** touches similar ideas (though BPR often aimed at improvement, here aim is also removal).
 - *"Dual Transformation" (Anthony, Johnson)* - a strategy book that talks about running a legacy business (Transformation B) while building new (Transformation A), and how to transfer capabilities from B to A. It's essentially how to refactor an organization during disruption, moving old capabilities to new growth, similar to refactoring concept described here.


### PR DESCRIPTION
Updated the 'Further Reading & References' heading in three strategy documents to conform to the style guide in CONTRIBUTING.md (H2, with emoji, bold text, and consistent naming 'Further Reading & References').

Files changed:
- docs/strategies/accelerators/industrial-policy/index.md
- docs/strategies/dealing-with-toxicity/refactoring/index.md
- docs/strategies/competitor/sapping/index.md