### PR TITLE
Fix reciprocal strategy links

### DIFF
--- a/docs/strategies/accelerators/cooperation/index.md
+++ b/docs/strategies/accelerators/cooperation/index.md
@@ -262,6 +262,8 @@ Use alliances when the goal is ecosystem-level impact or when formality helps se
 - [**Circling and Probing**](/strategies/competitor/circling-and-probing) - is opposite: testing a competitor rather than working with them.
 - [Standards Game](/strategies/markets/standards-game) - cooperation often aims to establish common standards and reduce friction.
 
+- [Market Enablement](/strategies/accelerators/market-enablement)
+- [Playing Both Sides](/strategies/attacking/playing-both-sides)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Components can co-evolve](/climatic-patterns/components-can-co-evolve) – influence: collaboration shapes how capabilities mature together.

--- a/docs/strategies/accelerators/exploiting-network-effects/index.md
+++ b/docs/strategies/accelerators/exploiting-network-effects/index.md
@@ -271,6 +271,8 @@ Focus on creating value for users and facilitating connections and interactions.
 - [**Two-Factor Markets**](/strategies/ecosystem/two-factor-markets) - explicitly building both sides of a network to exploit cross-side network effects
 - [**Standards Game**](/strategies/markets/standards-game) - Companies sometimes engage in standards warfare hoping their technology becomes the de facto standard (network), thus locking in an ecosystem.
 
+- [Market Enablement](/strategies/accelerators/market-enablement)
+- [Licensing](/strategies/poison/licensing)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Change is not always linear](/climatic-patterns/change-is-not-always-linear) – influence: network effects often produce sudden, exponential adoption curves.

--- a/docs/strategies/accelerators/market-enablement/index.md
+++ b/docs/strategies/accelerators/market-enablement/index.md
@@ -215,6 +215,11 @@ The degree of "openness" (e.g., open standards, open source, open data) is a cri
 - [Cooperation](/strategies/accelerators/cooperation) - Working with other players, even competitors, is fundamental to many market enablement initiatives.
 - [Exploiting Network Effects](/strategies/accelerators/exploiting-network-effects) - An enabled market can lead to network effects that further accelerate adoption and growth.
 
+- [Industrial Policy](/strategies/accelerators/industrial-policy)
+- [Press Release Process](/strategies/attacking/press-release-process)
+- [Undermining Barriers to Entry](/strategies/attacking/undermining-barriers-to-entry)
+- [Talent Raid](/strategies/competitor/talent-raid)
+- [Artificial Competition](/strategies/user-perception/artificial-competition)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Higher order systems create new sources of worth](/climatic-patterns/higher-order-systems-create-new-sources-of-worth) – trigger: enabling a market lets new value chains emerge.

--- a/docs/strategies/accelerators/open-approaches/index.md
+++ b/docs/strategies/accelerators/open-approaches/index.md
@@ -159,6 +159,15 @@ For example, if your competitor is slower-moving or dependent on licensing, open
 - [Embrace and Extend](/strategies/ecosystem/embrace-and-extend) – The inverse: a competitor may embrace your open tech, then extend it with proprietary features.
 - [Market Enablement](/strategies/accelerators/market-enablement) – Creating conditions for a market to grow, often by reducing friction.
 
+- [Patents & Intellectual Property Rights](/strategies/decelerators/ipr)
+- [Innovate, Leverage, Commoditize (ILC)](/strategies/ecosystem/innovate-leverage-commoditize)
+- [Press Release Process](/strategies/attacking/press-release-process)
+- [Fool's Mate](/strategies/attacking/fools-mate)
+- [Center of Gravity](/strategies/attacking/centre-of-gravity)
+- [Education](/strategies/user-perception/education)
+- [Licensing](/strategies/poison/licensing)
+- [Harvesting](/strategies/markets/harvesting)
+- [Standards Game](/strategies/markets/standards-game)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – trigger: industrialisation of a component often leads to opening it up.

--- a/docs/strategies/attacking/centre-of-gravity/index.md
+++ b/docs/strategies/attacking/centre-of-gravity/index.md
@@ -164,6 +164,9 @@ This kind of cultural or visionary gravity is harder to replicate or fight. It�
 - [Co-opting](/strategies/ecosystem/co-opting) – Absorbing or neutralising ecosystem participants can reinforce or undermine a center of gravity.
 - [Open Approaches](/strategies/accelerators/open-approaches) – Open platforms and standards can help build gravitational pull.
 
+- [Experimentation](/strategies/attacking/experimentation)
+- [Fool's Mate](/strategies/attacking/fools-mate)
+- [Directed Investment](/strategies/attacking/directed-investment)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Capital flows to new areas of value](/climatic-patterns/capital-flows-to-new-areas-of-value) – trigger: investment tends to cluster around emerging hubs.

--- a/docs/strategies/attacking/directed-investment/index.md
+++ b/docs/strategies/attacking/directed-investment/index.md
@@ -164,6 +164,7 @@ Directed investment can shift the centre of gravity in a value chain, attracting
 - [Center of Gravity](/strategies/attacking/centre-of-gravity) – Sometimes the goal of directed investment is to create a new hub of talent or activity.
 - [Experimentation](/strategies/attacking/experimentation) – Experimentation can precede or complement directed investment by surfacing opportunities.
 
+- [Press Release Process](/strategies/attacking/press-release-process)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Future value is inversely proportional to the certainty we have over it](/climatic-patterns/future-value-is-inversely-proportional-to-the-certainty-we-have-over-it) – influence: big bets seek uncertain but high-reward opportunities.

--- a/docs/strategies/attacking/experimentation/index.md
+++ b/docs/strategies/attacking/experimentation/index.md
@@ -166,6 +166,10 @@ Experiments often reveal new dependencies or bottlenecks early, letting you shap
 - [Co-creation](/strategies/ecosystem/co-creation) – Working with users during experiments deepens insight.
 - [Weak Signal (Horizon)](/strategies/positional/weak-signal-horizon) – Experiments often start by probing weak signals.
 
