### PR TITLE
Fix: Correct 'Relevant Climatic Patterns' heading format

### DIFF
--- a/docs/strategies/competitor/circling-and-probing/index.md
+++ b/docs/strategies/competitor/circling-and-probing/index.md
@@ -176,7 +176,7 @@ Avoid getting stuck in analysis; the goal is to use insights to decide where to 
 * "Competitive Strategy" by Michael Porter - For foundational concepts on competitive analysis and strategy.
 * "The Art of War" by Sun Tzu - For insights into strategic thinking and maneuvering in competitive situations.
 
-⛅ **Relevant Climatic Patterns**
+## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: The landscape is constantly changing, requiring ongoing circling and probing.
 - [Characteristics change](/climatic-patterns/characteristics-change) – rel: Competitor capabilities and market dynamics shift, necessitating adaptation.

--- a/docs/strategies/competitor/sapping/index.md
+++ b/docs/strategies/competitor/sapping/index.md
@@ -141,7 +141,7 @@ Sapping should lead to the competitor's collapse in one area or their retreat fr
 
 -   Clayton Christensen - "The Innovator's Dilemma" (for examples of multi-front competition and disruption).
 
-⛅ **Relevant Climatic Patterns**
+## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: The competitor's strengths and weaknesses will change over time, creating new sapping opportunities.
 - [Characteristics change](/climatic-patterns/characteristics-change) – rel: As components of a competitor's offering evolve, their dependencies might become vulnerabilities.

