### PR TITLE
Fix: Correct Related Strategies heading format

### DIFF
--- a/docs/strategies/competitor/circling-and-probing/index.md
+++ b/docs/strategies/competitor/circling-and-probing/index.md
@@ -164,7 +164,7 @@ Avoid getting stuck in analysis; the goal is to use insights to decide where to 
 - **Risk Assessment:** What are the potential downsides of this probe, including reputational risk or unwanted competitive attention, and how can we mitigate them?
 - **Strategic Alignment:** How will the insights from this probe inform our broader strategic decisions, regardless of the outcome?
 
-## 🔀 **Related Strategies:**
+## 🔀 **Related Strategies**
 
 * [**Misdirection**](/strategies/competitor/misdirection) - Using tactics to mislead a competitor about your intentions.
 * [**Tech Drops**](/strategies/competitor/tech-drops) - Launching a sudden, unexpected attack on a competitor.

--- a/docs/strategies/competitor/sapping/index.md
+++ b/docs/strategies/competitor/sapping/index.md
@@ -131,7 +131,7 @@ Sapping should lead to the competitor's collapse in one area or their retreat fr
 -   What is our plan for exploiting any wins?
 -   How will we measure the success of our sapping strategy?
 
-## 🔀 Related Strategies
+## 🔀 **Related Strategies**
 
 -   [**Tech Drops**](/strategies/competitor/tech-drops): Sapping can involve elements of Tech Drops by launching surprise attacks on multiple fronts.
 -   [**Restriction of Movement**](/strategies/competitor/restriction-of-movement): Sapping can be used to restrict a competitor's movement and limit their ability to respond to attacks.

--- a/docs/strategies/dealing-with-toxicity/refactoring/index.md
+++ b/docs/strategies/dealing-with-toxicity/refactoring/index.md
@@ -127,7 +127,7 @@ The primary leadership challenge is **managing the transition sensitively and de
 - What are the technical and operational risks during the transition?
 - How long will the refactoring process take, and what are the key milestones?
 
-## 🔀 **Related Strategies:**
+## 🔀 **Related Strategies**
 
 
 - [**Disposal of Liability**](/strategies/dealing-with-toxicity/disposal-of-liability) refactoring is an approach to disposal by reuse

--- a/docs/strategies/defensive/limitation-of-competition/index.md
+++ b/docs/strategies/defensive/limitation-of-competition/index.md
@@ -156,7 +156,7 @@ Limiting competition can slow evolution, but may also reduce overall market dyna
 - **Balance:** Are we investing enough in innovation, or relying too much on defensive plays?
 - **Signals:** What early warning signs suggest our barriers are eroding?
 
-🔀 **Related Strategies**
+## 🔀 **Related Strategies**
 - [Defensive Regulation](/strategies/defensive/defensive-regulation) – Using government or policy to create legal barriers.
 - [Raising Barriers to Entry](/strategies/defensive/raising-barriers-to-entry) – Shaping market/customer expectations to make entry costly.
 - [IPR](/strategies/decelerators/ipr) – Using patents and legal rights to block or slow rivals.

--- a/docs/strategies/markets/standards-game/index.md
+++ b/docs/strategies/markets/standards-game/index.md
@@ -142,7 +142,7 @@ Competitors may attempt embrace-and-extend tactics or create alternative allianc
 - **Long-term commitment:** Are we ready to maintain governance and backward compatibility for years?
 - **Counterplay:** How might competitors respond, and do we have a plan for their alternative standards?
 
-🔀 **Related Strategies**
+## 🔀 **Related Strategies**
 
 - [Open Approaches](/strategies/accelerators/open-approaches) – Opening code or processes can accelerate adoption and make your approach the default.
 - [Defensive Regulation](/strategies/defensive/defensive-regulation) – Embedding a standard in law cements your advantage.


### PR DESCRIPTION
Updated the heading for the 'Related Strategies' section in multiple strategy documents to conform to CONTRIBUTING.md guidelines.

The heading is now consistently `## 🔀 **Related Strategies**`.