+- [Fast Follower](/strategies/positional/fast-follower)
+- [Press Release Process](/strategies/attacking/press-release-process)
+- [circling-and-probing](/strategies/competitor/circling-and-probing)
+- [Differentiation](/strategies/markets/differentiation)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [You cannot measure evolution over time or adoption](/climatic-patterns/you-cannot-measure-evolution-over-time-or-adoption-you-need-to-embrace-uncertainty) – influence: uncertainty makes experimentation essential.

--- a/docs/strategies/attacking/playing-both-sides/index.md
+++ b/docs/strategies/attacking/playing-both-sides/index.md
@@ -154,6 +154,8 @@ At its core, this is a hedging strategy. It's an admission that you cannot predi
 - **[Standards Game](/strategies/markets/standards-game)**: Playing both sides is a specific move within a larger standards game.
 - **[Innovate, Leverage, Commoditize (ILC)](/strategies/ecosystem/innovate-leverage-commoditize)**: This strategy can be a component of ILC, where you leverage your position as a neutral supplier to sense where the market is heading.
 
+- [Ambush](/strategies/competitor/ambush)
+- [Artificial Competition](/strategies/user-perception/artificial-competition)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – trigger: shifting alliances alter how battles unfold.

--- a/docs/strategies/attacking/press-release-process/index.md
+++ b/docs/strategies/attacking/press-release-process/index.md
@@ -199,6 +199,7 @@ A press release that reads as weak or incoherent is a fast signal of strategic u
 - [Fast Follower](/strategies/positional/fast-follower) – The press release process can be used to quickly respond to emerging user needs with evolved capabilities.
 - [Experimentation](/strategies/attacking/experimentation) – Use press releases to simulate outcomes and test resonance before committing resources.
 
+- [insertion](/strategies/poison/insertion)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Future value is inversely proportional to the certainty we have over it](/climatic-patterns/future-value-is-inversely-proportional-to-the-certainty-we-have-over-it) – trigger: describing the end state clarifies uncertain outcomes.

--- a/docs/strategies/attacking/undermining-barriers-to-entry/index.md
+++ b/docs/strategies/attacking/undermining-barriers-to-entry/index.md
@@ -133,6 +133,7 @@ Open-sourcing a key technology is one of the most powerful ways to undermine a b
 *   **[Market Enablement](/strategies/accelerators/market-enablement)**: By undermining a barrier, you are often enabling a new market to emerge.
 *   **[Fool's Mate](/strategies/attacking/fools-mate)**: Undermining a critical barrier can be a key move in executing a Fool's Mate, leading to a rapid collapse of the incumbent's position.
 
+- [Tech Drops](/strategies/competitor/tech-drops)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Most competitors have poor situational awareness](/climatic-patterns/most-competitors-have-poor-situational-awareness) – trigger: incumbents may not notice barriers eroding until it's too late.

--- a/docs/strategies/competitor/circling-and-probing/index.md
+++ b/docs/strategies/competitor/circling-and-probing/index.md
@@ -171,6 +171,10 @@ Avoid getting stuck in analysis; the goal is to use insights to decide where to 
 * [**Experimentation**](/strategies/attacking/experimentation) - Testing new approaches to find effective strategies.
 * [**Alliances**](/strategies/ecosystem/alliances) - Forming partnerships, the opposite of testing a competitor.
 
+- [Cooperation](/strategies/accelerators/cooperation)
+- [sapping](/strategies/competitor/sapping)
+- [fragmentation](/strategies/competitor/fragmentation)
+- [Ambush](/strategies/competitor/ambush)
 ## 📚 **Further Reading & References**
 
 * "Competitive Strategy" by Michael Porter - For foundational concepts on competitive analysis and strategy.

--- a/docs/strategies/competitor/fragmentation/index.md
+++ b/docs/strategies/competitor/fragmentation/index.md
@@ -153,6 +153,8 @@ A fragmentation play is about playing divide and conquer in a market. It is most
 -   [**Circling and Probing**](/strategies/competitor/circling-and-probing) - Testing a competitor's defenses, the opposite of working with them
 -   [**Restriction of Movement**](/strategies/competitor/restriction-of-movement) - A strategy focused on limiting a competitor's options and flexibility
 
+- [insertion](/strategies/poison/insertion)
+- [Pricing Policy](/strategies/markets/pricing-policy)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Creative Destruction](/climatic-patterns/creative-destruction) – trigger: breaking a monolith clears the way for new entrants.

--- a/docs/strategies/competitor/misdirection/index.md
+++ b/docs/strategies/competitor/misdirection/index.md
@@ -148,6 +148,10 @@ Misdirection can lead to competitor inertia. If a company consistently signals t
 -   [**Signal Distortion**](/strategies/markets/signal-distortion): Misdirection deliberately distorts market signals to mislead competitors.
 -   [**Fear, Uncertainty, and Doubt**](/strategies/user-perception/fear-uncertainty-and-doubt): Misdirection can create fear, uncertainty, and doubt in the minds of competitors.
 
+- [circling-and-probing](/strategies/competitor/circling-and-probing)
+- [Artificial Competition](/strategies/user-perception/artificial-competition)
+- [insertion](/strategies/poison/insertion)
+- [designed-to-fail](/strategies/poison/designed-to-fail)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – influence: decoys buy time while rivals adjust.

--- a/docs/strategies/competitor/reinforcing-competitor-inertia/index.md
+++ b/docs/strategies/competitor/reinforcing-competitor-inertia/index.md
@@ -130,6 +130,7 @@ Reinforcing someone else's inertia often requires that the new paradigm you push
 -   [**Exploiting Constraint**](/strategies/decelerators/exploiting-constraint): Similar to reinforcing inertia, this strategy exploits limitations, but it focuses on external constraints rather than a competitor's internal resistance.
 -   [**Tech Drops**](/strategies/competitor/tech-drops): Can be used to capitalize on a competitor's inertia by launching a sudden, unexpected attack when they are least prepared.
 
+- [misdirection](/strategies/competitor/misdirection)
 ## 📚 **Further Reading & References**
 
 -   Clayton Christensen, *The Innovator's Dilemma*