--- a/docs/strategies/dealing-with-toxicity/disposal-of-liability/index.md
+++ b/docs/strategies/dealing-with-toxicity/disposal-of-liability/index.md
@@ -144,7 +144,7 @@ alternative to disposal.
 - HBR: [“Pruning the Corporate Portfolio”](https://hbr.org/2017/12/case-study-should-a-hotel-giant-eliminate-some-brands-and-refocus) - Guidance on divestment timing and execution.
 - [General Electric rids itself of financial unit in $26.5bn deal as it hones focus](https://www.theguardian.com/business/2015/apr/10/general-electric-sell-financial-unit-26-billion-deal) - GE’s divestiture of GE Capital (2015) - Case study of reducing complexity by divesting a non-core business.
 
-⛅ **Relevant Climatic Patterns**
+## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: What was once an asset can become a liability as the market and technology landscape changes.
 - [Characteristics change](/climatic-patterns/characteristics-change) – rel: The characteristics of a component or business unit can shift, making it toxic to the parent company.

--- a/docs/strategies/dealing-with-toxicity/pig-in-a-poke/index.md
+++ b/docs/strategies/dealing-with-toxicity/pig-in-a-poke/index.md
@@ -136,7 +136,7 @@ Executing a "Pig in a Poke" directly can inflict significant, long-lasting reput
 - [Pump and Dump](https://en.wikipedia.org/wiki/Pump_and_dump) – Overview of the practice in financial markets.
 - Case Study: Cuban’s [Broadcast.com Sale](https://en.wikipedia.org/wiki/Broadcast.com) – Timing an exit at peak hype for maximum gain.
 
-⛅ **Relevant Climatic Patterns**
+## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: A component that was once valuable can become less so, tempting a seller to offload it deceptively.
 - [Characteristics change](/climatic-patterns/characteristics-change) – rel: The declining characteristics of an asset might motivate its misrepresentation.

--- a/docs/strategies/dealing-with-toxicity/refactoring/index.md
+++ b/docs/strategies/dealing-with-toxicity/refactoring/index.md
@@ -138,7 +138,7 @@ The primary leadership challenge is **managing the transition sensitively and de
 - Agile/DevOps analogies - Many tech companies apply refactoring to processes: e.g., breaking a legacy business process into agile teams. Business literature on **business process re-engineering** touches similar ideas (though BPR often aimed at improvement, here aim is also removal).
 - *"Dual Transformation" (Anthony, Johnson)* - a strategy book that talks about running a legacy business (Transformation B) while building new (Transformation A), and how to transfer capabilities from B to A. It's essentially how to refactor an organization during disruption, moving old capabilities to new growth, similar to refactoring concept described here.
 
-⛅ **Relevant Climatic Patterns**
+## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: Legacy systems inevitably reach a point where they need refactoring or disposal due to evolution.
 - [Characteristics change](/climatic-patterns/characteristics-change) – rel: Components of a system change, making some parts obsolete (toxic) while others remain valuable and can be refactored.

--- a/docs/strategies/dealing-with-toxicity/sweat-and-dump/index.md
+++ b/docs/strategies/dealing-with-toxicity/sweat-and-dump/index.md
@@ -149,7 +149,7 @@ While operational burdens and capex are offloaded, significant reputational risk
 
 - Case Study: [Nortel](https://en.wikipedia.org/wiki/Timeline_of_Nortel) Support Spin-offs – Real-world legacy IT sweat & dump scenario.
 
-⛅ **Relevant Climatic Patterns**
+## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: Legacy systems become candidates for Sweat & Dump as they reach the end of their lifecycle.
 - [Characteristics change](/climatic-patterns/characteristics-change) – rel: Declining characteristics of an asset make it suitable for outsourcing to a specialist.

--- a/docs/strategies/markets/buyer-supplier-power/index.md
+++ b/docs/strategies/markets/buyer-supplier-power/index.md
@@ -149,7 +149,7 @@ Every value chain is also a power chain. Understanding this allows you to see th
 *   **[Competitive Strategy](https://www.goodreads.com/book/show/236901.Competitive_Strategy)** by Michael E. Porter. The classic text that introduced the "Five Forces" framework, which is central to understanding buyer-supplier power.
 *   **[The Everything Store: Jeff Bezos and the Age of Amazon](https://www.goodreads.com/book/show/17660462-the-everything-store)** by Brad Stone. Provides many examples of how Amazon has masterfully managed buyer-supplier power.
 
-⛅ **Relevant Climatic Patterns**
+## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: The balance of power between buyers and suppliers shifts as markets and components evolve.
 - [Characteristics change](/climatic-patterns/characteristics-change) – rel: As components commoditize, power often shifts from suppliers to buyers, or to those who control the new standard.

--- a/docs/strategies/markets/harvesting/index.md
+++ b/docs/strategies/markets/harvesting/index.md
@@ -150,7 +150,7 @@ At its best, harvesting is a symbiotic relationship. The ecosystem provides inno
 *   **[Platform Revolution](https://www.goodreads.com/book/show/26899832-platform-revolution)** by Geoffrey G. Parker, Marshall W. Van Alstyne, and Sangeet Paul Choudary. A comprehensive guide to platform business models.
 *   **[The Business of Platforms](https://www.goodreads.com/book/show/43688225-the-business-of-platforms)** by Michael A. Cusumano, Annabelle Gawer, and David B. Yoffie. Explores the strategies of platform companies.
 
-⛅ **Relevant Climatic Patterns**
+## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: The ecosystem around a platform evolves, creating new opportunities for harvesting.
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Third-party innovations on a platform often seek to improve efficiency or offer new capabilities, which can then be harvested.

--- a/docs/strategies/markets/signal-distortion/index.md
+++ b/docs/strategies/markets/signal-distortion/index.md
@@ -148,7 +148,7 @@ Signal Distortion is a powerful reminder that in many markets, the perception of
 *   **[Trust Me, I'm Lying: Confessions of a Media Manipulator](https://www.goodreads.com/book/show/13542853-trust-me-i-m-lying)** by Ryan Holiday. A stark look at how media can be manipulated.
 *   **[The Art of War](https://www.goodreads.com/book/show/10534.The_Art_of_War)** by Sun Tzu. The ancient text is full of wisdom on deception and misdirection.
 
-⛅ **Relevant Climatic Patterns**
+## ⛅ **Relevant Climatic Patterns**
 
 - [Most competitors have poor situational awareness](/climatic-patterns/most-competitors-have-poor-situational-awareness) – rel: This strategy exploits the poor situational awareness of competitors by feeding them misleading signals.
 - [Economy has cycles](/climatic-patterns/economy-has-cycles) – rel: Hype cycles and economic bubbles can be amplified or created through signal distortion.

--- a/docs/strategies/markets/standards-game/index.md
+++ b/docs/strategies/markets/standards-game/index.md
@@ -156,7 +156,7 @@ Competitors may attempt embrace-and-extend tactics or create alternative allianc
 - [GSM Association](https://www.gsma.com/) – Case study of regulators and industry collaborating on a global mobile standard.
 - [RFC 2026 – The Internet Standards Process](https://www.rfc-editor.org/rfc/rfc2026) – Insight into how open standards bodies govern technical specifications.
 
-⛅ **Relevant Climatic Patterns**
+## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: Standards emerge as components evolve towards commodity; playing the standards game is a way to influence this evolution.
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Standards often arise to improve efficiency and interoperability, which then enables higher-order innovation.

--- a/docs/strategies/poison/designed-to-fail/index.md
+++ b/docs/strategies/poison/designed-to-fail/index.md
@@ -167,7 +167,7 @@ These initiatives are not meant to last. Their purpose is to occupy space, creat
 - [Betamax vs VHS (Wikipedia)](https://en.wikipedia.org/wiki/Betamax) — example of proprietary format wars.
 - *Blue Ocean Strategy* (W. Chan Kim & Renée Mauborgne) — insights into creating and defending market spaces.
 
-⛅ **Relevant Climatic Patterns**
+## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: This strategy aims to disrupt the natural evolution of a nascent market.
 - [The less evolved something is the more uncertain it becomes](/climatic-patterns/the-less-evolved-something-is-then-the-more-uncertain-it-becomes) – rel: The uncertainty of early markets makes them vulnerable to "designed to fail" initiatives.

--- a/docs/strategies/poison/insertion/index.md
+++ b/docs/strategies/poison/insertion/index.md
@@ -177,7 +177,7 @@ Insertion is rarely a standalone play. Its effectiveness is often amplified when
 - Cialdini, R. — [*Influence: The Psychology of Persuasion*](https://www.amazon.co.uk/Influence-Psychology-Robert-Cialdini-PhD/dp/006124189X) — foundational concepts of behavioral influence.
 - Mitnick, K. — [*The Art of Deception*](https://www.amazon.co.uk/Art-Deception-Controlling-Element-Security/dp/076454280X) — case studies on social engineering and covert operations.
 
-⛅ **Relevant Climatic Patterns**
+## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: The methods of insertion and the vulnerabilities of competitors evolve over time.
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: Insertion aims to directly influence and manipulate competitors' actions.

--- a/docs/strategies/poison/licensing/index.md
+++ b/docs/strategies/poison/licensing/index.md
@@ -174,7 +174,7 @@ In complex ecosystems where multiple patented technologies are required to creat
 - [GPLv3 License](https://www.gnu.org/licenses/gpl-3.0.html) — example of strong copyleft.
 - [Multi-licensing](https://en.wikipedia.org/wiki/Multi-licensing) — overview of dual and multi-licensing strategies.
 
-⛅ **Relevant Climatic Patterns**
+## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: Licensing terms must adapt as technologies evolve and commoditize.
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Restrictive licensing can stifle innovation by preventing efficient use or combination of technologies.

--- a/docs/strategies/positional/weak-signal-horizon/index.md
+++ b/docs/strategies/positional/weak-signal-horizon/index.md
@@ -151,7 +151,7 @@ Effective sensing requires an organisational culture that values and acts on ear
 - Kahneman, D. – [*Thinking, Fast and Slow*](https://www.amazon.co.uk/Thinking-Fast-Slow-Daniel-Kahneman/dp/0141033576#:~:text=Book%20details&text=Nobel%20Prize%20winner%20Daniel%20Kahneman,%2C%20and%20slow%2C%20rational%20thinking.) – for insights on bias and signal interpretation.
 - [*Horizon Scanning*](https://en.wikipedia.org/wiki/Horizon_scanning), Wikipedia - methodologies in foresight practice.
 
-⛅ **Relevant Climatic Patterns**
+## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: Weak signals often indicate the early stages of a component's evolution or a shift in its trajectory.
 - [Characteristics change](/climatic-patterns/characteristics-change) – rel: Subtle changes in component characteristics can be weak signals of broader market shifts.


### PR DESCRIPTION
Corrected the formatting of the 'Relevant Climatic Patterns' heading in 14 strategy files to ensure consistency with CONTRIBUTING.md guidelines. The heading is now correctly formatted as '## ⛅ **Relevant Climatic Patterns**' and placed as the 14th section in the document structure.