### PR TITLE
Fix: Correct strategy headings and add missing climatic patterns

### DIFF
--- a/docs/strategies/accelerators/cooperation/index.md
+++ b/docs/strategies/accelerators/cooperation/index.md
@@ -255,7 +255,7 @@ Use alliances when the goal is ecosystem-level impact or when formality helps se
 - Market impact: Will this cooperation accelerate or inhibit market formation?
 - Exit scenarios: Under what conditions should we
 
-## 🔀 **Related Strategies:**
+## 🔀 **Related Strategies**
 
 - [**Alliances**](/strategies/ecosystem/alliances) - a formalized group of cooperating entities, essentially the same domain
 - [**Co-creation**](/strategies/ecosystem/co-creation) - a form of cooperation with *users*

--- a/docs/strategies/accelerators/exploiting-network-effects/index.md
+++ b/docs/strategies/accelerators/exploiting-network-effects/index.md
@@ -264,7 +264,7 @@ Focus on creating value for users and facilitating connections and interactions.
 - How will I measure the success of my network effects strategy?
 - How can I maintain and strengthen network effects over time?
 
-## 🔀 **Related Strategies:**
+## 🔀 **Related Strategies**
 
 - [**Land Grab**](/strategies/positional/land-grab) - often used to quickly build the network
 - [**Last Man Standing**](/strategies/markets/last-man-standing) - network effects can contribute to becoming the last survivor

--- a/docs/strategies/accelerators/market-enablement/index.md
+++ b/docs/strategies/accelerators/market-enablement/index.md
@@ -215,6 +215,8 @@ The degree of "openness" (e.g., open standards, open source, open data) is a cri
 - [Cooperation](/strategies/accelerators/cooperation) - Working with other players, even competitors, is fundamental to many market enablement initiatives.
 - [Exploiting Network Effects](/strategies/accelerators/exploiting-network-effects) - An enabled market can lead to network effects that further accelerate adoption and growth.
 
+## ⛅ **Relevant Climatic Patterns**
+
 ## 📚 **Further Reading & References**
 
 - *"The Innovator's Dilemma"* by Clayton M. Christensen - While not directly about market enablement, this book provides deep insights into how markets evolve and how incumbents can be disrupted, which is relevant context for why and how one might enable new markets.

--- a/docs/strategies/accelerators/open-approaches/index.md
+++ b/docs/strategies/accelerators/open-approaches/index.md
@@ -152,7 +152,7 @@ For example, if your competitor is slower-moving or dependent on licensing, open
 - **Community:** How will we attract and sustain contributors?
 - **Risk:** Are we prepared for competitors to benefit from our openness?
 
-🔀 **Related Strategies**
+## 🔀 **Related Strategies**
 
 - [Co-creation](/strategies/ecosystem/co-creation) – Inviting others to build on your open platform and drive innovation.
 - [Undermining Barriers to Entry](/strategies/attacking/undermining-barriers-to-entry) – Making a technology free removes a barrier and enables new entrants.

--- a/docs/strategies/attacking/centre-of-gravity/index.md
+++ b/docs/strategies/attacking/centre-of-gravity/index.md
@@ -157,7 +157,7 @@ This kind of cultural or visionary gravity is harder to replicate or fight. It�
 - **Competition:** How are rivals responding to our position? Are new hubs emerging?
 - **Diversity:** Are we fostering a diverse and innovative environment, or becoming insular?
 
-🔀 **Related Strategies**
+## 🔀 **Related Strategies**
 
 - [Talent Raid](/strategies/competitor/talent-raid) – Raiding or defending against raids is a key dynamic for maintaining or disrupting a center of gravity.
 - [Alliances](/strategies/ecosystem/alliances) – Forming alliances can increase your gravity as more attach to you; alliances can also counterbalance a dominant hub.

--- a/docs/strategies/attacking/directed-investment/index.md
+++ b/docs/strategies/attacking/directed-investment/index.md
@@ -157,7 +157,7 @@ Directed investment can shift the centre of gravity in a value chain, attracting
 - **Exit:** What is our plan if the bet does not pay off?
 - **Counterplay:** How might competitors respond?
 