--- a/docs/strategies/competitor/restriction-of-movement/index.md
+++ b/docs/strategies/competitor/restriction-of-movement/index.md
@@ -144,6 +144,10 @@ Ultimately, restriction of movement can create a **stalemate favoring the strong
 -   [**Talent Raid**](/strategies/competitor/talent-raid) - Limits a competitor's movement by restricting access to talent.
 -   [**Limitation of Competition**](/strategies/defensive/limitation-of-competition) - The overarching goal of restriction of movement.
 
+- [Threat Acquisition](/strategies/defensive/threat-acquisition)
+- [sapping](/strategies/competitor/sapping)
+- [fragmentation](/strategies/competitor/fragmentation)
+- [Ambush](/strategies/competitor/ambush)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – influence: blocking options keeps rivals tied to outdated approaches.

--- a/docs/strategies/competitor/sapping/index.md
+++ b/docs/strategies/competitor/sapping/index.md
@@ -137,6 +137,7 @@ Sapping should lead to the competitor's collapse in one area or their retreat fr
 -   [**Restriction of Movement**](/strategies/competitor/restriction-of-movement): Sapping can be used to restrict a competitor's movement and limit their ability to respond to attacks.
 -   [**Circling and Probing**](/strategies/competitor/circling-and-probing): Circling and probing can be used to identify weaknesses in a competitor before launching a sapping attack.
 
+- [Ambush](/strategies/competitor/ambush)
 ## 📚 **Further Reading & References**
 
 -   Clayton Christensen - "The Innovator's Dilemma" (for examples of multi-front competition and disruption).

--- a/docs/strategies/competitor/talent-raid/index.md
+++ b/docs/strategies/competitor/talent-raid/index.md
@@ -174,6 +174,8 @@ It's essential to consider the potential optics and impact on relationships with
 * [**Raising Barriers to Entry**](/strategies/defensive/raising-barriers-to-entry) - A successful Talent Raid can raise barriers to entry for competitors by depriving them of critical talent.
 * [**Market Enablement**](/strategies/accelerators/market-enablement) - If the talent raid brings in individuals with strong market connections or expertise, it can enable market growth.
 
+- [Center of Gravity](/strategies/attacking/centre-of-gravity)
+- [insertion](/strategies/poison/insertion)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Future value is inversely proportional to the certainty we have over it](/climatic-patterns/future-value-is-inversely-proportional-to-the-certainty-we-have-over-it) – influence: securing key talent helps navigate uncertain markets.

--- a/docs/strategies/competitor/tech-drops/index.md
+++ b/docs/strategies/competitor/tech-drops/index.md
@@ -158,6 +158,9 @@ It's important to distinguish Tech Drops from [Ambush](/strategies/competitor/am
 - [**Undermining Barriers to Entry**](/strategies/attacking/undermining-barriers-to-entry): A successful Tech Drop often inherently undermines existing barriers by creating a new playing field or rendering old advantages irrelevant.
 - [**Ambush**](/strategies/competitor/ambush): Contrasts with Tech Drops in its reactive nature. Understanding Ambush helps clarify the proactive, market-creating intent of Tech Drops.
 
+- [sapping](/strategies/competitor/sapping)
+- [reinforcing-competitor-inertia](/strategies/competitor/reinforcing-competitor-inertia)
+- [Talent Raid](/strategies/competitor/talent-raid)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Change is not always linear](/climatic-patterns/change-is-not-always-linear) – influence: a Tech Drop creates a punctuated equilibrium, a sudden leap in evolution.

--- a/docs/strategies/dealing-with-toxicity/refactoring/index.md
+++ b/docs/strategies/dealing-with-toxicity/refactoring/index.md
@@ -133,6 +133,7 @@ The primary leadership challenge is **managing the transition sensitively and de
 - [**Disposal of Liability**](/strategies/dealing-with-toxicity/disposal-of-liability) refactoring is an approach to disposal by reuse
 - [**Sweat & Dump**](/strategies/dealing-with-toxicity/sweat-and-dump) as an alternative - instead of third-party, you internally transform
 
+- [Pig in a Poke](/strategies/dealing-with-toxicity/pig-in-a-poke)
 ## 📚 **Further Reading & References**
 
 - Agile/DevOps analogies - Many tech companies apply refactoring to processes: e.g., breaking a legacy business process into agile teams. Business literature on **business process re-engineering** touches similar ideas (though BPR often aimed at improvement, here aim is also removal).

--- a/docs/strategies/dealing-with-toxicity/sweat-and-dump/index.md
+++ b/docs/strategies/dealing-with-toxicity/sweat-and-dump/index.md
@@ -145,6 +145,8 @@ While operational burdens and capex are offloaded, significant reputational risk
 - [Refactoring](/strategies/dealing-with-toxicity/refactoring) – Internally transform or repurpose assets, retaining control and capex.
 - [Innovate-Leverage-Commoditize](/strategies/ecosystem/innovate-leverage-commoditize) - Could be the end-goal that Sweat & Dump enables resources for.
 
+- [designed-to-fail](/strategies/poison/designed-to-fail)
+- [Last Man Standing](/strategies/markets/last-man-standing)
 ## 📚 **Further Reading & References**
 
 - Case Study: [Nortel](https://en.wikipedia.org/wiki/Timeline_of_Nortel) Support Spin-offs – Real-world legacy IT sweat & dump scenario.

--- a/docs/strategies/decelerators/exploiting-constraint/index.md
+++ b/docs/strategies/decelerators/exploiting-constraint/index.md
@@ -144,6 +144,9 @@ Analyze supply chain and partner feedback to anticipate shifts that could neutra
 - [Patents & Intellectual Property Rights](/strategies/decelerators/ipr) - Use legal rights to impose constraints on competitors’ technology evolution.
 - [Raising Barriers to Entry](/strategies/defensive/raising-barriers-to-entry) - Broader defensive tactics to limit market entry.
 
+- [Fool's Mate](/strategies/attacking/fools-mate)
+- [reinforcing-competitor-inertia](/strategies/competitor/reinforcing-competitor-inertia)
+- [Last Man Standing](/strategies/markets/last-man-standing)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Creative Destruction](/climatic-patterns/creative-destruction) – trigger: forcing prices down can reset an industry landscape.

--- a/docs/strategies/decelerators/ipr/index.md
+++ b/docs/strategies/decelerators/ipr/index.md
@@ -158,6 +158,9 @@ Intellectual Property Rights are increasingly becoming a significant element in 
 - [Defensive Regulation](/strategies/defensive/defensive-regulation) - Using regulation to create legal constraints.
 - [Open Approaches](/strategies/accelerators/open-approaches) - Alternative strategy leveraging open standards and collaboration.
 
+- [Creating Constraints](/strategies/decelerators/creating-constraints)
+- [Exploiting Existing Constraint](/strategies/decelerators/exploiting-constraint)
+- [Limitation of Competition](/strategies/defensive/limitation-of-competition)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Inertia can kill an organisation](/climatic-patterns/inertia-can-kill-an-organisation) – influence: aggressive IP use can entrench slow-moving leaders.

