### PR TITLE
Add Relevant Climatic Patterns section to 14 strategy pages

### DIFF
--- a/docs/strategies/competitor/circling-and-probing/index.md
+++ b/docs/strategies/competitor/circling-and-probing/index.md
@@ -175,3 +175,11 @@ Avoid getting stuck in analysis; the goal is to use insights to decide where to 
 
 * "Competitive Strategy" by Michael Porter - For foundational concepts on competitive analysis and strategy.
 * "The Art of War" by Sun Tzu - For insights into strategic thinking and maneuvering in competitive situations.
+
+⛅ **Relevant Climatic Patterns**
+
+- [Everything evolves](/climatic-patterns/everything-evolves) – rel: The landscape is constantly changing, requiring ongoing circling and probing.
+- [Characteristics change](/climatic-patterns/characteristics-change) – rel: Competitor capabilities and market dynamics shift, necessitating adaptation.
+- [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Competitors might become complacent, creating opportunities.
+- [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Probing can uncover inefficiencies that can be exploited or areas ripe for innovation.
+- [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: This strategy is a direct response to and anticipation of competitor actions.

--- a/docs/strategies/competitor/sapping/index.md
+++ b/docs/strategies/competitor/sapping/index.md
@@ -140,3 +140,11 @@ Sapping should lead to the competitor's collapse in one area or their retreat fr
 ## 📚 **Further Reading & References**
 
 -   Clayton Christensen - "The Innovator's Dilemma" (for examples of multi-front competition and disruption).
+
+⛅ **Relevant Climatic Patterns**
+
+- [Everything evolves](/climatic-patterns/everything-evolves) – rel: The competitor's strengths and weaknesses will change over time, creating new sapping opportunities.
+- [Characteristics change](/climatic-patterns/characteristics-change) – rel: As components of a competitor's offering evolve, their dependencies might become vulnerabilities.
+- [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: A competitor's past success can make them slow to react to sapping efforts.
+- [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Identifying and exploiting a competitor's inefficiencies is a key aspect of sapping.
+- [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: Sapping is a direct action to change the game by weakening a competitor.

--- a/docs/strategies/dealing-with-toxicity/disposal-of-liability/index.md
+++ b/docs/strategies/dealing-with-toxicity/disposal-of-liability/index.md
@@ -143,3 +143,11 @@ alternative to disposal.
 
 - HBR: [“Pruning the Corporate Portfolio”](https://hbr.org/2017/12/case-study-should-a-hotel-giant-eliminate-some-brands-and-refocus) - Guidance on divestment timing and execution.
 - [General Electric rids itself of financial unit in $26.5bn deal as it hones focus](https://www.theguardian.com/business/2015/apr/10/general-electric-sell-financial-unit-26-billion-deal) - GE’s divestiture of GE Capital (2015) - Case study of reducing complexity by divesting a non-core business.
+
+⛅ **Relevant Climatic Patterns**
+
+- [Everything evolves](/climatic-patterns/everything-evolves) – rel: What was once an asset can become a liability as the market and technology landscape changes.
+- [Characteristics change](/climatic-patterns/characteristics-change) – rel: The characteristics of a component or business unit can shift, making it toxic to the parent company.
+- [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Holding onto a liability due to past success can be detrimental; disposal is necessary.
+- [Creative Destruction](/climatic-patterns/creative-destruction) – rel: Disposing of a liability can be a form of creative destruction, allowing resources to be reallocated to more promising areas.
+- [Capital flows to new areas of value](/climatic-patterns/capital-flows-to-new-areas-of-value) – rel: Freeing up capital by disposing of liabilities allows investment in new value-creating opportunities.

--- a/docs/strategies/dealing-with-toxicity/pig-in-a-poke/index.md
+++ b/docs/strategies/dealing-with-toxicity/pig-in-a-poke/index.md
@@ -135,3 +135,11 @@ Executing a "Pig in a Poke" directly can inflict significant, long-lasting reput
 
 - [Pump and Dump](https://en.wikipedia.org/wiki/Pump_and_dump) – Overview of the practice in financial markets.
 - Case Study: Cuban’s [Broadcast.com Sale](https://en.wikipedia.org/wiki/Broadcast.com) – Timing an exit at peak hype for maximum gain.
+
+⛅ **Relevant Climatic Patterns**
+
+- [Everything evolves](/climatic-patterns/everything-evolves) – rel: A component that was once valuable can become less so, tempting a seller to offload it deceptively.
+- [Characteristics change](/climatic-patterns/characteristics-change) – rel: The declining characteristics of an asset might motivate its misrepresentation.
+- [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Buyers might be blinded by the past reputation of an asset, failing to see its current toxicity.
+- [Most competitors have poor situational awareness](/climatic-patterns/most-competitors-have-poor-situational-awareness) – rel: The seller exploits the buyer's lack of awareness or due diligence.
+- [Future value is inversely proportional to the certainty we have over it](/climatic-patterns/future-value-is-inversely-proportional-to-the-certainty-we-have-over-it) – rel: The seller creates a false sense of certainty about future value.

--- a/docs/strategies/dealing-with-toxicity/refactoring/index.md
+++ b/docs/strategies/dealing-with-toxicity/refactoring/index.md
@@ -137,3 +137,11 @@ The primary leadership challenge is **managing the transition sensitively and de
 
 - Agile/DevOps analogies - Many tech companies apply refactoring to processes: e.g., breaking a legacy business process into agile teams. Business literature on **business process re-engineering** touches similar ideas (though BPR often aimed at improvement, here aim is also removal).
 - *"Dual Transformation" (Anthony, Johnson)* - a strategy book that talks about running a legacy business (Transformation B) while building new (Transformation A), and how to transfer capabilities from B to A. It's essentially how to refactor an organization during disruption, moving old capabilities to new growth, similar to refactoring concept described here.
+
+⛅ **Relevant Climatic Patterns**
+
+- [Everything evolves](/climatic-patterns/everything-evolves) – rel: Legacy systems inevitably reach a point where they need refactoring or disposal due to evolution.
+- [Characteristics change](/climatic-patterns/characteristics-change) – rel: Components of a system change, making some parts obsolete (toxic) while others remain valuable and can be refactored.
+- [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Inertia towards successful legacy systems can delay necessary refactoring.
+- [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Refactoring can improve efficiency by removing outdated components, freeing resources for innovation.
+- [Higher order systems create new sources of worth](/climatic-patterns/higher-order-systems-create-new-sources-of-worth) – rel: Refactoring can involve integrating salvaged components into new, higher-order systems.

--- a/docs/strategies/dealing-with-toxicity/sweat-and-dump/index.md
+++ b/docs/strategies/dealing-with-toxicity/sweat-and-dump/index.md
@@ -148,3 +148,11 @@ While operational burdens and capex are offloaded, significant reputational risk
 ## 📚 **Further Reading & References**
 
 - Case Study: [Nortel](https://en.wikipedia.org/wiki/Timeline_of_Nortel) Support Spin-offs – Real-world legacy IT sweat & dump scenario.
+
+⛅ **Relevant Climatic Patterns**
+
+- [Everything evolves](/climatic-patterns/everything-evolves) – rel: Legacy systems become candidates for Sweat & Dump as they reach the end of their lifecycle.
+- [Characteristics change](/climatic-patterns/characteristics-change) – rel: Declining characteristics of an asset make it suitable for outsourcing to a specialist.
+- [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Inertia can prevent organizations from divesting toxic assets, making Sweat & Dump a necessary strategy.
+- [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Offloading a legacy system allows the organization to focus resources on innovation.
+- [Capital flows to new areas of value](/climatic-patterns/capital-flows-to-new-areas-of-value) – rel: Sweat & Dump frees up capital from legacy systems to be invested in new, higher-value areas.

--- a/docs/strategies/markets/buyer-supplier-power/index.md
+++ b/docs/strategies/markets/buyer-supplier-power/index.md
@@ -148,3 +148,11 @@ Every value chain is also a power chain. Understanding this allows you to see th
 
 *   **[Competitive Strategy](https://www.goodreads.com/book/show/236901.Competitive_Strategy)** by Michael E. Porter. The classic text that introduced the "Five Forces" framework, which is central to understanding buyer-supplier power.
 *   **[The Everything Store: Jeff Bezos and the Age of Amazon](https://www.goodreads.com/book/show/17660462-the-everything-store)** by Brad Stone. Provides many examples of how Amazon has masterfully managed buyer-supplier power.
+
+⛅ **Relevant Climatic Patterns**
+
+- [Everything evolves](/climatic-patterns/everything-evolves) – rel: The balance of power between buyers and suppliers shifts as markets and components evolve.
+- [Characteristics change](/climatic-patterns/characteristics-change) – rel: As components commoditize, power often shifts from suppliers to buyers, or to those who control the new standard.
+- [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Increased efficiency in a part of the value chain can alter power dynamics, e.g., by making suppliers more interchangeable.
+- [Higher order systems create new sources of worth](/climatic-patterns/higher-order-systems-create-new-sources-of-worth) – rel: New higher-order systems can create new chokepoints and shift power, like platform ecosystems.
+- [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: Competitors' moves to consolidate power or form alliances will impact the buyer-supplier landscape.

--- a/docs/strategies/markets/harvesting/index.md
+++ b/docs/strategies/markets/harvesting/index.md
@@ -149,3 +149,11 @@ At its best, harvesting is a symbiotic relationship. The ecosystem provides inno
 
 *   **[Platform Revolution](https://www.goodreads.com/book/show/26899832-platform-revolution)** by Geoffrey G. Parker, Marshall W. Van Alstyne, and Sangeet Paul Choudary. A comprehensive guide to platform business models.
 *   **[The Business of Platforms](https://www.goodreads.com/book/show/43688225-the-business-of-platforms)** by Michael A. Cusumano, Annabelle Gawer, and David B. Yoffie. Explores the strategies of platform companies.
+
+⛅ **Relevant Climatic Patterns**
+
+- [Everything evolves](/climatic-patterns/everything-evolves) – rel: The ecosystem around a platform evolves, creating new opportunities for harvesting.
+- [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Third-party innovations on a platform often seek to improve efficiency or offer new capabilities, which can then be harvested.
+- [Higher order systems create new sources of worth](/climatic-patterns/higher-order-systems-create-new-sources-of-worth) – rel: Successful harvested features often become part of a higher-order system (the platform), increasing its overall value.
+- [No choice on evolution](/climatic-patterns/no-choice-on-evolution) – rel: Platforms must evolve by incorporating successful ecosystem innovations (harvesting) to stay relevant.
+- [Capital flows to new areas of value](/climatic-patterns/capital-flows-to-new-areas-of-value) – rel: Harvesting directs the platform owner's capital (build or buy) towards validated areas of value.

--- a/docs/strategies/markets/signal-distortion/index.md
+++ b/docs/strategies/markets/signal-distortion/index.md
@@ -147,3 +147,11 @@ Signal Distortion is a powerful reminder that in many markets, the perception of
 
 *   **[Trust Me, I'm Lying: Confessions of a Media Manipulator](https://www.goodreads.com/book/show/13542853-trust-me-i-m-lying)** by Ryan Holiday. A stark look at how media can be manipulated.
 *   **[The Art of War](https://www.goodreads.com/book/show/10534.The_Art_of_War)** by Sun Tzu. The ancient text is full of wisdom on deception and misdirection.
+
+⛅ **Relevant Climatic Patterns**
+
+- [Most competitors have poor situational awareness](/climatic-patterns/most-competitors-have-poor-situational-awareness) – rel: This strategy exploits the poor situational awareness of competitors by feeding them misleading signals.
+- [Economy has cycles](/climatic-patterns/economy-has-cycles) – rel: Hype cycles and economic bubbles can be amplified or created through signal distortion.
+- [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Competitors relying on past successful signals may be easily misled by distorted new signals.
+- [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: The goal of signal distortion is to influence competitors' actions to your advantage.
+- [The less evolved something is the more uncertain it becomes](/climatic-patterns/the-less-evolved-something-is-then-the-more-uncertain-it-becomes) – rel: Uncertainty in early-stage markets makes them more susceptible to signal distortion.

--- a/docs/strategies/markets/standards-game/index.md
+++ b/docs/strategies/markets/standards-game/index.md
@@ -156,3 +156,10 @@ Competitors may attempt embrace-and-extend tactics or create alternative allianc
 - [GSM Association](https://www.gsma.com/) – Case study of regulators and industry collaborating on a global mobile standard.
 - [RFC 2026 – The Internet Standards Process](https://www.rfc-editor.org/rfc/rfc2026) – Insight into how open standards bodies govern technical specifications.
 
+⛅ **Relevant Climatic Patterns**
+
+- [Everything evolves](/climatic-patterns/everything-evolves) – rel: Standards emerge as components evolve towards commodity; playing the standards game is a way to influence this evolution.
+- [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Standards often arise to improve efficiency and interoperability, which then enables higher-order innovation.
+- [Shifts from product to utility show punctuated equilibrium](/climatic-patterns/shifts-from-product-to-utility-tend-to-demonstrate-a-punctuated-equilibrium) – rel: The establishment of a standard can be a punctuation point in the shift of a component to a utility.
+- [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: Competitors will fight to establish their own standards or resist yours.
+- [No one size fits all](/climatic-patterns/no-one-size-fits-all) – rel: While a standard aims for uniformity, its application might still vary, or competing standards may serve different niches.

--- a/docs/strategies/poison/designed-to-fail/index.md
+++ b/docs/strategies/poison/designed-to-fail/index.md
@@ -166,3 +166,11 @@ These initiatives are not meant to last. Their purpose is to occupy space, creat
 - [HD DVD vs Blu-ray (Wikipedia)](https://en.wikipedia.org/wiki/HD_DVD) — a case of market fragmentation leading to failure.
 - [Betamax vs VHS (Wikipedia)](https://en.wikipedia.org/wiki/Betamax) — example of proprietary format wars.
 - *Blue Ocean Strategy* (W. Chan Kim & Renée Mauborgne) — insights into creating and defending market spaces.
+
+⛅ **Relevant Climatic Patterns**
+
+- [Everything evolves](/climatic-patterns/everything-evolves) – rel: This strategy aims to disrupt the natural evolution of a nascent market.
+- [The less evolved something is the more uncertain it becomes](/climatic-patterns/the-less-evolved-something-is-then-the-more-uncertain-it-becomes) – rel: The uncertainty of early markets makes them vulnerable to "designed to fail" initiatives.
+- [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: This is a direct attempt to influence and derail competitors' actions.
+- [Most competitors have poor situational awareness](/climatic-patterns/most-competitors-have-poor-situational-awareness) – rel: Exploits competitors' inability to discern a deliberately flawed initiative from a genuine one.
+- [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: A company might use this to protect a successful but aging core business from a disruptive new market.

--- a/docs/strategies/poison/insertion/index.md
+++ b/docs/strategies/poison/insertion/index.md
@@ -176,3 +176,11 @@ Insertion is rarely a standalone play. Its effectiveness is often amplified when
 
 - Cialdini, R. — [*Influence: The Psychology of Persuasion*](https://www.amazon.co.uk/Influence-Psychology-Robert-Cialdini-PhD/dp/006124189X) — foundational concepts of behavioral influence.
 - Mitnick, K. — [*The Art of Deception*](https://www.amazon.co.uk/Art-Deception-Controlling-Element-Security/dp/076454280X) — case studies on social engineering and covert operations.
+
+⛅ **Relevant Climatic Patterns**
+
+- [Everything evolves](/climatic-patterns/everything-evolves) – rel: The methods of insertion and the vulnerabilities of competitors evolve over time.
+- [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: Insertion aims to directly influence and manipulate competitors' actions.
+- [Most competitors have poor situational awareness](/climatic-patterns/most-competitors-have-poor-situational-awareness) – rel: This strategy exploits the target's lack of awareness about being influenced.
+- [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Competitors relying on past successful decision-making frameworks can be vulnerable to inserted narratives that fit those frameworks.
+- [The less evolved something is the more uncertain it becomes](/climatic-patterns/the-less-evolved-something-is-then-the-more-uncertain-it-becomes) – rel: Uncertainty in a competitor's strategy or market understanding provides fertile ground for insertion.

--- a/docs/strategies/poison/licensing/index.md
+++ b/docs/strategies/poison/licensing/index.md
@@ -173,3 +173,11 @@ In complex ecosystems where multiple patented technologies are required to creat
 
 - [GPLv3 License](https://www.gnu.org/licenses/gpl-3.0.html) — example of strong copyleft.
 - [Multi-licensing](https://en.wikipedia.org/wiki/Multi-licensing) — overview of dual and multi-licensing strategies.
+
+⛅ **Relevant Climatic Patterns**
+
+- [Everything evolves](/climatic-patterns/everything-evolves) – rel: Licensing terms must adapt as technologies evolve and commoditize.
+- [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Restrictive licensing can stifle innovation by preventing efficient use or combination of technologies.
+- [Higher order systems create new sources of worth](/climatic-patterns/higher-order-systems-create-new-sources-of-worth) – rel: Licensing can control access to components needed to build higher-order systems, thus capturing value.
+- [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: Competitors may challenge licenses or create alternatives, forcing changes in licensing strategy.
+- [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: A company successful with a particular licensing model might be slow to adapt it as the market changes.

--- a/docs/strategies/positional/weak-signal-horizon/index.md
+++ b/docs/strategies/positional/weak-signal-horizon/index.md
@@ -150,3 +150,11 @@ Effective sensing requires an organisational culture that values and acts on ear
 - Wardley, S. – [*Anticipation*](https://blog.gardeviance.org/2016/12/anticipation.html) – foundational concepts on sensing and foresight.
 - Kahneman, D. – [*Thinking, Fast and Slow*](https://www.amazon.co.uk/Thinking-Fast-Slow-Daniel-Kahneman/dp/0141033576#:~:text=Book%20details&text=Nobel%20Prize%20winner%20Daniel%20Kahneman,%2C%20and%20slow%2C%20rational%20thinking.) – for insights on bias and signal interpretation.
 - [*Horizon Scanning*](https://en.wikipedia.org/wiki/Horizon_scanning), Wikipedia - methodologies in foresight practice.
+
+⛅ **Relevant Climatic Patterns**
+
+- [Everything evolves](/climatic-patterns/everything-evolves) – rel: Weak signals often indicate the early stages of a component's evolution or a shift in its trajectory.
+- [Characteristics change](/climatic-patterns/characteristics-change) – rel: Subtle changes in component characteristics can be weak signals of broader market shifts.
+- [The less evolved something is the more uncertain it becomes](/climatic-patterns/the-less-evolved-something-is-then-the-more-uncertain-it-becomes) – rel: Weak signals are inherently uncertain but crucial for navigating early, unevolved spaces.
+- [Economy has cycles](/climatic-patterns/economy-has-cycles) – rel: Recognizing cyclical patterns can help identify weak signals related to market peaks, troughs, and transitions.
+- [Not everything is random](/climatic-patterns/not-everything-is-random) – rel: The core belief of weak signal detection is that underlying patterns, not randomness, drive market changes.


### PR DESCRIPTION
This commit adds the '⛅ Relevant Climatic Patterns' section to 14 strategy pages that were missing it, as per the issue description and CONTRIBUTING.md guidelines.

Each new section includes a default set of 5 broadly applicable climatic patterns with generic 'rel:' descriptions as a starting point for further refinement.