-🔀 **Related Strategies**
+## 🔀 **Related Strategies**
 
 - [Weak Signal (Horizon)](/strategies/positional/weak-signal-horizon) – Sensing and interpreting early signals often triggers directed investment.
 - [First Mover](/strategies/positional/first-mover) – Directed investment is a key way to achieve first-mover advantage.

--- a/docs/strategies/attacking/experimentation/index.md
+++ b/docs/strategies/attacking/experimentation/index.md
@@ -159,7 +159,7 @@ Experiments often reveal new dependencies or bottlenecks early, letting you shap
 - **Capacity:** Do we have time and budget for experimentation?
 - **Ethics:** Could any experiment harm users or reputation?
 
-🔀 **Related Strategies**
+## 🔀 **Related Strategies**
 
 - [Directed Investment](/strategies/attacking/directed-investment) – Big bets once experimentation reveals potential.
 - [Centre of Gravity](/strategies/attacking/centre-of-gravity) – Successful labs can become magnets for talent.

--- a/docs/strategies/attacking/fools-mate/index.md
+++ b/docs/strategies/attacking/fools-mate/index.md
@@ -248,6 +248,8 @@ While the strategy involves attacking an opponent's constraint (by commoditizing
 - [Signal Distortion](/strategies/markets/signal-distortion) - While execution relies on surprise, the *threat* or capability of such a move, if perceived, could be a powerful, distorting signal.
 - [Centre of Gravity](/strategies/attacking/centre-of-gravity) - A Fool's Mate often targets a component that, while perhaps not obvious, acts as a centre of gravity for the opponent's business model, leading to systemic failure if attacked.
 