--- a/docs/strategies/defensive/defensive-regulation/index.md
+++ b/docs/strategies/defensive/defensive-regulation/index.md
@@ -138,6 +138,8 @@ Defensive Regulation is a strategy that is primarily available to large, powerfu
 *   **[Limitation of Competition](/strategies/defensive/limitation-of-competition)**: This is often the goal of defensive regulation.
 *   **[Standards Game](/strategies/markets/standards-game)**: This strategy can be used to get your proprietary standard enshrined in law, creating a powerful and legally-enforced moat.
 
+- [Patents & Intellectual Property Rights](/strategies/decelerators/ipr)
+- [Lobbying](/strategies/user-perception/lobbying)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – trigger: regulation is often introduced when challengers threaten the status quo.

--- a/docs/strategies/defensive/limitation-of-competition/index.md
+++ b/docs/strategies/defensive/limitation-of-competition/index.md
@@ -164,6 +164,8 @@ Limiting competition can slow evolution, but may also reduce overall market dyna
 - [Standards Game](/strategies/markets/standards-game) – Making your approach the market norm, locking out alternatives.
 - [Lobbying](/strategies/user-perception/lobbying) – Influencing policy or standards as a precursor to limitation of competition.
 
+- [restriction-of-movement](/strategies/competitor/restriction-of-movement)
+- [Licensing](/strategies/poison/licensing)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Economy has cycles](/climatic-patterns/economy-has-cycles) – trigger: shifts in market conditions can erode imposed limits.

--- a/docs/strategies/defensive/raising-barriers-to-entry/index.md
+++ b/docs/strategies/defensive/raising-barriers-to-entry/index.md
@@ -132,6 +132,15 @@ Raising the barriers to entry shifts the basis of competition. It's no longer ab
 *   **[Limitation of Competition](/strategies/defensive/limitation-of-competition)**: This is the ultimate goal of raising the barriers to entry.
 *   **[Standards Game](/strategies/markets/standards-game)**: By creating a tightly integrated suite, you can attempt to make your proprietary integration points the de facto standard for the market.
 
+- [Creating Constraints](/strategies/decelerators/creating-constraints)
+- [Exploiting Existing Constraint](/strategies/decelerators/exploiting-constraint)
+- [Defensive Regulation](/strategies/defensive/defensive-regulation)
+- [reinforcing-competitor-inertia](/strategies/competitor/reinforcing-competitor-inertia)
+- [Talent Raid](/strategies/competitor/talent-raid)
+- [restriction-of-movement](/strategies/competitor/restriction-of-movement)
+- [Lobbying](/strategies/user-perception/lobbying)
+- [Bundling](/strategies/user-perception/bundling)
+- [Buyer-Supplier Power](/strategies/markets/buyer-supplier-power)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Inertia can kill an organisation](/climatic-patterns/inertia-can-kill-an-organisation) – trigger: barriers entrench incumbents and slow adaptation.

--- a/docs/strategies/defensive/threat-acquisition/index.md
+++ b/docs/strategies/defensive/threat-acquisition/index.md
@@ -146,6 +146,9 @@ While threat acquisitions can be expensive, the cost of inaction can be even hig
 *   **[Restriction of Movement](/strategies/competitor/restriction-of-movement)**: Hindering a competitor's ability to operate without acquiring them.
 *   **[Talent Raid](/strategies/competitor/talent-raid)**: Acquiring key talent from a competitor to weaken their capabilities.
 
+- [Limitation of Competition](/strategies/defensive/limitation-of-competition)
+- [Harvesting](/strategies/markets/harvesting)
+- [Last Man Standing](/strategies/markets/last-man-standing)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – trigger: acquisitions help an organisation adapt as markets shift.

--- a/docs/strategies/ecosystem/alliances/index.md
+++ b/docs/strategies/ecosystem/alliances/index.md
@@ -156,6 +156,10 @@ If cooperation is about joint exploration, alliances are about jointly steering 
 - [Standards Game](/strategies/markets/standards-game) - alliances often form to promote or defend a shared standard.
 - [Center of Gravity](/strategies/attacking/centre-of-gravity) - alliances can shift the industry's center of gravity against a rival.
 
+- [Market Enablement](/strategies/accelerators/market-enablement)
+- [restriction-of-movement](/strategies/competitor/restriction-of-movement)
+- [circling-and-probing](/strategies/competitor/circling-and-probing)
+- [fragmentation](/strategies/competitor/fragmentation)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [A 'war' causes organisations to evolve](/climatic-patterns/a-war-causes-organisations-to-evolve) – trigger: intense competition often pushes companies to form alliances.

--- a/docs/strategies/ecosystem/channel-conflict-and-disintermediation/index.md
+++ b/docs/strategies/ecosystem/channel-conflict-and-disintermediation/index.md
@@ -141,6 +141,7 @@ Channel conflict is not just about cutting costs; it's about forcing change. It 
 *   **[Vertical Integration](/terms/value-chain)**: Disintermediation is a form of vertical integration, as you are taking on a part of the value chain that was previously outsourced.
 *   **[Direct-to-Consumer (DTC)](https://en.wikipedia.org/wiki/Direct-to-consumer)**: This is the most common manifestation of a disintermediation strategy.
 
+- [Two-Sided Markets](/strategies/ecosystem/two-factor-markets)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Shifts from product to utility tend to demonstrate a punctuated equilibrium](/climatic-patterns/shifts-from-product-to-utility-tend-to-demonstrate-a-punctuated-equilibrium) – trigger: direct channels emerge as industries commoditise.

