### PR TITLE
Expand CI triggers and add pytest workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,23 @@
+name: Pytest
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: ['**']
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,10 @@
 name: Node.js CI
 
 on:
-  pull_request:
   push:
-    branches: [ main ]
+    branches: ['**']
+  pull_request:
+    branches: ['**']
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- run Node.js tests on all branches
- add a workflow to run pytest

## Testing
- `npm test`
- `pytest` *(fails: Found non-reciprocal strategy links and missing climatic pattern links)*

------
https://chatgpt.com/codex/tasks/task_e_6861a8154504832bb1a09f20415ebb09