+## ⛅ **Relevant Climatic Patterns**
+
 ## 📚 **Further Reading & References**
 
 - [Fool's mate in Business](https://blog.gardeviance.org/2014/11/fools-mate-in-business.html) - A blog post by Simon Wardley that discusses the concept of Fool's Mate in a business context, providing insights into how it can be applied strategically.

--- a/docs/strategies/attacking/playing-both-sides/index.md
+++ b/docs/strategies/attacking/playing-both-sides/index.md
@@ -154,6 +154,8 @@ At its core, this is a hedging strategy. It's an admission that you cannot predi
 - **[Standards Game](/strategies/markets/standards-game)**: Playing both sides is a specific move within a larger standards game.
 - **[Innovate, Leverage, Commoditize (ILC)](/strategies/ecosystem/innovate-leverage-commoditize)**: This strategy can be a component of ILC, where you leverage your position as a neutral supplier to sense where the market is heading.
 
+## ⛅ **Relevant Climatic Patterns**
+
 ## 📚 **Further Reading & References**
 
 - **"The Art of War" by Sun Tzu:** While not a business book, it offers timeless insights into strategy and the benefits of understanding the competitive landscape from multiple perspectives.

--- a/docs/strategies/attacking/press-release-process/index.md
+++ b/docs/strategies/attacking/press-release-process/index.md
@@ -199,6 +199,7 @@ A press release that reads as weak or incoherent is a fast signal of strategic u
 - [Fast Follower](/strategies/positional/fast-follower) – The press release process can be used to quickly respond to emerging user needs with evolved capabilities.
 - [Experimentation](/strategies/attacking/experimentation) – Use press releases to simulate outcomes and test resonance before committing resources.
 
+## ⛅ **Relevant Climatic Patterns**
 
 ## 📚 **Further Reading & References**
 

--- a/docs/strategies/competitor/fragmentation-play/index.md
+++ b/docs/strategies/competitor/fragmentation-play/index.md
@@ -145,13 +145,15 @@ A fragmentation play is about playing divide and conquer in a market. It is most
 -   How will we capture value from the fragmented market?
 -   What are the potential negative consequences of fragmentation, and how can we address them?
 
-## 🔀 **Related Strategies:**
+## 🔀 **Related Strategies**
 
 -   [**Alliances**](/strategies/ecosystem/alliances) - A formalized group of co-operating entities, essentially the same domain
 -   [**Co-opting**](/strategies/ecosystem/co-opting) - Enlisting a third party into your ecosystem to draw them away from a competitor’s control or influence
 -   [**Embrace and Extend**](/strategies/ecosystem/embrace-and-extend) - A controversial strategy that can lead to fragmentation by altering standards
 -   [**Circling and Probing**](/strategies/competitor/circling-and-probing) - Testing a competitor's defenses, the opposite of working with them
 -   [**Restriction of Movement**](/strategies/competitor/restriction-of-movement) - A strategy focused on limiting a competitor's options and flexibility
+
+## ⛅ **Relevant Climatic Patterns**
 
 ## 📚 **Further Reading & References**
 

--- a/docs/strategies/competitor/misdirection/index.md
+++ b/docs/strategies/competitor/misdirection/index.md
@@ -141,12 +141,14 @@ Misdirection can lead to competitor inertia. If a company consistently signals t
 -   How will we know if the misdirection is working?
 -   How and when will we reveal our true strategy?
 
-## 🔀 **Related Strategies:**
+## 🔀 **Related Strategies**
 
 -   [**Reinforcing Competitor Inertia**](/strategies/competitor/reinforcing-competitor-inertia): Misdirection can be used to reinforce competitor inertia by making them underestimate your true strategy
 -   [**Tech Drops**](/strategies/competitor/tech-drops): Misdirection can set up a Tech Drop by concealing your true intentions until the last moment.
 -   [**Signal Distortion**](/strategies/markets/signal-distortion): Misdirection deliberately distorts market signals to mislead competitors.
 -   [**Fear, Uncertainty, and Doubt**](/strategies/user-perception/fear-uncertainty-and-doubt): Misdirection can create fear, uncertainty, and doubt in the minds of competitors.
+
+## ⛅ **Relevant Climatic Patterns**
 
 ## 📚 **Further Reading & References**
 

--- a/docs/strategies/competitor/restriction-of-movement/index.md
+++ b/docs/strategies/competitor/restriction-of-movement/index.md
@@ -135,7 +135,7 @@ Ultimately, restriction of movement can create a **stalemate favoring the strong
 -   How will we measure the success of this strategy?
 -   How can we adapt this strategy as the market evolves?
 
-## 🔀 **Related Strategies:**
+## 🔀 **Related Strategies**
 
 -   [**Alliances**](/strategies/ecosystem/alliances) - Forming alliances can be a way to restrict a competitor's access to partners.
 -   [**Co-opting**](/strategies/ecosystem/co-opting) - Can be used to influence the ecosystem to restrict a competitor.
@@ -143,6 +143,8 @@ Ultimately, restriction of movement can create a **stalemate favoring the strong
 -   [**Embrace and Extend**](/strategies/ecosystem/embrace-and-extend) - Can be used to control standards and limit competitor options.
 -   [**Talent Raid**](/strategies/competitor/talent-raid) - Limits a competitor's movement by restricting access to talent.
 -   [**Limitation of Competition**](/strategies/defensive/limitation-of-competition) - The overarching goal of restriction of movement.
+
+## ⛅ **Relevant Climatic Patterns**
 
 ## 📚 **Further Reading & References**
 

--- a/docs/strategies/competitor/talent-raid/index.md
+++ b/docs/strategies/competitor/talent-raid/index.md
@@ -166,13 +166,15 @@ It's essential to consider the potential optics and impact on relationships with
 * How might our competitors respond, and how will we mitigate those risks?
 * What is our plan for developing and retaining our existing talent?
 
-## 🔀 **Related Strategies:**
+## 🔀 **Related Strategies**
 
 * [**Restriction of Movement**](/strategies/competitor/restriction-of-movement) - Aims to prevent talent from leaving or joining competitors, the opposite of Talent Raid.
 * [**Tech Drops**](/strategies/competitor/tech-drops) - Can be used in conjunction with a Talent Raid to exploit a competitor's weakened position after the raid.
 * [**Threat Acquisition**](/strategies/defensive/threat-acquisition) - Acquiring a company to eliminate a potential competitor can also bring in valuable talent.
 * [**Raising Barriers to Entry**](/strategies/defensive/raising-barriers-to-entry) - A successful Talent Raid can raise barriers to entry for competitors by depriving them of critical talent.
 * [**Market Enablement**](/strategies/accelerators/market-enablement) - If the talent raid brings in individuals with strong market connections or expertise, it can enable market growth.
+
+## ⛅ **Relevant Climatic Patterns**
 
 ## 📚 **Further Reading & References**
 

--- a/docs/strategies/decelerators/creating-constraints/index.md
+++ b/docs/strategies/decelerators/creating-constraints/index.md
@@ -150,6 +150,8 @@ Anticipate potential defenses and have responses ready to uphold your newly crea
 - [Patents & Intellectual Property Rights](/strategies/decelerators/ipr) - Leverage legal rights to block competitors from evolving key technologies.
 - [Raising Barriers to Entry](/strategies/defensive/raising-barriers-to-entry) - Broader tactics to limit competitor market entry.
 
+## ⛅ **Relevant Climatic Patterns**
+
 ## 📚 **Further Reading & References**
 
 - [Exclusive Dealing](https://en.wikipedia.org/wiki/Exclusive_dealing) - Overview of how exclusive contracts can shape market access.

--- a/docs/strategies/decelerators/exploiting-constraint/index.md
+++ b/docs/strategies/decelerators/exploiting-constraint/index.md
@@ -138,11 +138,13 @@ Analyze supply chain and partner feedback to anticipate shifts that could neutra
 - **How will competitors adapt?** What are their likely counter-moves?
 - **Is it legal?** Are there regulatory or contractual limitations?
 
-🔀 **Related Strategies**
+## 🔀 **Related Strategies**
 
 - [Creating Constraints](/strategies/decelerators/creating-constraints) - Manufacture new bottlenecks instead of amplifying existing ones.
 - [Patents & Intellectual Property Rights](/strategies/decelerators/ipr) - Use legal rights to impose constraints on competitors’ technology evolution.
 - [Raising Barriers to Entry](/strategies/defensive/raising-barriers-to-entry) - Broader defensive tactics to limit market entry.
+
+## ⛅ **Relevant Climatic Patterns**
 
 ## 📚 **Further Reading & References**
 

--- a/docs/strategies/decelerators/ipr/index.md
+++ b/docs/strategies/decelerators/ipr/index.md
@@ -152,11 +152,13 @@ Intellectual Property Rights are increasingly becoming a significant element in 
 - **Reputation:** Could aggressive IP strategies harm brand or partnerships?
 - **Alternatives:** Are there open or collaborative approaches that align better with our goals?
 
-🔀 **Related Strategies**
+## 🔀 **Related Strategies**
 
 - [Licensing](/strategies/poison/licensing) - Offensive use of IP through strategic licensing.
 - [Defensive Regulation](/strategies/defensive/defensive-regulation) - Using regulation to create legal constraints.
 - [Open Approaches](/strategies/accelerators/open-approaches) - Alternative strategy leveraging open standards and collaboration.
+
+## ⛅ **Relevant Climatic Patterns**
 
 ## 📚 **Further Reading & References**
 

--- a/docs/strategies/defensive/limitation-of-competition/index.md
+++ b/docs/strategies/defensive/limitation-of-competition/index.md
@@ -164,6 +164,8 @@ Limiting competition can slow evolution, but may also reduce overall market dyna
 - [Standards Game](/strategies/markets/standards-game) – Making your approach the market norm, locking out alternatives.
 - [Lobbying](/strategies/user-perception/lobbying) – Influencing policy or standards as a precursor to limitation of competition.
 
+## ⛅ **Relevant Climatic Patterns**
+
 ## 📚 **Further Reading & References**
 - Case: **Taxi Medallion System vs Uber** – How city-enforced medallion limits kept competition out for decades, and how Uber circumvented it, leading to medallion value collapse.
 - Business History: *Airline Regulation (1930s–70s)* – U.S. Civil Aeronautics Board tightly controlled routes and fares (incumbents secure, no new airlines). Post-deregulation, competition soared (some incumbents struggled). Illustrates the long-term effects and eventual breakdown of limitation of competition.

--- a/docs/strategies/defensive/procrastination/index.md
+++ b/docs/strategies/defensive/procrastination/index.md
@@ -139,6 +139,8 @@ In a world obsessed with speed and being first, deliberate patience can be a pow
 *   **[Fast Follower](/strategies/positional/fast-follower)**: Strategic procrastination is the prerequisite for being a successful fast follower.
 *   **[Weak Signal (Horizon)](/strategies/positional/weak-signal-horizon)**: While procrastinating, you must be actively scanning for weak signals that indicate the market is ready for your entry.
 
+## ⛅ **Relevant Climatic Patterns**
+
 ## 📚 **Further Reading & References**
 
 *   **[The Innovator's Dilemma](https://www.goodreads.com/book/show/2618.The_Innovator_s_Dilemma)** by Clayton M. Christensen. Provides a deep understanding of why incumbent companies often procrastinate on disruptive innovations.

--- a/docs/strategies/defensive/raising-barriers-to-entry/index.md
+++ b/docs/strategies/defensive/raising-barriers-to-entry/index.md
@@ -132,6 +132,8 @@ Raising the barriers to entry shifts the basis of competition. It's no longer ab
 *   **[Limitation of Competition](/strategies/defensive/limitation-of-competition)**: This is the ultimate goal of raising the barriers to entry.
 *   **[Standards Game](/strategies/markets/standards-game)**: By creating a tightly integrated suite, you can attempt to make your proprietary integration points the de facto standard for the market.
 
+## ⛅ **Relevant Climatic Patterns**
+
 ## 📚 **Further Reading & References**
 
 *   **[The Innovator's Dilemma](https://www.goodreads.com/book/show/2618.The_Innovator_s_Dilemma)** by Clayton M. Christensen. Discusses how incumbents can be disrupted by new entrants with simpler, more focused products, which is the threat that this strategy is designed to counter.

--- a/docs/strategies/defensive/threat-acquisition/index.md
+++ b/docs/strategies/defensive/threat-acquisition/index.md
@@ -146,6 +146,8 @@ While threat acquisitions can be expensive, the cost of inaction can be even hig
 *   **[Restriction of Movement](/strategies/competitor/restriction-of-movement)**: Hindering a competitor's ability to operate without acquiring them.
 *   **[Talent Raid](/strategies/competitor/talent-raid)**: Acquiring key talent from a competitor to weaken their capabilities.
 
+## ⛅ **Relevant Climatic Patterns**
+
 ## 📚 **Further Reading & References**
 
 *   [Wardley Maps](https://medium.com/wardleymaps) by Simon Wardley.

--- a/docs/strategies/ecosystem/channel-conflict-and-disintermediation/index.md
+++ b/docs/strategies/ecosystem/channel-conflict-and-disintermediation/index.md
@@ -141,6 +141,8 @@ Channel conflict is not just about cutting costs; it's about forcing change. It 
 *   **[Vertical Integration](/terms/value-chain)**: Disintermediation is a form of vertical integration, as you are taking on a part of the value chain that was previously outsourced.
 *   **[Direct-to-Consumer (DTC)](https://en.wikipedia.org/wiki/Direct-to-consumer)**: This is the most common manifestation of a disintermediation strategy.
 
+## ⛅ **Relevant Climatic Patterns**
+
 ## 📚 **Further Reading & References**
 
 *   **[The Direct-to-Consumer Playbook](https://books.google.co.uk/books/about/The_Direct_to_Consumer_Playbook.html?id=THibzgEACAAJ&redir_esc=y)** by Mike Stevens. A guide to building a DTC business.

--- a/docs/strategies/ecosystem/embrace-and-extend/index.md
+++ b/docs/strategies/ecosystem/embrace-and-extend/index.md
@@ -141,6 +141,8 @@ A strong, vibrant open-source community around a standard is one of the best def
 *   **[Lock-In](/terms/lock-in)**: The ultimate goal of this strategy is to create customer lock-in.
 *   **[Fear, Uncertainty, and Doubt (FUD)](/terms/fear-uncertainty-and-doubt)**: FUD is often used as a tactic to support an Embrace and Extend strategy by creating anxiety about the future of the open standard.
 
+## ⛅ **Relevant Climatic Patterns**
+
 ## 📚 **Further Reading & References**
 
 *   **[The Halloween Documents](https://en.wikipedia.org/wiki/Halloween_documents)**: A series of confidential Microsoft memos that were leaked in the late 1990s, which provide a detailed, internal view of this strategy.

--- a/docs/strategies/ecosystem/innovate-leverage-commoditize/index.md
+++ b/docs/strategies/ecosystem/innovate-leverage-commoditize/index.md
@@ -155,6 +155,8 @@ This strategy is based on the insight that today's innovations are tomorrow's co
 *   **[Tower and Moat](/strategies/ecosystem/tower-and-moat)**: ILC is the engine that builds a powerful Tower and Moat. The Tower is the platform, and the Moat is built by continuously commoditizing complements.
 *   **[Fast Follower](/strategies/positional/fast-follower)**: The commoditization step is a form of fast-following the innovations of your own ecosystem.
 
+## ⛅ **Relevant Climatic Patterns**
+
 ## 📚 **Further Reading & References**
 
 *   **[Wardley Maps (the book)](https://medium.com/wardleymaps/on-being-lost-2ef5f05eb1ec)** by Simon Wardley. The foundational text for understanding the ILC cycle.

--- a/docs/strategies/user-perception/artificial-competition/index.md
+++ b/docs/strategies/user-perception/artificial-competition/index.md
@@ -165,4 +165,6 @@ There is a line between strategic positioning and market distortion. Regularly t
 - [Market Enablement](/strategies/accelerators/market-enablement) - Enabling more competition under your control.
 - [Misdirection](/strategies/competitor/misdirection) - Misleading customers about the true competitive landscape.
 
+## ⛅ **Relevant Climatic Patterns**
+
 ## 📚 **Further Reading & References**

--- a/docs/strategies/user-perception/brand-and-marketing/index.md
+++ b/docs/strategies/user-perception/brand-and-marketing/index.md
@@ -158,5 +158,7 @@ Effective branding requires thinking beyond immediate sales. It involves alignin
 - [Fear, Uncertainty and Doubt](/strategies/user-perception/fear-uncertainty-and-doubt) - Counterplay competitors might use.
 - [Differentiation](/strategies/markets/differentiation) - Highlighting unique selling points.
 
+## ⛅ **Relevant Climatic Patterns**
+
 ## 📚 **Further Reading & References**
 

--- a/docs/strategies/user-perception/bundling/index.md
+++ b/docs/strategies/user-perception/bundling/index.md
@@ -131,6 +131,8 @@ From a value chain perspective, bundling can represent a form of vertical integr
 - [Raising Barriers to Entry](/strategies/defensive/raising-barriers-to-entry) – Bundling many features raises customer expectations and can deter new entrants.
 - [Land Grab](/strategies/positional/land-grab) – Bundling can quickly expand user base for a new service by piggybacking on an existing one.
 
+## ⛅ **Relevant Climatic Patterns**
+
 ## 📚 **Further Reading & References**
 
 - [U.S. v. Microsoft (1998) – DOJ Antitrust Case Documents](https://www.justice.gov/atr/us-v-microsoft-courts-findings-fact) – Describes how bundling Internet Explorer with Windows gave Microsoft a strategic edge and the legal ramifications.

--- a/docs/strategies/user-perception/confusion-of-choice/index.md
+++ b/docs/strategies/user-perception/confusion-of-choice/index.md
@@ -147,6 +147,8 @@ Ethically, Confusion of Choice is a gray area. While businesses are not obligate
 - [FUD](/strategies/user-perception/fear-uncertainty-and-doubt) – Also prevents rational decision-making but via fear instead of complexity.
 - [Last Man Standing](/strategies/markets/last-man-standing) – Another strategy that exploits competitors' complacency; confusion exploits customers' cognitive limits.
 
+## ⛅ **Relevant Climatic Patterns**
+
 ## 📚 **Further Reading & References**
 
 - [The Paradox of Choice by Barry Schwartz](https://en.wikipedia.org/wiki/The_Paradox_of_Choice) – Explains the psychology behind why too much choice can hinder decision-making.

--- a/docs/strategies/user-perception/creating-artificial-needs/index.md
+++ b/docs/strategies/user-perception/creating-artificial-needs/index.md
@@ -143,6 +143,8 @@ Counter-strategies often involve education, promoting conscious consumerism, or 
 - [Brand & Marketing](/strategies/user-perception/brand-and-marketing) - Central to creating needs via messaging.
 - [Education](/strategies/user-perception/education) - A more genuine way to create need by informing why something is important; in artificial needs, the education might be closer to propaganda.
 
+## ⛅ **Relevant Climatic Patterns**
+
 ## 📚 **Further Reading & References**
 
 - [HowStuffWorks – "How Advertising Invented the Diamond Engagement Ring"](https://money.howstuffworks.com/african-diamond-trade.htm) – Explores the De Beers case, showing how marketing created a long-lasting social norm (a need where none existed before).

--- a/docs/strategies/user-perception/education/index.md
+++ b/docs/strategies/user-perception/education/index.md
@@ -139,5 +139,7 @@ The effectiveness of education strategies often varies with market and product e
 - [Fear, Uncertainty & Doubt (FUD)](/strategies/user-perception/fear-uncertainty-and-doubt) - The "dark side" alternative of influencing perception with fear.
 - [Open Approaches](/strategies/accelerators/open-approaches) - Sometimes educating about an open standard to drive its adoption.
 
+## ⛅ **Relevant Climatic Patterns**
+
 ## 📚 **Further Reading & References**
 

--- a/docs/strategies/user-perception/fear-uncertainty-and-doubt/index.md
+++ b/docs/strategies/user-perception/fear-uncertainty-and-doubt/index.md
@@ -162,6 +162,8 @@ The ethical spectrum of FUD is broad, from aggressive but legitimate competition
 - [Misdirection](/strategies/competitor/misdirection) – Another deceptive tactic.
 - [Lobbying](/strategies/user-perception/lobbying) – Using fear-based arguments in regulatory affairs is essentially FUD toward policymakers.
 
+## ⛅ **Relevant Climatic Patterns**
+
 ## 📚 **Further Reading & References**
 
 - [Wired (1999) – "FUD, Counter-FUD"](https://www.wired.com/1999/04/fud-counter-fud/) – Explains FUD's origins with IBM/Microsoft and how insinuating rival tech is "untrustworthy" became a go-to strategy.

--- a/docs/strategies/user-perception/lobbying/index.md
+++ b/docs/strategies/user-perception/lobbying/index.md
@@ -154,12 +154,14 @@ Aligning with user or public interest narratives increases the chance of success
 - **Counterplay:** What are competitors lobbying for, and how can we respond?
 - **Resilience:** How will we adapt if the regulatory environment shifts?
 
-🔀 **Related Strategies**
+## 🔀 **Related Strategies**
 - [Defensive Regulation](/strategies/defensive/defensive-regulation) – Using government or policy to create legal barriers.
 - [Limitation of Competition](/strategies/defensive/limitation-of-competition) – The overarching goal of many lobbying efforts.
 - [Standards Game](/strategies/markets/standards-game) – Institutionalising a technical approach via policy or regulation.
 - [Industrial Policy](/strategies/accelerators/industrial-policy) – Aligning with government investment or strategic priorities.
 - [Raising Barriers to Entry](/strategies/defensive/raising-barriers-to-entry) – Shaping market/customer expectations, sometimes via lobbying.
+
+## ⛅ **Relevant Climatic Patterns**
 
 ## 📚 **Further Reading & References**
 


### PR DESCRIPTION
- Iterated through files identified by check_strategy_headings.py.
- Corrected formatting of '## 🔀 Related Strategies' heading (removed colons, ensured correct markdown prefix).
- Added '## ⛅ Relevant Climatic Patterns' heading where it was missing, ensuring correct placement before '## 📚 Further Reading & References'.

This addresses a significant portion of the files requiring heading corrections as per step 2 of the plan.