--- a/docs/strategies/ecosystem/co-creation/index.md
+++ b/docs/strategies/ecosystem/co-creation/index.md
@@ -138,6 +138,11 @@ The core insight of co-creation is that value is not created by the company and 
 *   **[Open Approaches](/strategies/accelerators/open-approaches)**: Co-creation is a form of open innovation and often relies on open platforms and standards.
 *   **[Innovate-Leverage-Commoditize (ILC)](/strategies/ecosystem/innovate-leverage-commoditize)**: Co-creation can be a powerful input to the "Leverage" phase of the ILC cycle, providing clear signals about what to commoditize next.
 
+- [Cooperation](/strategies/accelerators/cooperation)
+- [Press Release Process](/strategies/attacking/press-release-process)
+- [Experimentation](/strategies/attacking/experimentation)
+- [Harvesting](/strategies/markets/harvesting)
+- [Differentiation](/strategies/markets/differentiation)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Components can co-evolve](/climatic-patterns/components-can-co-evolve) – influence: working directly with users shapes how products and practices mature together.

--- a/docs/strategies/ecosystem/co-opting/index.md
+++ b/docs/strategies/ecosystem/co-opting/index.md
@@ -131,6 +131,10 @@ This strategy is often used to neutralize a competitor's main weapon. By removin
 *   **[Fast Follower](/strategies/positional/fast-follower)**: A company that has a deliberate strategy of being a fast follower will be skilled at co-opting.
 *   **[Harvesting](/strategies/markets/harvesting)**: Similar in that it involves adopting an idea from the outside, but harvesting is typically aimed at the innovations of partners within your own ecosystem, whereas co-opting is aimed at external competitors.
 
+- [Threat Acquisition](/strategies/defensive/threat-acquisition)
+- [Center of Gravity](/strategies/attacking/centre-of-gravity)
+- [restriction-of-movement](/strategies/competitor/restriction-of-movement)
+- [fragmentation](/strategies/competitor/fragmentation)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – trigger: a rival's successful move often prompts co-opting as a counter.

--- a/docs/strategies/ecosystem/embrace-and-extend/index.md
+++ b/docs/strategies/ecosystem/embrace-and-extend/index.md
@@ -141,6 +141,10 @@ A strong, vibrant open-source community around a standard is one of the best def
 *   **[Lock-In](/terms/lock-in)**: The ultimate goal of this strategy is to create customer lock-in.
 *   **[Fear, Uncertainty, and Doubt (FUD)](/terms/fear-uncertainty-and-doubt)**: FUD is often used as a tactic to support an Embrace and Extend strategy by creating anxiety about the future of the open standard.
 
+- [Open Approaches](/strategies/accelerators/open-approaches)
+- [Co-opting](/strategies/ecosystem/co-opting)
+- [restriction-of-movement](/strategies/competitor/restriction-of-movement)
+- [fragmentation](/strategies/competitor/fragmentation)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Creative Destruction](/climatic-patterns/creative-destruction) – trigger: extending a standard can undermine incumbent approaches.

--- a/docs/strategies/ecosystem/innovate-leverage-commoditize/index.md
+++ b/docs/strategies/ecosystem/innovate-leverage-commoditize/index.md
@@ -155,6 +155,10 @@ This strategy is based on the insight that today's innovations are tomorrow's co
 *   **[Tower and Moat](/strategies/ecosystem/tower-and-moat)**: ILC is the engine that builds a powerful Tower and Moat. The Tower is the platform, and the Moat is built by continuously commoditizing complements.
 *   **[Fast Follower](/strategies/positional/fast-follower)**: The commoditization step is a form of fast-following the innovations of your own ecosystem.
 
+- [Weak Signal (Horizon)](/strategies/positional/weak-signal-horizon)
+- [Co-creation](/strategies/ecosystem/co-creation)
+- [Sweat & Dump](/strategies/dealing-with-toxicity/sweat-and-dump)
+- [Playing Both Sides](/strategies/attacking/playing-both-sides)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Components can co-evolve](/climatic-patterns/components-can-co-evolve) – trigger: nurturing an ecosystem accelerates mutual improvement.

--- a/docs/strategies/ecosystem/tower-and-moat/index.md
+++ b/docs/strategies/ecosystem/tower-and-moat/index.md
@@ -137,6 +137,7 @@ A Tower and Moat strategy is the ultimate positional play. It's not about having
 *   **[Embrace and Extend](/strategies/ecosystem/embrace-and-extend)**: A related strategy, but typically focused on co-opting an existing standard rather than building a new Tower.
 *   **[Raising Barriers to Entry](/strategies/defensive/raising-barriers-to-entry)**: The Moat is a powerful set of barriers to entry.
 
+- [Buyer-Supplier Power](/strategies/markets/buyer-supplier-power)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Shifts from product to utility show punctuated equilibrium](/climatic-patterns/shifts-from-product-to-utility-tend-to-demonstrate-a-punctuated-equilibrium) – trigger: rapid transitions create opportunities to build the tower.

--- a/docs/strategies/ecosystem/two-factor-markets/index.md
+++ b/docs/strategies/ecosystem/two-factor-markets/index.md
@@ -147,6 +147,7 @@ In a two-sided market, your product is not just a piece of software; it is the e
 *   **[Tower and Moat](/strategies/ecosystem/tower-and-moat)**: A successful two-sided market can create a very powerful moat.
 *   **[Channel Conflict and Disintermediation](/strategies/ecosystem/channel-conflict-and-disintermediation)**: Creating a two-sided market often involves disintermediating existing channels.
 
+- [Exploiting Network Effects](/strategies/accelerators/exploiting-network-effects)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Change is not always linear](/climatic-patterns/change-is-not-always-linear) – influence: once both sides engage, adoption can accelerate rapidly.

--- a/docs/strategies/markets/buyer-supplier-power/index.md
+++ b/docs/strategies/markets/buyer-supplier-power/index.md
@@ -144,6 +144,8 @@ Every value chain is also a power chain. Understanding this allows you to see th
 *   **[Standards Game](/strategies/markets/standards-game)**: A way to shift power dynamics by making your technology the industry standard.
 *   **[Vertical Integration](/terms/value-chain)**: A common tactic for directly controlling more of the value chain and altering power dynamics.
 
+- [Channel Conflict and Disintermediation](/strategies/ecosystem/channel-conflict-and-disintermediation)
+- [Pricing Policy](/strategies/markets/pricing-policy)
 ## 📚 **Further Reading & References**
 
 *   **[Competitive Strategy](https://www.goodreads.com/book/show/236901.Competitive_Strategy)** by Michael E. Porter. The classic text that introduced the "Five Forces" framework, which is central to understanding buyer-supplier power.

--- a/docs/strategies/markets/differentiation/index.md
+++ b/docs/strategies/markets/differentiation/index.md
@@ -142,6 +142,8 @@ Differentiation is useless if customers don't know about it or don't understand 
 *   **[Co-creation](/strategies/ecosystem/co-creation)**: Working directly with users is a great way to uncover meaningful opportunities for differentiation.
 *   **[Creating Artificial Needs](/strategies/user-perception/creating-artificial-needs)**: A risky and ethically questionable strategy that attempts to create differentiation through marketing rather than genuine user needs.
 
+- [Press Release Process](/strategies/attacking/press-release-process)
+- [Brand and Marketing](/strategies/user-perception/brand-and-marketing)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [The less evolved something is then the more uncertain it becomes](/climatic-patterns/the-less-evolved-something-is-then-the-more-uncertain-it-becomes) – trigger: differentiation flourishes when components are immature.

--- a/docs/strategies/markets/harvesting/index.md
+++ b/docs/strategies/markets/harvesting/index.md
@@ -145,6 +145,7 @@ At its best, harvesting is a symbiotic relationship. The ecosystem provides inno
 *   **[Co-opting](/strategies/ecosystem/co-opting)**: A related strategy where you might absorb a competitor's differentiation into your platform.
 *   **[Threat Acquisition](/strategies/defensive/threat-acquisition)**: Harvesting can sometimes be a defensive move to acquire a company that is becoming a threat.
 
+- [Market Enablement](/strategies/accelerators/market-enablement)
 ## 📚 **Further Reading & References**
 
 *   **[Platform Revolution](https://www.goodreads.com/book/show/26899832-platform-revolution)** by Geoffrey G. Parker, Marshall W. Van Alstyne, and Sangeet Paul Choudary. A comprehensive guide to platform business models.

--- a/docs/strategies/markets/last-man-standing/index.md
+++ b/docs/strategies/markets/last-man-standing/index.md
@@ -140,6 +140,8 @@ This strategy is a powerful example of Joseph Schumpeter's concept of "creative 
 *   **[Sweat and Dump](/strategies/dealing-with-toxicity/sweat-and-dump)**: You might use this to offload non-essential assets before embarking on a war of attrition.
 *   **[Exploiting Constraint](/strategies/decelerators/exploiting-constraint)**: If competitors are constrained (e.g., by supply chain issues), you can accelerate their demise.
 
+- [Exploiting Network Effects](/strategies/accelerators/exploiting-network-effects)
+- [Confusion of Choice](/strategies/user-perception/confusion-of-choice)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Economy has cycles](/climatic-patterns/economy-has-cycles) – trigger: attrition strategies often surface during war phases when the market contracts.

--- a/docs/strategies/markets/signal-distortion/index.md
+++ b/docs/strategies/markets/signal-distortion/index.md
@@ -143,6 +143,7 @@ Signal Distortion is a powerful reminder that in many markets, the perception of
 *   **[First Mover](/strategies/positional/first-mover)**: The *perception* of being a first mover can be a powerful signal, even if it's not entirely true.
 *   **[Fear, Uncertainty, and Doubt (FUD)](/terms/fear-uncertainty-and-doubt)**: A specific tactic of signal distortion focused on creating negative perceptions about a competitor.
 
+- [Fool's Mate](/strategies/attacking/fools-mate)
 ## 📚 **Further Reading & References**
 
 *   **[Trust Me, I'm Lying: Confessions of a Media Manipulator](https://www.goodreads.com/book/show/13542853-trust-me-i-m-lying)** by Ryan Holiday. A stark look at how media can be manipulated.

--- a/docs/strategies/markets/standards-game/index.md
+++ b/docs/strategies/markets/standards-game/index.md
@@ -150,6 +150,15 @@ Competitors may attempt embrace-and-extend tactics or create alternative allianc
 - [Raising Barriers to Entry](/strategies/defensive/raising-barriers-to-entry) – Standards can raise compliance costs for newcomers.
 - [Designed to Fail](/strategies/poison/designed-to-fail) – Poisoning rival standards can clear the field for your own.
 
+- [Cooperation](/strategies/accelerators/cooperation)
+- [Industrial Policy](/strategies/accelerators/industrial-policy)
+- [Exploiting Network Effects](/strategies/accelerators/exploiting-network-effects)
+- [Market Enablement](/strategies/accelerators/market-enablement)
+- [Limitation of Competition](/strategies/defensive/limitation-of-competition)
+- [Embrace and Extend](/strategies/ecosystem/embrace-and-extend)
+- [Alliances](/strategies/ecosystem/alliances)
+- [Playing Both Sides](/strategies/attacking/playing-both-sides)
+- [Buyer-Supplier Power](/strategies/markets/buyer-supplier-power)
 ## 📚 **Further Reading & References**
 
 - [USB Implementers Forum](https://www.usb.org/) – Example of industry coordination driving a ubiquitous standard.

--- a/docs/strategies/poison/designed-to-fail/index.md
+++ b/docs/strategies/poison/designed-to-fail/index.md
@@ -161,6 +161,7 @@ These initiatives are not meant to last. Their purpose is to occupy space, creat
 - [Insertion](/strategies/poison/insertion) — embedding flawed influence via people.
 - [Licensing](/strategies/poison/licensing) — controlling ecosystems through legal terms.
 
+- [Standards Game](/strategies/markets/standards-game)
 ## 📚 **Further Reading & References**
 
 - [HD DVD vs Blu-ray (Wikipedia)](https://en.wikipedia.org/wiki/HD_DVD) — a case of market fragmentation leading to failure.

--- a/docs/strategies/positional/fast-follower/index.md
+++ b/docs/strategies/positional/fast-follower/index.md
@@ -151,6 +151,10 @@ Superior processes, cost structures, and delivery models can overcome first-move
 - [Weak Signal Horizon](/strategies/positional/weak-signal-horizon) – to detect and act on market shifts.
 - [Experimentation](/strategies/attacking/experimentation) – to test new ideas on a small scale before wider deployment.
 
+- [Procrastination](/strategies/defensive/procrastination)
+- [Innovate, Leverage, Commoditize (ILC)](/strategies/ecosystem/innovate-leverage-commoditize)
+- [Co-opting](/strategies/ecosystem/co-opting)
+- [Press Release Process](/strategies/attacking/press-release-process)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Change is not always linear](/climatic-patterns/change-is-not-always-linear) – trigger: wait until the market shows a clear acceleration before following.

--- a/docs/strategies/positional/first-mover/index.md
+++ b/docs/strategies/positional/first-mover/index.md
@@ -144,6 +144,9 @@ Heavy upfront investment requires clear signals and strong governance to avoid w
 - [Land Grab](/strategies/positional/land-grab) – to secure critical infrastructure or resources early.
 - [Weak Signal Horizon](/strategies/positional/weak-signal-horizon) – to detect opportunities before committing as a First Mover.
 
+- [Directed Investment](/strategies/attacking/directed-investment)
+- [Differentiation](/strategies/markets/differentiation)
+- [Signal Distortion](/strategies/markets/signal-distortion)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – trigger: industrialising a component early can accelerate its evolution.

--- a/docs/strategies/positional/land-grab/index.md
+++ b/docs/strategies/positional/land-grab/index.md
@@ -144,6 +144,8 @@ Maintain agility by planning divestment or spin-off strategies for positions tha
 - [Fast Follower](/strategies/positional/fast-follower) – to enter after pioneers have cleared the path.
 - [Weak Signal Horizon](/strategies/positional/weak-signal-horizon) – to detect where to grab land early.
 
+- [Exploiting Network Effects](/strategies/accelerators/exploiting-network-effects)
+- [Bundling](/strategies/user-perception/bundling)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Rates of evolution can vary by ecosystem](/climatic-patterns/rates-of-evolution-can-vary-by-ecosystem) – trigger: faster-moving landscapes reward early positioning.

--- a/docs/strategies/positional/weak-signal-horizon/index.md
+++ b/docs/strategies/positional/weak-signal-horizon/index.md
@@ -145,6 +145,9 @@ Effective sensing requires an organisational culture that values and acts on ear
 - [Fast Follower](/strategies/positional/fast-follower) – to time entry based on pioneer signals.
 - [Innovate-Leverage-Commoditize (ILC)](/strategies/ecosystem/innovate-leverage-commoditize) – building infrastructure for systematic data collection.
 
+- [Procrastination](/strategies/defensive/procrastination)
+- [Experimentation](/strategies/attacking/experimentation)
+- [Directed Investment](/strategies/attacking/directed-investment)
 ## 📚 **Further Reading & References**
 
 - Wardley, S. – [*Anticipation*](https://blog.gardeviance.org/2016/12/anticipation.html) – foundational concepts on sensing and foresight.

--- a/docs/strategies/user-perception/brand-and-marketing/index.md
+++ b/docs/strategies/user-perception/brand-and-marketing/index.md
@@ -158,6 +158,8 @@ Effective branding requires thinking beyond immediate sales. It involves alignin
 - [Fear, Uncertainty and Doubt](/strategies/user-perception/fear-uncertainty-and-doubt) - Counterplay competitors might use.
 - [Differentiation](/strategies/markets/differentiation) - Highlighting unique selling points.
 
+- [Press Release Process](/strategies/attacking/press-release-process)
+- [Creating Artificial Needs](/strategies/user-perception/creating-artificial-needs)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – influence: brand messages must adapt as products mature.

--- a/docs/strategies/user-perception/creating-artificial-needs/index.md
+++ b/docs/strategies/user-perception/creating-artificial-needs/index.md
@@ -143,6 +143,8 @@ Counter-strategies often involve education, promoting conscious consumerism, or 
 - [Brand & Marketing](/strategies/user-perception/brand-and-marketing) - Central to creating needs via messaging.
 - [Education](/strategies/user-perception/education) - A more genuine way to create need by informing why something is important; in artificial needs, the education might be closer to propaganda.
 
+- [Differentiation](/strategies/markets/differentiation)
+- [Signal Distortion](/strategies/markets/signal-distortion)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Future value is inversely proportional to the certainty we have over it](/climatic-patterns/future-value-is-inversely-proportional-to-the-certainty-we-have-over-it) – trigger: manufactured demand bets on speculative future gains.

--- a/docs/strategies/user-perception/education/index.md
+++ b/docs/strategies/user-perception/education/index.md
@@ -139,6 +139,8 @@ The effectiveness of education strategies often varies with market and product e
 - [Fear, Uncertainty & Doubt (FUD)](/strategies/user-perception/fear-uncertainty-and-doubt) - The "dark side" alternative of influencing perception with fear.
 - [Open Approaches](/strategies/accelerators/open-approaches) - Sometimes educating about an open standard to drive its adoption.
 
+- [Press Release Process](/strategies/attacking/press-release-process)
+- [Creating Artificial Needs](/strategies/user-perception/creating-artificial-needs)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Future value is inversely proportional to the certainty we have over it](/climatic-patterns/future-value-is-inversely-proportional-to-the-certainty-we-have-over-it) – trigger: learning prepares for uncertain opportunities.

--- a/docs/strategies/user-perception/fear-uncertainty-and-doubt/index.md
+++ b/docs/strategies/user-perception/fear-uncertainty-and-doubt/index.md
@@ -162,6 +162,9 @@ The ethical spectrum of FUD is broad, from aggressive but legitimate competition
 - [Misdirection](/strategies/competitor/misdirection) – Another deceptive tactic.
 - [Lobbying](/strategies/user-perception/lobbying) – Using fear-based arguments in regulatory affairs is essentially FUD toward policymakers.
 
+- [Education](/strategies/user-perception/education)
+- [Confusion of Choice](/strategies/user-perception/confusion-of-choice)
+- [Brand and Marketing](/strategies/user-perception/brand-and-marketing)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [The less evolved something is then the more uncertain it becomes](/climatic-patterns/the-less-evolved-something-is-then-the-more-uncertain-it-becomes) – trigger: sowing doubt exploits the unknowns around emerging tech.

--- a/docs/strategies/user-perception/lobbying/index.md
+++ b/docs/strategies/user-perception/lobbying/index.md
@@ -161,6 +161,7 @@ Aligning with user or public interest narratives increases the chance of success
 - [Industrial Policy](/strategies/accelerators/industrial-policy) – Aligning with government investment or strategic priorities.
 - [Raising Barriers to Entry](/strategies/defensive/raising-barriers-to-entry) – Shaping market/customer expectations, sometimes via lobbying.
 
+- [Fear, Uncertainty and Doubt](/strategies/user-perception/fear-uncertainty-and-doubt)
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Economy has cycles](/climatic-patterns/economy-has-cycles) – trigger: lobbying efforts intensify when markets contract.

--- a/scripts/add_related_links.py
+++ b/scripts/add_related_links.py
@@ -2,6 +2,7 @@ import os
 import re
 import csv
 import sys
+from typing import List, Dict
 
 STRATEGY_DIR = os.path.join('docs', 'strategies')
 link_pattern = re.compile(r'\[[^\]]+\]\((/strategies[^)\s#]+)')
@@ -64,42 +65,66 @@ def collect_docs():
     return docs, related_map, section_map
 
 
+def insert_into_related(slug: str, targets: List[str], section_map: Dict[str, bool]):
+    path = slug_to_path(slug)
+    with open(path, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+
+    if section_map.get(slug):
+        idx = next(i for i, l in enumerate(lines) if 'Related Strategies' in l)
+        insert_idx = idx + 1
+        while insert_idx < len(lines) and not lines[insert_idx].startswith('#'):
+            insert_idx += 1
+        new_lines = [f"- [{get_title(t)}]({t})\n" for t in targets]
+        lines[insert_idx:insert_idx] = new_lines
+    else:
+        header = "## 🔀 **Related Strategies**\n"
+        new_lines = [header] + [f"- [{get_title(t)}]({t})\n" for t in targets] + ["\n"]
+        insert_idx = None
+        for i, l in enumerate(lines):
+            if 'Further Reading & References' in l:
+                insert_idx = i
+                break
+        if insert_idx is None:
+            lines.extend(['\n'] + new_lines)
+        else:
+            lines[insert_idx:insert_idx] = new_lines
+
+    with open(path, 'w', encoding='utf-8') as f:
+        f.writelines(lines)
+
+
 def add_links():
     docs, related_map, section_map = collect_docs()
     writer = csv.writer(sys.stdout)
     writer.writerow(['source', 'target'])
     count = 0
+
+    # Ensure links found in the document appear in its Related Strategies section
     for src, targets in docs.items():
         missing = [t for t in targets if t in docs and t not in related_map[src]]
-        if not missing:
-            continue
-        path = slug_to_path(src)
-        with open(path, 'r', encoding='utf-8') as f:
-            lines = f.readlines()
-        if section_map[src]:
-            idx = next(i for i, l in enumerate(lines) if 'Related Strategies' in l)
-            insert_idx = idx + 1
-            while insert_idx < len(lines) and not lines[insert_idx].startswith('#'):
-                insert_idx += 1
-            new_lines = [f"- [{get_title(t)}]({t})\n" for t in missing]
-            lines[insert_idx:insert_idx] = new_lines
-        else:
-            header = "## 🔀 **Related Strategies**\n"
-            new_lines = [header] + [f"- [{get_title(t)}]({t})\n" for t in missing] + ["\n"]
-            insert_idx = None
-            for i, l in enumerate(lines):
-                if 'Further Reading & References' in l:
-                    insert_idx = i
-                    break
-            if insert_idx is None:
-                lines.extend(['\n'] + new_lines)
-            else:
-                lines[insert_idx:insert_idx] = new_lines
-        with open(path, 'w', encoding='utf-8') as f:
-            f.writelines(lines)
-        for t in missing:
-            writer.writerow([src, t])
+        if missing:
+            insert_into_related(src, missing, section_map)
+            for t in missing:
+                writer.writerow([src, t])
+                count += 1
+
+    # Re-collect after modifications
+    docs, related_map, section_map = collect_docs()
+
+    # Add reciprocal links where target does not link back
+    reciprocal_map: Dict[str, List[str]] = {}
+    for src, targets in docs.items():
+        for tgt in targets:
+            if tgt in docs and src not in docs[tgt]:
+                reciprocal_map.setdefault(tgt, []).append(src)
+
+    for tgt, srcs in reciprocal_map.items():
+        insert_into_related(tgt, srcs, section_map)
+        for s in srcs:
+            writer.writerow([tgt, s])
             count += 1
+
     print(count, file=sys.stderr)
 
 


### PR DESCRIPTION
## Summary
- update `add_related_links.py` to add reciprocal links without any explanation text
- remove leftover "reciprocal link" explanations from strategy docs

## Testing
- `npm install`
- `npm test`
- `pytest tests/test_content_quality.py::test_reciprocal_strategy_links -q`
- `pytest -q` *(fails: test_related_strategy_links_are_explained, test_strategy_headings_in_order)*

------
https://chatgpt.com/codex/tasks/task_e_6861c1bf951c832b9f36e92f939089cb