### PR TITLE
Fix: Correct strategy document heading order and formatting

### DIFF
--- a/docs/strategies/accelerators/cooperation/index.md
+++ b/docs/strategies/accelerators/cooperation/index.md
@@ -22,7 +22,6 @@ It sounds straightforward, but as Wardley wryly notes, "sounds easy, actually it
 <AssessmentToolAdvert strategyName="Cooperation" />
 
 ## 🤔 **Explanation**
-
 ### What is Cooperation
 
 **Cooperation** in this context is a broad strategy involving collaboration between entities to achieve mutual goals. It encompasses a range of practices, from informal knowledge sharing to formal alliances and joint ventures. See [Alliances](/strategies/ecosystem/alliances) for a more structured, formal subset of cooperation.
@@ -92,8 +91,22 @@ mindmap
       Exit Strategies
 ```
 
-## 🚦 **When to Use / When to Avoid**
+## 🗺️ **Real-World Examples**
+### The Sony-Ericsson partnership (early 2000s)
 
+Sony had consumer electronics expertise, Ericsson had telecom infrastructure and phone tech. They cooperated to create Sony-Ericsson mobile phones, each filling gaps in the other's capabilities. This cooperation allowed them to compete in mobile phones against larger rivals (Nokia, etc.) with a combined strength neither had alone.
+
+### The Bluetooth SIG (Special Interest Group)
+
+[![Bluetooth SIG Wardley map](bluetooth-sig-wardley-map.svg)](https://onlinewardleymaps.com/#Rn7EaUmb1KfengeImh)
+
+ An industry cooperation of many companies (Ericsson, Nokia, IBM, Intel, etc.) to develop the Bluetooth standard. Instead of fighting over wireless peripheral connectivity solutions, they cooperated to establish one standard. This expanded the market for everyone's interoperable devices and accelerated Bluetooth's evolution.
+
+### Hypothetical examples
+
+Two mid-sized pharmaceutical firms co-develop a drug for a rare disease. Each firm had a candidate compound; instead of running two costly parallel trials, they form a cooperative agreement to test a combined therapy and share data. By cooperating, they cut R&D time and cost, and if successful, both share the market (perhaps each selling in different regions). They achieved faster evolution of a treatment than either could alone.
+
+## 🚦 **When to Use / When to Avoid**
 <Assessment strategyName="Cooperation">
   <MapSignals>
     <li>We’re addressing a component in the Genesis or Custom stage that is too large, risky, or slow to develop alone.</li>
@@ -123,25 +136,7 @@ The **task is too large, risky, or slow** to do alone, and partners have complem
 
 Your goals and potential partners' goals fundamentally clash. Forced cooperation can implode (e.g., if co-development means you later directly compete with the jointly created product, tensions arise). Also avoid if cooperating would give a weaker competitor undue advantage that they can then use against you. If you have the means to win outright, cooperation might unnecessarily share the spoils.
 
-
-## 🗺️ **Real-World Examples**
-
-### The Sony-Ericsson partnership (early 2000s)
-
-Sony had consumer electronics expertise, Ericsson had telecom infrastructure and phone tech. They cooperated to create Sony-Ericsson mobile phones, each filling gaps in the other's capabilities. This cooperation allowed them to compete in mobile phones against larger rivals (Nokia, etc.) with a combined strength neither had alone.
-
-### The Bluetooth SIG (Special Interest Group)
-
-[![Bluetooth SIG Wardley map](bluetooth-sig-wardley-map.svg)](https://onlinewardleymaps.com/#Rn7EaUmb1KfengeImh)
-
- An industry cooperation of many companies (Ericsson, Nokia, IBM, Intel, etc.) to develop the Bluetooth standard. Instead of fighting over wireless peripheral connectivity solutions, they cooperated to establish one standard. This expanded the market for everyone's interoperable devices and accelerated Bluetooth's evolution.
-
-### Hypothetical examples
-
-Two mid-sized pharmaceutical firms co-develop a drug for a rare disease. Each firm had a candidate compound; instead of running two costly parallel trials, they form a cooperative agreement to test a combined therapy and share data. By cooperating, they cut R&D time and cost, and if successful, both share the market (perhaps each selling in different regions). They achieved faster evolution of a treatment than either could alone.
-
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 A leader must **balance control and openness**. Cooperation can accelerate innovation but also risks creating dependencies or eroding unique advantages. Effective leadership in cooperation means structuring agreements that align interests while maintaining strategic flexibility.
@@ -151,7 +146,6 @@ A leader must **balance control and openness**. Cooperation can accelerate innov
 fostering trust, managing alliances, setting governance rules
 
 ## 📋 **How to Execute**
-
 1. Assess alignment and goals
    - alignment: Incentive structuring: Revenue-sharing models, IP-sharing agreements, performance-based milestones
 2. Define governance
@@ -163,7 +157,6 @@ fostering trust, managing alliances, setting governance rules
 ### Ethical considerations
 
 ## 📈 **Measuring Success**
-
 - Speed metrics: Reduction in time-to-market or development cycles compared to solo efforts
 - Cost efficiency: Reduced R&D or market-entry costs versus going alone
 - Market creation: Growth in total addressable market (especially for standards-based cooperation)
@@ -174,7 +167,6 @@ fostering trust, managing alliances, setting governance rules
 - Innovation rate: Number of new features, products, or methods developed through the partnership
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Alignment issues
 
 Cooperation can fail due to misaligned incentives (one party might freeride or diverge later). Clear agreements and exit strategies are crucial.
@@ -199,7 +191,6 @@ Partnerships mean committees: things can move slower than a single, decisive ent
 If one side unilaterally exploits the partnership (e.g., learns from cooperation then goes solo), it can lead to sour relations or even legal battles.
 
 ## 🧠 **Strategic Insights**
-
 ### Evolution and Cooperation
 
 Cooperation strategies differ dramatically based on component evolution stage:
@@ -244,9 +235,7 @@ Successful cooperation often targets specific *leverage points*:
 
 Use alliances when the goal is ecosystem-level impact or when formality helps secure trust and alignment.
 
-
 ## ❓ **Key Questions to Ask**
-
 - Value alignment: What specific value does each party bring and extract? Are these balanced and sustainable?
 - Evolution stage: Where on the evolution curve are the components we're collaborating on? (Genesis, Custom, Product, Commodity)
 - Power dynamics: Will this cooperation create dependencies we can't easily escape? Who ultimately controls critical interfaces?
@@ -256,17 +245,15 @@ Use alliances when the goal is ecosystem-level impact or when formality helps se
 - Exit scenarios: Under what conditions should we
 
 ## 🔀 **Related Strategies**
-
 - [**Alliances**](/strategies/ecosystem/alliances) - a formalized group of cooperating entities, essentially the same domain
 - [**Co-creation**](/strategies/ecosystem/co-creation) - a form of cooperation with *users*
 - [**Circling and Probing**](/strategies/competitor/circling-and-probing) - is opposite: testing a competitor rather than working with them.
 - [Standards Game](/strategies/markets/standards-game) - cooperation often aims to establish common standards and reduce friction.
 
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Components can co-evolve](/climatic-patterns/components-can-co-evolve) – influence: collaboration shapes how capabilities mature together.
 - [Economy has cycles](/climatic-patterns/economy-has-cycles) – trigger: shifts from peace to war often spur new partnerships.
-## 📚 **Further Reading & References**
 
+## 📚 **Further Reading & References**
 - [On 61 different forms of gameplay](https://blog.gardeviance.org/2015/05/on-61-different-forms-of-gameplay.html) on Simon Wardley's Blog. *"Cooperation: Working with others... not easy."* . Underscores that while straightforward in concept, the execution of cooperation is challenging.
 -  HBR Article [*"Simple Rules for Making Alliances Work"*](https://hbr.org/2007/11/simple-rules-for-making-alliances-work) - details best practices and pitfalls in strategic cooperations (e.g., the necessity of aligned incentives and trust-building measures).

--- a/docs/strategies/accelerators/exploiting-network-effects/index.md
+++ b/docs/strategies/accelerators/exploiting-network-effects/index.md
@@ -19,7 +19,6 @@ This accelerates adoption in a self-reinforcing loop. In practice, it means stru
 <AssessmentToolAdvert strategyName="Network Effects" />
 
 ## 🤔 **Explanation**
-
 ### What are Network Effects and how are they exploited?
 
 Network effects drive value and competitive advantage in the digital economy. The value a user gains from a service increases with the number of other users. This creates **positive feedback loops**, where new users improve the service for existing users, driving further adoption and potential market dominance.
@@ -124,9 +123,21 @@ The origin of these plays is in platform economics. The purpose is to achieve lo
 - Removing friction for new users.
 - Sometimes subsidizing one side of a platform to benefit the other (e.g., paying drivers to join a ride-share to improve service for riders).
 
+## 🗺️ **Real-World Examples**
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```
+
+- **iOS and Android:** *Indirect network effects* based on their extensive app ecosystems.
+- **Telephone:** Classic example of *direct network effects*.
+- **WhatsApp:** Relies on *direct network effects* for messaging.
+- **Financial Exchanges (e.g., Chicago Board of Trade):** Maintained dominance through *network effects* related to liquidity.
+- **LinkedIn:** Benefits from *direct network effects* among professionals.
+
 ## 🚦 **When to Use / When to Avoid**
- 
- <Assessment strategyName="Network Effects">
+<Assessment strategyName="Network Effects">
   <MapSignals>
     <li>The value of our offering increases for each user as more users join (same-side or cross-side).</li>
     <li>We’re building or operating a platform, marketplace, or system with two or more interdependent user groups.</li>
@@ -155,22 +166,7 @@ Use when your business model naturally has network effects (social media, market
 
 Avoid when Network effects are weak or nonexistent. If your product doesn't actually get better with more users, focusing on pure volume can just lead to low-quality growth and strain resources. Also avoid overspending on growth if you're in a niche where quality or profit per user matters more (network effects often pair with winner-take-all outcomes. If that's not your market, this strategy might not pay off).
 
-## 🗺️ **Real-World Examples**
-
-```mdx-code-block
-import DocCardList from '@theme/DocCardList';
-
-<DocCardList />
-```
-
-- **iOS and Android:** *Indirect network effects* based on their extensive app ecosystems.
-- **Telephone:** Classic example of *direct network effects*.
-- **WhatsApp:** Relies on *direct network effects* for messaging.
-- **Financial Exchanges (e.g., Chicago Board of Trade):** Maintained dominance through *network effects* related to liquidity.
-- **LinkedIn:** Benefits from *direct network effects* among professionals.
-
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 - Overcoming the "chicken and egg problem" in two-sided networks (how to attract initial users on both sides).
@@ -184,7 +180,6 @@ import DocCardList from '@theme/DocCardList';
 - Proactive management to address potential negative network effects
 
 ## 📋 **How to Execute**
-
 ### Early Adoption Strategies: Overcoming the Chicken-and-Egg Problem
 
 Building two-sided platforms requires solving the "chicken and egg problem" of attracting both user groups. Common solutions include: subsidizing one side to encourage early adoption (e.g., discounted rides or driver bonuses), targeting niche markets for focused growth, or offering initial value independent of network size, like unique features or content.
@@ -218,7 +213,6 @@ Maintaining network effects requires increasing user interconnectedness and fost
 Ethical considerations are crucial in managing network effects. Preventing **monopolies** and ensuring fair competition is essential. Platforms must prioritize user safety and data privacy, and balance free expression with responsible content moderation. Equitable access is vital to avoid digital divides and ensure the benefits of network effects are distributed fairly.
 
 ## 📈 **Measuring Success**
-
 - Network size and growth rate.
 - User engagement and retention.
 - Value per user.
@@ -227,7 +221,6 @@ Ethical considerations are crucial in managing network effects. Preventing **mon
 - Customer acquisition cost.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 - **Burning cash without strategy:** Many chase user numbers without a path to monetize the network later (leading to unsustainable "bubble" growth).
 - **Ignoring other value drivers:** Network effects alone don't solve everything: you still need user satisfaction. For example, if quality drops as you grow (common in gig platforms), network advantages can vanish if people churn out.
 - **Overestimation:** Sometimes network effects plateau; assuming infinite increasing returns can be false. E.g., after a point, adding more users might not add value (if the network is saturated or gets noisy).
@@ -239,7 +232,6 @@ Ethical considerations are crucial in managing network effects. Preventing **mon
 - Not recognising that **network effects are distinct from viral effects**: while viral growth can help acquire new users, network effects are about creating defensibility and increasing the value of the product for existing users with each new addition 9.
 
 ## 🧠 **Strategic Insights**
-
 ### Evolution and Exploiting Network Effects
 
 Achieving critical mass is a pivotal force that shapes the trajectory of a component’s evolution within a value chain.
@@ -257,7 +249,6 @@ In summary, understanding the timing and mechanisms for achieving critical mass 
 Focus on creating value for users and facilitating connections and interactions.
 
 ## ❓ **Key Questions to Ask**
-
 - What type of network effects are relevant to my business?
 - How can I design my product or platform to maximize network effects?
 - What are the key challenges and potential pitfalls in exploiting network effects?
@@ -265,19 +256,16 @@ Focus on creating value for users and facilitating connections and interactions.
 - How can I maintain and strengthen network effects over time?
 
 ## 🔀 **Related Strategies**
-
 - [**Land Grab**](/strategies/positional/land-grab) - often used to quickly build the network
 - [**Last Man Standing**](/strategies/markets/last-man-standing) - network effects can contribute to becoming the last survivor
 - [**Two-Factor Markets**](/strategies/ecosystem/two-factor-markets) - explicitly building both sides of a network to exploit cross-side network effects
 - [**Standards Game**](/strategies/markets/standards-game) - Companies sometimes engage in standards warfare hoping their technology becomes the de facto standard (network), thus locking in an ecosystem.
 
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Change is not always linear](/climatic-patterns/change-is-not-always-linear) – influence: network effects often produce sudden, exponential adoption curves.
 - [No choice on evolution](/climatic-patterns/no-choice-on-evolution) – trigger: once a network dominates, others must join to remain competitive.
 
 ## 📚 **Further Reading & References**
-
 - [Network effect - Wikipedia](https://en.wikipedia.org/wiki/Network_effect)
 - [What Is the Network Effect? - Investopedia](https://www.investopedia.com/terms/n/network-effect.asp)
 - [What Are Network Effects? | HBS Online](https://online.hbs.edu/blog/post/what-are-network-effects)

--- a/docs/strategies/accelerators/industrial-policy/index.md
+++ b/docs/strategies/accelerators/industrial-policy/index.md
@@ -23,29 +23,28 @@ core_challenge: Balancing public objectives with private strategic goals.
 <AssessmentToolAdvert strategyName="Industrial Policy" />
 
 ## 🤔 **Explanation**
-
 ### What is Industrial Policy?
 
 **Industrial Policy** refers to deliberate actions by governments to support strategic industries through instruments such as subsidies, tax incentives, public procurement, regulation, or infrastructure investment. For organizations, it involves aligning with or influencing these policies to de-risk investments, secure funding, and shape market conditions in their favor.
 
 ### Why use Industrial Policy?
 
-- De-risks high-capital projects with public funding or guarantees  
-- Accelerates R&D and innovation through targeted grants or contracts  
-- Creates market demand via government procurement or mandated standards  
-- Shapes regulatory environments to lower barriers or secure competitive advantages  
+- De-risks high-capital projects with public funding or guarantees
+- Accelerates R&D and innovation through targeted grants or contracts
+- Creates market demand via government procurement or mandated standards
+- Shapes regulatory environments to lower barriers or secure competitive advantages
 - Builds strategic autonomy in critical sectors (e.g., semiconductors, green energy)
 
 ### How it works
 
 Organizations can engage in industrial policy by:
 
-1. Mapping policy priorities and timelines  
-2. Building relationships with policymakers and influencers  
-3. Framing proposals to align corporate goals with public objectives  
+1. Mapping policy priorities and timelines
+2. Building relationships with policymakers and influencers
+3. Framing proposals to align corporate goals with public objectives
 4. Piloting projects or proofs of concept to demonstrate value
-5. Securing grants, subsidies, or favorable contracts  
-6. Ensuring compliance and maintaining stakeholder trust  
+5. Securing grants, subsidies, or favorable contracts
+6. Ensuring compliance and maintaining stakeholder trust
 
 ### Forms of Industrial Policy
 
@@ -75,8 +74,14 @@ Organizations can engage in industrial policy by:
 >       Compliance
 > ```
 
-## 🚦 **When to Use / When to Avoid**
+## 🗺️ **Real-World Examples**
+**Historical:** Aerospace industry funding – Boeing and Airbus grew rapidly on the back of government defense contracts, direct subsidies, and co-ownership arrangements, accelerating innovation and scale beyond pure private investment.
 
+**Contemporary:** China’s EV sector – extensive subsidies, infrastructure development, and manufacturing incentives propelled companies like BYD and NIO to global competitiveness years ahead of market-driven timelines.
+
+**Hypothetical:** A renewable energy startup partners with a national green infrastructure program, securing R&D grants and guaranteed off-take contracts for pilot wave energy projects, dramatically reducing risk and time-to-market.
+
+## 🚦 **When to Use / When to Avoid**
 <Assessment strategyName="Industrial Policy">
   <MapSignals>
     <li>Government announces initiatives or budgets for your sector (e.g., green technology, defense, semiconductors).</li>
@@ -100,57 +105,44 @@ The long-term benefits of public funding, market guarantees, or regulatory suppo
 
 Policy cycles are highly uncertain or slow, funding strings create strategic constraints, or overreliance on state support risks future agility.
 
-## 🗺️ **Real-World Examples**
-
-**Historical:** Aerospace industry funding – Boeing and Airbus grew rapidly on the back of government defense contracts, direct subsidies, and co-ownership arrangements, accelerating innovation and scale beyond pure private investment.
-
-**Contemporary:** China’s EV sector – extensive subsidies, infrastructure development, and manufacturing incentives propelled companies like BYD and NIO to global competitiveness years ahead of market-driven timelines.
-
-**Hypothetical:** A renewable energy startup partners with a national green infrastructure program, securing R&D grants and guaranteed off-take contracts for pilot wave energy projects, dramatically reducing risk and time-to-market.
-
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 Balancing public objectives with private strategic goals, maintaining agility while managing government oversight and stakeholder expectations.
 
 ### Key leadership skills
 
-- Political acumen and stakeholder management  
-- Strategic framing and narrative building  
-- Compliance oversight and governance  
+- Political acumen and stakeholder management
+- Strategic framing and narrative building
+- Compliance oversight and governance
 - Coalition building across public and private sectors
 
 ## 📋 **How to Execute**
-
-1. Scan and map relevant policy landscapes and funding programs.  
-2. Form cross-functional teams (policy, legal, technical, finance) for engagement.  
-3. Develop aligned proposals highlighting mutual benefits.  
-4. Engage in pilot or demonstrator projects with clear success metrics.  
-5. Negotiate terms for subsidies, tax breaks, or public procurement.  
-6. Implement governance structures for compliance and reporting.  
-7. Monitor policy changes and adapt strategy accordingly.  
+1. Scan and map relevant policy landscapes and funding programs.
+2. Form cross-functional teams (policy, legal, technical, finance) for engagement.
+3. Develop aligned proposals highlighting mutual benefits.
+4. Engage in pilot or demonstrator projects with clear success metrics.
+5. Negotiate terms for subsidies, tax breaks, or public procurement.
+6. Implement governance structures for compliance and reporting.
+7. Monitor policy changes and adapt strategy accordingly.
 8. Plan exit or diversification to avoid overdependence.
 
 ## 📈 **Measuring Success**
-
-- Public funding secured (amount and terms)  
-- Accelerated project timelines versus baseline  
-- Regulatory approvals or standards adoption  
-- Market share or volume growth enabled by policy support  
-- Cost-of-capital reduction  
+- Public funding secured (amount and terms)
+- Accelerated project timelines versus baseline
+- Regulatory approvals or standards adoption
+- Market share or volume growth enabled by policy support
+- Cost-of-capital reduction
 - Successful audits and stakeholder satisfaction
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
-- Overdependence on a single policy program or government sponsor.  
-- Neglecting market viability in favor of subsidy-driven activities.  
-- Bureaucratic delays undermining agility.  
-- Public backlash over perceived unfair advantages.  
+- Overdependence on a single policy program or government sponsor.
+- Neglecting market viability in favor of subsidy-driven activities.
+- Bureaucratic delays undermining agility.
+- Public backlash over perceived unfair advantages.
 - Policy reversals exposing strategic gaps.
 
 ## 🧠 **Strategic Insights**
-
 ### Aligning with National Champions vs. Fostering Ecosystems
 Industrial policy can take the form of backing national champions (betting on a few large players) or fostering a broader ecosystem of innovation. Leadership must understand the nuances of the specific policy they are engaging with. Aligning with a "national champion" approach might offer significant scale but also carries risks if that champion falters. Ecosystem approaches might offer more resilience but require navigating a more complex set of relationships.
 
@@ -161,7 +153,6 @@ While subsidies can accelerate development and market entry, they can also disto
 Industrial policies are subject to political winds and can change with new administrations or shifting national priorities. Companies leveraging industrial policy must build in resilience to these shifts, perhaps by diversifying their reliance across different programs or geographies, or by ensuring their core value proposition remains strong even without specific policy support.
 
 ## ❓ **Key Questions to Ask**
-
 - **Alignment:** How does this specific industrial policy align with our long-term strategic goals, beyond the immediate financial incentives?
 - **Capabilities:** Do we have the internal capabilities (e.g., for grant application, compliance, lobbying) to effectively engage with this policy?
 - **Risk Mitigation:** What are the primary risks associated with this policy (e.g., political change, dependency, reputational risk), and how can we mitigate them?
@@ -170,18 +161,15 @@ Industrial policies are subject to political winds and can change with new admin
 - **Ethical Considerations:** Are there any ethical concerns or potential negative externalities associated with this policy or our involvement in it?
 
 ## 🔀 **Related Strategies**
-
-- [Lobbying](/strategies/user-perception/lobbying) - influencing policy is a core tactic within industrial policy.  
-- [Market Enablement](/strategies/accelerators/market-enablement) - government backing can create or expand markets.  
+- [Lobbying](/strategies/user-perception/lobbying) - influencing policy is a core tactic within industrial policy.
+- [Market Enablement](/strategies/accelerators/market-enablement) - government backing can create or expand markets.
 - [Standards Game](/strategies/markets/standards-game) - industrial policy often promotes standards to secure advantage.
 
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Capital flows to new areas of value](/climatic-patterns/capital-flows-to-new-areas-of-value) – influence: government investment channels funds toward targeted sectors.
 - [Economy has cycles](/climatic-patterns/economy-has-cycles) – trigger: policy support often intensifies during war or wonder phases.
 
 ## 📚 **Further Reading & References**
-
-- Wardley, S. – *On Industrial Policy and Strategic Climatic Patterns*.  
-- Case Study: *The Rise of Airbus* – European government consortiums and subsidies.  
-- InfoQ Interview: *Wardley on Industrial Policy in China’s Tech Landscape*.  
+- Wardley, S. – *On Industrial Policy and Strategic Climatic Patterns*.
+- Case Study: *The Rise of Airbus* – European government consortiums and subsidies.
+- InfoQ Interview: *Wardley on Industrial Policy in China’s Tech Landscape*.

--- a/docs/strategies/attacking/press-release-process/index.md
+++ b/docs/strategies/attacking/press-release-process/index.md
@@ -11,7 +11,6 @@ tags: [press-release-process, attacking, marketing, product development, working
 :::
 
 ## 🤔 **Explanation**
-
 ### What is Press Release Process?
 
 The Press Release Process starts by writing the press release and FAQ for a proposed product before development begins. This fictional launch artefact defines the user problem, the solution, and the differentiation—anchoring the vision in customer value from day one.
@@ -49,8 +48,16 @@ It’s about **identifying what’s ready to be commoditised**, and building eff
 
 Then execute against that. The press release becomes a forcing function for evolutionary acceleration, team alignment, and strategic focus.
 
-## 🚦 **When to Use / When to Avoid**
+## 🗺️ **Real-World Examples**
+### Amazon
 
+Almost every product at Amazon, such as Kindle, AWS services, and Echo, began with an internal press release draft. For example, AWS Lambda's team wrote a press release about running code without managing servers, which guided development and ensured clear messaging at launch.
+
+### Netflix
+
+Netflix uses a similar approach for feature development, such as "Downloads for Offline Viewing." Writing the blog announcement first helped them communicate the feature better than competitors.
+
+## 🚦 **When to Use / When to Avoid**
 <Assessment strategyName="Press Release Process">
   <MapSignals>
     <li>We're initiating development of a new product, feature, or user-facing service.</li>
@@ -94,18 +101,7 @@ quadrantChart
     quadrant-4 "Abandon or Rethink"
 ```
 
-## 🗺️ **Real-World Examples**
-
-### Amazon
-
-Almost every product at Amazon, such as Kindle, AWS services, and Echo, began with an internal press release draft. For example, AWS Lambda's team wrote a press release about running code without managing servers, which guided development and ensured clear messaging at launch.
-
-### Netflix
-
-Netflix uses a similar approach for feature development, such as "Downloads for Offline Viewing." Writing the blog announcement first helped them communicate the feature better than competitors.
-
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 Ensuring the process is taken seriously and influences product design is critical to its success. Leaders must foster a culture where the press release process is foundational step in product development, rather than a formality. This involves actively engaging teams to iterate on the press release until it is compelling and aligns with customer needs.
@@ -123,14 +119,12 @@ Leaders should ensure that the press release remains a living document, guiding 
 Avoid overhyping or promising features that cannot be delivered.
 
 ## 📋 **How to Execute**
-
 1. Draft a press release and FAQ for the product.
 2. Iterate on the product idea until the press release is compelling.
 3. Use the press release as a guiding document throughout development.
 4. Update the press release as the product evolves.
 
 ## 📈 **Measuring Success**
-
 - Clear and compelling press releases for all initiatives.
 - Improved product-market fit.
 - Faster adoption and positive customer feedback.
@@ -138,7 +132,6 @@ Avoid overhyping or promising features that cannot be delivered.
 - Reduced feature creep.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Faking it
 
 Writing a press release without letting it influence design yields no benefit.
@@ -152,7 +145,6 @@ Ignoring the press release after writing it wastes the effort.
 Overpromising in the press release can lead to a disconnect at launch.
 
 ## 🧠 **Strategic Insights**
-
 ### Forcing Function for Value Chain Coherence
 
 The Press Release Process acts as a forcing function to define a coherent value chain *before* resources are committed. By articulating the end-state (customer value) up front, it forces strategic decisions about *what must exist* to realise that value. This exposes key components, dependencies, and whether you're working with industrialised building blocks—or inventing where you shouldn’t be. It transforms vague intent into explicit structure.
@@ -182,13 +174,11 @@ In fast-moving markets, delay often stems from poor alignment and rework. Pre-co
 A press release that reads as weak or incoherent is a fast signal of strategic unfitness. If you can’t make the narrative credible, it likely means the need isn’t real, the differentiation is unclear, or the supporting capabilities don’t exist. This gives you a cheap, fast, repeatable filter, before expensive commitments are made.
 
 ## ❓ **Key Questions to Ask**
-
 - **Customer focus:** Does the press release clearly articulate the customer benefit?
 - **Clarity:** Is the message simple and compelling?
 - **Differentiation:** Does the product stand out from competitors?
 
 ## 🔀 **Related Strategies**
-
 - [Brand & Marketing](/strategies/user-perception/brand-and-marketing) - Integrates marketing into development.
 - [Directed Investment](/strategies/attacking/directed-investment) – Helps prioritise resources toward capabilities surfaced during the press release process.
 - [Market Enablement](/strategies/accelerators/market-enablement) – Ensures downstream ecosystem or partner support for the customer-facing outcome.
@@ -200,10 +190,8 @@ A press release that reads as weak or incoherent is a fast signal of strategic u
 - [Experimentation](/strategies/attacking/experimentation) – Use press releases to simulate outcomes and test resonance before committing resources.
 
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Future value is inversely proportional to the certainty we have over it](/climatic-patterns/future-value-is-inversely-proportional-to-the-certainty-we-have-over-it) – trigger: describing the end state clarifies uncertain outcomes.
 - [Everything evolves](/climatic-patterns/everything-evolves) – influence: the press release helps teams anticipate how the product will mature.
 
 ## 📚 **Further Reading & References**
-
 - [Working Backwards](https://www.amazon.com/Working-Backwards-Insights-Stories-Secrets/dp/1250267595) - Details Amazon's methodology.

--- a/docs/strategies/competitor/ambush/index.md
+++ b/docs/strategies/competitor/ambush/index.md
@@ -12,7 +12,6 @@ authors: [dave-hulbert]
 :::
 
 ## 🤔 **Explanation**
-
 ### What is Ambush?
 
 Ambush is a competitive strategy focused on a reactive, competitor-specific surprise attack. Its primary intent is to undermine a specific competitor's progress, negate their recently gained advantage, or disrupt their business model at a critical juncture. Unlike strategies focused on broad market innovation, Ambush is a targeted strike designed to dismantle a rival's efforts, often by strategically repositioning or aggressively deploying existing or slightly adapted assets and capabilities. The element of surprise comes from the timing and nature of the counter-move, rather than solely the novelty of a technology.
@@ -33,8 +32,20 @@ The Ambush strategy relies on keen competitor intelligence, patience, and decisi
 
 Secrecy in planning the counter-move is crucial, as is the rapid, forceful execution of the Ambush to maximize its disorienting effect on the targeted competitor.
 
-## 🚦 **When to Use / When to Avoid**
+## 🗺️ **Real-World Examples**
+### Microsoft Bundling Internet Explorer with Windows (vs. Netscape)
 
+In the 1990s browser wars, Netscape Navigator was the dominant browser, sold as a standalone product. Microsoft, seeing the strategic importance of the browser, executed an Ambush. Instead of trying to out-feature Netscape initially, they bundled Internet Explorer (IE) for free with their dominant Windows 95 operating system. This move directly undermined Netscape's business model (selling browser software). Netscape couldn't compete with "free" and deeply integrated, leading to IE's market dominance. The "drop" wasn't a radically new *type* of technology, but a strategic bundling and pricing play.
+
+### LMW Open-Sourcing a Core Feature (Hypothetical Wardley Mapping Example)
+
+Imagine "Leading Wardley Mapper" (LWM) is a company selling a proprietary Wardley Mapping tool. A competitor, "NewMap," finally develops a feature that brings it to near parity with a key LWM offering. Just as NewMap launches its marketing campaign highlighting this new feature, LWM executes an Ambush by open-sourcing its equivalent (and mature) feature. This negates NewMap's marketing claims, makes their recent development effort less valuable, and potentially attracts developers to LWM's ecosystem.
+
+### Price War Initiation (e.g., Airline Industry)
+
+An airline might execute an Ambush if a competitor launches a new, premium-priced route. The ambushing airline could immediately offer drastically lower fares on the same route, using existing aircraft and staff. This isn't a new technology, but a pricing Ambush designed to devalue the competitor's new premium service and force them into a price war, potentially making the new route unprofitable for them.
+
+## 🚦 **When to Use / When to Avoid**
 <Assessment strategyName="Ambush">
   <MapSignals>
     <li>A specific competitor is about to launch a product that threatens our position.</li>
@@ -53,22 +64,7 @@ Secrecy in planning the counter-move is crucial, as is the rapid, forceful execu
   </Readiness>
 </Assessment>
 
-## 🗺️ **Real-World Examples**
-
-### Microsoft Bundling Internet Explorer with Windows (vs. Netscape)
-
-In the 1990s browser wars, Netscape Navigator was the dominant browser, sold as a standalone product. Microsoft, seeing the strategic importance of the browser, executed an Ambush. Instead of trying to out-feature Netscape initially, they bundled Internet Explorer (IE) for free with their dominant Windows 95 operating system. This move directly undermined Netscape's business model (selling browser software). Netscape couldn't compete with "free" and deeply integrated, leading to IE's market dominance. The "drop" wasn't a radically new *type* of technology, but a strategic bundling and pricing play.
-
-### LMW Open-Sourcing a Core Feature (Hypothetical Wardley Mapping Example)
-
-Imagine "Leading Wardley Mapper" (LWM) is a company selling a proprietary Wardley Mapping tool. A competitor, "NewMap," finally develops a feature that brings it to near parity with a key LWM offering. Just as NewMap launches its marketing campaign highlighting this new feature, LWM executes an Ambush by open-sourcing its equivalent (and mature) feature. This negates NewMap's marketing claims, makes their recent development effort less valuable, and potentially attracts developers to LWM's ecosystem.
-
-### Price War Initiation (e.g., Airline Industry)
-
-An airline might execute an Ambush if a competitor launches a new, premium-priced route. The ambushing airline could immediately offer drastically lower fares on the same route, using existing aircraft and staff. This isn't a new technology, but a pricing Ambush designed to devalue the competitor's new premium service and force them into a price war, potentially making the new route unprofitable for them.
-
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 The core challenge in an Ambush strategy is maintaining the discipline of waiting for the precise moment to act, coupled with the ability to execute a decisive and potentially aggressive maneuver with speed and precision. It requires deep understanding of a competitor's strategy, vulnerabilities, and likely reactions, while also managing the internal risks of preparing a counter-move in secret.
@@ -87,7 +83,6 @@ The core challenge in an Ambush strategy is maintaining the discipline of waitin
 Ambush strategies, by their nature, are aggressive and designed to be detrimental to a specific competitor. Ethical lines can be crossed if the Ambush involves spreading misinformation, engaging in illegal anti-competitive behavior, or causing undue harm beyond the scope of fair competition. The focus should be on negating a competitor's strategic advantage through legitimate business maneuvers (pricing, bundling, innovation, strategic acquisition) rather than deceit or sabotage. Transparency about *what* was done, even if the *timing* was a surprise, is important post-Ambush.
 
 ## 📋 **How to Execute**
-
 1.  **Identify Key Competitors & Monitor:** Continuously gather intelligence on target competitors: their product roadmaps, financial health, strategic partnerships, dependencies, and market announcements.
 2.  **Pinpoint Triggers and Vulnerabilities:** Based on mapping and intelligence, identify specific competitor actions, achievements, or dependencies that would constitute an opportune trigger for an Ambush.
 3.  **Develop Ambush Scenarios:** Prepare specific counter-moves (the "drop") tailored to likely triggers. This could involve preparing to open-source a component, readying a price change, lining up an acquisition, or developing a targeted alternative offering.
@@ -111,7 +106,6 @@ sequenceDiagram
 ```
 
 ## 📈 **Measuring Success**
-
 - **Competitor Response:** Observable defensive reactions, changes in competitor's strategy, or public statements acknowledging the impact.
 - **Negation of Competitor Advantage:** Evidence that the competitor's specific initiative targeted by the Ambush has stalled, been withdrawn, or is underperforming.
 - **Market Share Shift:** Measurable changes in market share in the specific segment targeted.
@@ -119,7 +113,6 @@ sequenceDiagram
 - **Media/Analyst Commentary:** Coverage that recognizes the Ambush and its impact on the competitive dynamic.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Mistimed Ambush
 
 Launching the Ambush too early (before the competitor is committed) or too late (after the competitor has already solidified their advantage) can significantly reduce its effectiveness.
@@ -141,7 +134,6 @@ An aggressive Ambush might inadvertently harm partners, customers, or the broade
 Actions like predatory pricing or certain types_of_acquisitions designed to stifle competition can attract unwanted legal or regulatory attention.
 
 ## 🧠 **Strategic Insights**
-
 ### Negating Competitor ROI
 
 A primary goal of Ambush is to make a competitor's recent investment (in R&D, marketing, acquisitions, etc.) worthless or significantly less valuable. By waiting for them to commit resources and then striking, you maximize the financial and strategic pain.
@@ -167,7 +159,6 @@ It's important to distinguish Ambush from [Tech Drops](/strategies/competitor/te
 | **Surprise From**  | The novelty/scale of the innovation itself.                               | The timing and nature of the counter-attack.                                                           |
 
 ## ❓ **Key Questions to Ask**
-
 - **Target Specificity:** Which specific competitor and which specific initiative are we targeting?
 - **Trigger Clarity:** What precise competitor action will trigger our Ambush?
 - **Impact Assessment:** Is our planned "drop" substantial enough to truly undermine the competitor's advantage?
@@ -176,7 +167,6 @@ It's important to distinguish Ambush from [Tech Drops](/strategies/competitor/te
 - **Resource Alignment:** Do we have the resources (financial, operational, legal) to execute the Ambush effectively and manage its consequences?
 
 ## 🔀 **Related Strategies**
-
 - [**Tech Drops**](/strategies/competitor/tech-drops) - While different, understanding Tech Drops helps clarify what Ambush is not. An Ambush might be a response *to* a Tech Drop.
 - [**Circling and Probing**](/strategies/competitor/circling-and-probing) - Used to gather the intelligence necessary to plan an effective Ambush.
 - [**Sapping**](/strategies/competitor/sapping) - An Ambush can be a powerful form of sapping a competitor's strength and morale.
@@ -184,13 +174,11 @@ It's important to distinguish Ambush from [Tech Drops](/strategies/competitor/te
 - [**Playing Both Sides**](/strategies/attacking/playing-both-sides) - An Ambush could be part of a larger strategy of playing both sides, for instance, by commoditizing a component one competitor relies on, thereby benefiting another.
 
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – trigger: An Ambush is a direct response to a competitor's game-changing move, aiming to change it again.
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – influence: An Ambush can exploit a competitor's inertia or their overconfidence from past successes.
 - [Shifts from product to utility tend to demonstrate a punctuated equilibrium](/climatic-patterns/shifts-from-product-to-utility-tend-to-demonstrate-a-punctuated-equilibrium) – influence: An Ambush can trigger or accelerate such a shift (e.g., by open-sourcing or commoditizing something).
 
 ## 📚 **Further Reading & References**
-
 - [The Art of War](https://www.goodreads.com/book/show/10534.The_Art_of_War) by Sun Tzu - Provides timeless wisdom on surprise, timing, and knowing your enemy, all crucial for Ambush strategies.
 - [Competitive Strategy: Techniques for Analyzing Industries and Competitors](https://www.goodreads.com/book/show/309100.Competitive_Strategy) by Michael E. Porter - Offers frameworks for understanding competitor behavior and industry dynamics, useful for identifying Ambush opportunities.
 - [Thinking in Bets: Making Smarter Decisions When You Don't Have All the Facts](https://www.goodreads.com/book/show/35911677-thinking-in-bets) by Annie Duke - While not directly about Ambush, it offers insights into decision-making under uncertainty, relevant for timing an Ambush.

--- a/docs/strategies/competitor/circling-and-probing/index.md
+++ b/docs/strategies/competitor/circling-and-probing/index.md
@@ -13,7 +13,6 @@ tags: [circling-and-probing, competitor, circling, probing, exploration, experim
 This strategy involves making small, tentative moves into a competitor's space to test their reactions and identify opportunities.
 
 ## 🤔 **Explanation**
-
 ### What is Circling and Probing
 
 Circling and probing is a strategy of making small-scale incursions into a competitor's market to explore opportunities and assess the competitive landscape. Instead of a direct attack, a company observes from the periphery, launching experimental offerings to uncover unmet needs or competitor weaknesses.
@@ -33,8 +32,12 @@ This approach reduces risk by using low-cost, low-commitment experiments to gath
 
 The core idea is competitive exploration. A company tests the opponent's defenses and customer response through small experiments (pilot programs, beta products, limited releases). By observing how the market and competitors respond, the company gains insights to inform future actions. This strategy is about learning and adaptation, allowing for adjustments based on the intelligence gathered.
 
-## 🚦 **When to Use / When to Avoid**
+## 🗺️ **Real-World Examples**
+* **Netflix’s Entry into Gaming:** Netflix began its move into the gaming market with small steps. It added mobile games for subscribers and experimented with streaming games on TVs and PCs in limited beta tests. This probed a market dominated by console and PC game providers. By assessing user interest and technological feasibility on a small scale, Netflix circled the gaming industry without a large upfront investment.
+* **Google’s Trial Products:** Google frequently launches beta products or services in areas where a competitor is strong. For example, Google+ in social networking (Facebook’s territory) and Google Wave for collaboration (rivaling emerging enterprise tools). These efforts served as exploratory probes. Google+ allowed Google to learn about social media user behavior and integrate features into other products.
+* **Amazon’s Beta Offerings:** Amazon has a history of testing new business ideas in limited regions or with trials, such as grocery delivery and fashion (e.g., Amazon Pantry, Prime Wardrobe beta). These probes gauge demand in markets dominated by others (like supermarkets or apparel retailers). Promising results lead to scaling up, while limited risk and cost are incurred if results are poor.
 
+## 🚦 **When to Use / When to Avoid**
 <Assessment strategyName="Circling and Probing">
   <MapSignals>
     <li>We see a valuable market or user segment currently served by a competitor, but with unclear user satisfaction or unmet needs.</li>
@@ -70,14 +73,7 @@ Circling and probing is useful for:
 * The competitor is highly vulnerable and can be easily defeated
 * The risks associated with provoking a competitor outweigh the potential benefits of probing
 
-## 🗺️ **Real-World Examples**
-
-* **Netflix’s Entry into Gaming:** Netflix began its move into the gaming market with small steps. It added mobile games for subscribers and experimented with streaming games on TVs and PCs in limited beta tests. This probed a market dominated by console and PC game providers. By assessing user interest and technological feasibility on a small scale, Netflix circled the gaming industry without a large upfront investment.
-* **Google’s Trial Products:** Google frequently launches beta products or services in areas where a competitor is strong. For example, Google+ in social networking (Facebook’s territory) and Google Wave for collaboration (rivaling emerging enterprise tools). These efforts served as exploratory probes. Google+ allowed Google to learn about social media user behavior and integrate features into other products.
-* **Amazon’s Beta Offerings:** Amazon has a history of testing new business ideas in limited regions or with trials, such as grocery delivery and fashion (e.g., Amazon Pantry, Prime Wardrobe beta). These probes gauge demand in markets dominated by others (like supermarkets or apparel retailers). Promising results lead to scaling up, while limited risk and cost are incurred if results are poor.
-
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 Leaders must balance a **curious, data-driven mindset** with a tolerance for ambiguity. They should foster an environment where small experiments are encouraged and failures are acceptable.
@@ -90,7 +86,6 @@ Leaders must balance a **curious, data-driven mindset** with a tolerance for amb
 * Clear communication
 
 ## 📋 **How to Execute**
-
 1.  **Define the hypothesis:** Clearly state what you aim to learn from the probe.
 2.  **Develop a minimal viable offering:** Create something that can be launched quickly and with limited investment, yet is sufficient to attract users and generate feedback.
 3.  **Target strategically:** Use geographic or demographic targeting to limit exposure.
@@ -104,7 +99,6 @@ Leaders must balance a **curious, data-driven mindset** with a tolerance for amb
 Circling and probing should be conducted ethically, respecting competitors' intellectual property and avoiding deceptive practices.
 
 ## 📈 **Measuring Success**
-
 * Learning objectives met: Did the probe provide the intended insights?
 * Cost-effectiveness: Were the probes conducted with minimal investment?
 * Competitor reaction: Did the competitor's response provide valuable intelligence?
@@ -115,7 +109,6 @@ Circling and probing should be conducted ethically, respecting competitors' inte
 * Knowledge acquisition: What new knowledge was gained about the market and competitors?
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Overconfidence
 
 Underestimating a competitor's strengths or overestimating the probe's potential impact.
@@ -129,7 +122,6 @@ Getting stuck in continuous probing without taking decisive action based on the 
 Scaling up a probe before fully understanding its implications or the market's response.
 
 ## 🧠 **Strategic Insights**
-
 ### Reducing Uncertainty
 
 Circling and probing reduces uncertainty before making major commitments. It helps avoid costly missteps by revealing market attractiveness and competitor strengths.
@@ -156,7 +148,6 @@ Avoid getting stuck in analysis; the goal is to use insights to decide where to 
 * [IBM to Spend Another $1 Billion on Linux - Business Insider](https://www.businessinsider.com/ibm-to-spend-another-1-billion-on-linux-2013-9)
 
 ## ❓ **Key Questions to Ask**
-
 - **Market Understanding:** What specific hypothesis about the competitor's market or offering are we testing with this probe?
 - **Resource Allocation:** What is the minimal investment required for this probe to yield meaningful data, and how does this align with our overall experimental budget?
 - **Competitor Response:** What is the range of potential competitor reactions, and how prepared are we to adapt our strategy based on these responses?
@@ -165,21 +156,18 @@ Avoid getting stuck in analysis; the goal is to use insights to decide where to 
 - **Strategic Alignment:** How will the insights from this probe inform our broader strategic decisions, regardless of the outcome?
 
 ## 🔀 **Related Strategies**
-
 * [**Misdirection**](/strategies/competitor/misdirection) - Using tactics to mislead a competitor about your intentions.
 * [**Tech Drops**](/strategies/competitor/tech-drops) - Launching a sudden, unexpected attack on a competitor.
 * [**Experimentation**](/strategies/attacking/experimentation) - Testing new approaches to find effective strategies.
 * [**Alliances**](/strategies/ecosystem/alliances) - Forming partnerships, the opposite of testing a competitor.
 
-## 📚 **Further Reading & References**
-
-* "Competitive Strategy" by Michael Porter - For foundational concepts on competitive analysis and strategy.
-* "The Art of War" by Sun Tzu - For insights into strategic thinking and maneuvering in competitive situations.
-
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: The landscape is constantly changing, requiring ongoing circling and probing.
 - [Characteristics change](/climatic-patterns/characteristics-change) – rel: Competitor capabilities and market dynamics shift, necessitating adaptation.
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Competitors might become complacent, creating opportunities.
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Probing can uncover inefficiencies that can be exploited or areas ripe for innovation.
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: This strategy is a direct response to and anticipation of competitor actions.
+
+## 📚 **Further Reading & References**
+* "Competitive Strategy" by Michael Porter - For foundational concepts on competitive analysis and strategy.
+* "The Art of War" by Sun Tzu - For insights into strategic thinking and maneuvering in competitive situations.

--- a/docs/strategies/competitor/fragmentation/index.md
+++ b/docs/strategies/competitor/fragmentation/index.md
@@ -9,7 +9,6 @@ tags: [competitor, fragmentation, markets, underdog, disruption, divide and conq
 It involves exploiting weaknesses to break the competitor's market into smaller pieces.
 
 ## 🤔 **Explanation**
-
 ### What is Fragmentation
 
 Fragmentation is a competitive strategy focused on breaking apart a competitor's market dominance. It involves leveraging pricing differences, constraints, or co-opting strategies to undermine a competitor by changing the market dynamics around them. Rather than directly confronting a competitor in their core market, this strategy aims to erode their stronghold by introducing alternatives or supporting multiple options to prevent them from achieving scale.
@@ -26,8 +25,14 @@ The core idea is to break a competitor's market into smaller segments that can b
 -   Supporting multiple alternatives to prevent the rival from achieving scale.
 -   Exploiting a competitor's constraints or weaknesses.
 
-## 🚦 **When to Use / When to Avoid**
+## 🗺️ **Real-World Examples**
+-   **IBM and Linux vs. Microsoft**: In 2000, IBM committed \$1 billion to support the Linux operating system, a free, open-source alternative to Microsoft Windows, to fragment Microsoft's dominance in operating systems. At the time, Windows was dominant and expensive for enterprise. IBM's backing gave Linux enterprise legitimacy, leading to its widespread adoption. This carved off a significant portion of what might have been Windows-only server deployments and created a thriving ecosystem outside Microsoft's control.
 
+-   **Android Open-Source Strategy**: Google's decision to make Android an open-source, freely licensed mobile OS can be seen as a fragmentation play against potential mobile monopolies. Android co-founder Rich Miner stated, "I literally helped create Android to prevent Microsoft from controlling the phone the way they did the PC -- stifling innovation." By giving Android away to device manufacturers, Google fragmented what could have been a unified market under a single player, such as Microsoft or Apple's iOS. The result was a proliferation of Android devices across many vendors. This strategy co-opted phone manufacturers to rally behind Android, fracturing the landscape into an alliance Google led.
+
+-   **Pricing Wars**: A new entrant may deliberately price a product or service far below the incumbent's pricing to attract a different segment of customers, splitting the market by price-sensitive vs. premium segments. For example, when discount airlines entered markets dominated by national carriers, they fragmented the air travel market. Legacy airlines retained higher-paying business travelers, while budget-conscious travelers flocked to low-cost carriers. Similarly, freemium models in software can take market share from enterprise software incumbents.
+
+## 🚦 **When to Use / When to Avoid**
 <Assessment strategyName="Fragmentation">
   <MapSignals>
     <li>We are facing a dominant competitor who holds a consolidated market position or strong ecosystem control.</li>
@@ -56,16 +61,7 @@ Use a fragmentation play when you want to undermine a competitor's stronghold by
 
 Avoid this strategy if the competitor is not dominant or if fragmenting the market would not create a more favorable environment for your organization. Also, avoid it if the competitor can easily counter your moves or if the resulting fragmented market would be detrimental to overall market growth.
 
-## 🗺️ **Real-World Examples**
-
--   **IBM and Linux vs. Microsoft**: In 2000, IBM committed \$1 billion to support the Linux operating system, a free, open-source alternative to Microsoft Windows, to fragment Microsoft's dominance in operating systems. At the time, Windows was dominant and expensive for enterprise. IBM's backing gave Linux enterprise legitimacy, leading to its widespread adoption. This carved off a significant portion of what might have been Windows-only server deployments and created a thriving ecosystem outside Microsoft's control.
-
--   **Android Open-Source Strategy**: Google's decision to make Android an open-source, freely licensed mobile OS can be seen as a fragmentation play against potential mobile monopolies. Android co-founder Rich Miner stated, "I literally helped create Android to prevent Microsoft from controlling the phone the way they did the PC -- stifling innovation." By giving Android away to device manufacturers, Google fragmented what could have been a unified market under a single player, such as Microsoft or Apple's iOS. The result was a proliferation of Android devices across many vendors. This strategy co-opted phone manufacturers to rally behind Android, fracturing the landscape into an alliance Google led.
-
--   **Pricing Wars**: A new entrant may deliberately price a product or service far below the incumbent's pricing to attract a different segment of customers, splitting the market by price-sensitive vs. premium segments. For example, when discount airlines entered markets dominated by national carriers, they fragmented the air travel market. Legacy airlines retained higher-paying business travelers, while budget-conscious travelers flocked to low-cost carriers. Similarly, freemium models in software can take market share from enterprise software incumbents.
-
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 Leading a fragmentation strategy requires strategic thinking and a deep understanding of market dynamics. Leaders must identify leverage points to pry the market apart, such as price, openness, or convenience.
@@ -78,7 +74,6 @@ Leading a fragmentation strategy requires strategic thinking and a deep understa
 -   Addressing ethical and reputational considerations, as fragmentation can be perceived as aggressive.
 
 ## 📋 **How to Execute**
-
 1.  **Identify the Wedge**: Find a way to split the market, such as lower pricing, an open standard, a new distribution channel, or a different business model.
 2.  **Amass Support**: Gather support for your chosen wedge. If undercutting on price, ensure you have cost advantages or alternate revenue streams. If open-sourcing technology, engage the developer community and potential partners.
 3.  **Over-invest in the Wedge**: Dedicate resources to the wedge area, such as subsidizing a product to be very cheap or over-communicating the advantages of an open alternative.
@@ -93,7 +88,6 @@ Leading a fragmentation strategy requires strategic thinking and a deep understa
 Fragmentation can be seen as an aggressive strategy, so leaders must be prepared to justify their moves as ultimately customer-friendly, such as by providing more choice or lower prices.
 
 ## 📈 **Measuring Success**
-
 -   Market share changes: Track the competitor's loss of market share and the gain of market share by new entrants or competitors.
 -   Adoption rates: Measure the adoption rates of the alternative products, services, or standards introduced to fragment the market.
 -   Ecosystem growth: Monitor the growth and diversity of the fragmented ecosystem, including the number of new participants and innovations.
@@ -101,7 +95,6 @@ Fragmentation can be seen as an aggressive strategy, so leaders must be prepared
 -   Customer satisfaction: Assess customer satisfaction and feedback regarding the fragmented market, including increased choice and innovation.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Failure to capture value
 
 Successfully fragmenting a market does not guarantee that your organization will benefit. You must have a plan to capture the newly created opportunities.
@@ -111,7 +104,6 @@ Successfully fragmenting a market does not guarantee that your organization will
 If not managed carefully, fragmentation can lead to a chaotic market where no player, including your organization, can achieve a sustainable competitive advantage.
 
 ## 🧠 **Strategic Insights**
-
 ### Incumbent Vulnerability
 
 A unified market controlled by an incumbent is more vulnerable to fragmentation because the incumbent may struggle to respond effectively without damaging their core business.
@@ -137,7 +129,6 @@ Fragmentation can introduce complexity, customer confusion, or interoperability 
 A fragmentation play is about playing divide and conquer in a market. It is most effective when the incumbent cannot follow you without self-harm, and when you have the patience to let a fragmented ecosystem evolve to your advantage.
 
 ## ❓ **Key Questions to Ask**
-
 -   What are the key vulnerabilities or constraints of the incumbent that can be exploited for fragmentation?
 -   Which segments of the market are most likely to be receptive to a fragmenting offer?
 -   How can we build a sustainable ecosystem around the fragmented elements?
@@ -146,7 +137,6 @@ A fragmentation play is about playing divide and conquer in a market. It is most
 -   What are the potential negative consequences of fragmentation, and how can we address them?
 
 ## 🔀 **Related Strategies**
-
 -   [**Alliances**](/strategies/ecosystem/alliances) - A formalized group of co-operating entities, essentially the same domain
 -   [**Co-opting**](/strategies/ecosystem/co-opting) - Enlisting a third party into your ecosystem to draw them away from a competitor’s control or influence
 -   [**Embrace and Extend**](/strategies/ecosystem/embrace-and-extend) - A controversial strategy that can lead to fragmentation by altering standards
@@ -154,11 +144,9 @@ A fragmentation play is about playing divide and conquer in a market. It is most
 -   [**Restriction of Movement**](/strategies/competitor/restriction-of-movement) - A strategy focused on limiting a competitor's options and flexibility
 
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Creative Destruction](/climatic-patterns/creative-destruction) – trigger: breaking a monolith clears the way for new entrants.
 - [Components can co-evolve](/climatic-patterns/components-can-co-evolve) – influence: smaller pieces evolve faster once separated.
 
 ## 📚 **Further Reading & References**
-
 -   Wardley Mapping Reference - *"Fragmentation"* . Underscores the goal of breaking apart a competitor's stronghold.
 -   Clayton Christensen - *The Innovator's Dilemma* - Provides extensive case studies of how disruptive innovation (a form of fragmentation) undermines established market leaders.

--- a/docs/strategies/competitor/misdirection/index.md
+++ b/docs/strategies/competitor/misdirection/index.md
@@ -9,7 +9,6 @@ tags: [misdirection, competitor, deception, assumptions, signals, influence, com
 It's about appearing to go one way while secretly moving another.
 
 ## 🤔 **Explanation**
-
 ### What is Misdirection?
 
 Misdirection involves strategically providing misleading information to competitors (or potential competitors) to manipulate their perceptions and actions. It's designed to make rivals misjudge your strategic intent, leading them to allocate resources or make decisions that benefit you.
@@ -27,8 +26,14 @@ Misdirection is valuable because it allows a company to:
 
 Misdirection works by exploiting the fact that competitors monitor each other closely. By carefully controlling the signals you send (public statements, investment hints, product announcements), you can influence what your rivals *think* you are doing. This can cause them to move in ways that leave them vulnerable or give you an advantage. It requires a deep understanding of what information your competitors monitor and how they interpret it.
 
-## 🚦 **When to Use / When to Avoid**
+## 🗺️ **Real-World Examples**
+-   **Pre-Announcements and Vaporware:** Announcing a product that is not yet ready (vaporware) can deter competitors or influence customer expectations. IBM's announcement of the System/360 Model 91 after a competitor's launch caused a drop in the competitor's sales, even though IBM's product was not available for two years. Microsoft has also been accused of using early announcements to hinder competitors.
 
+-   **False Investment Signals:** Companies may signal heavy investment in a technology or market that is not their true focus, hoping competitors will follow and waste resources. The misdirecting company can then focus on its real innovation while rivals chase a false lead.
+
+-   **Public Statements & Strategic Messaging:** Leaders can use public statements and marketing to misdirect. For example, a CEO might downplay interest in a market to lull competitors into complacency, then later enter that market. Apple kept its iPhone plans secret, so competitors were not fully prepared for its debut. Startups might emphasize a less important feature to keep competitors from noticing their real asset.
+
+## 🚦 **When to Use / When to Avoid**
 <Assessment strategyName="Misdirection">
   <MapSignals>
     <li>Our strategy depends on timing, secrecy, or avoiding early competitive response.</li>
@@ -57,16 +62,7 @@ Misdirection is most useful when you have a significant move planned that could 
 
 Misdirection should be used sparingly because overuse or discovery can damage a company's credibility. Competitors may begin to distrust all communications, which can be harmful when genuine communication is needed. Misdirection can also mislead external stakeholders like investors or customers, causing confusion or distrust.
 
-## 🗺️ **Real-World Examples**
-
--   **Pre-Announcements and Vaporware:** Announcing a product that is not yet ready (vaporware) can deter competitors or influence customer expectations. IBM's announcement of the System/360 Model 91 after a competitor's launch caused a drop in the competitor's sales, even though IBM's product was not available for two years. Microsoft has also been accused of using early announcements to hinder competitors.
-
--   **False Investment Signals:** Companies may signal heavy investment in a technology or market that is not their true focus, hoping competitors will follow and waste resources. The misdirecting company can then focus on its real innovation while rivals chase a false lead.
-
--   **Public Statements & Strategic Messaging:** Leaders can use public statements and marketing to misdirect. For example, a CEO might downplay interest in a market to lull competitors into complacency, then later enter that market. Apple kept its iPhone plans secret, so competitors were not fully prepared for its debut. Startups might emphasize a less important feature to keep competitors from noticing their real asset.
-
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 The core challenge is balancing the need for deception with the need to maintain credibility. Leaders must manage internal knowledge while projecting a false narrative externally.
@@ -76,7 +72,6 @@ The core challenge is balancing the need for deception with the need to maintain
 Calculated deception, strategic communication, disciplined execution, and an understanding of competitors' intelligence-gathering habits.
 
 ## 📋 **How to Execute**
-
 1.  **Identify channels of influence:** Determine which communication channels competitors monitor (e.g., press releases, conferences, patents, social media).
 2.  **Craft the decoy narrative:** Develop a false narrative that aligns with the misdirection goals.
 3.  **Ensure consistency:** Align all outward-facing communications with the misdirection story.
@@ -90,14 +85,12 @@ Calculated deception, strategic communication, disciplined execution, and an und
 Misdirection should focus on misleading competitors without deceiving customers or engaging in illegal activities.
 
 ## 📈 **Measuring Success**
-
 -   Competitor resource allocation: Are competitors investing in the decoy area?
 -   Competitor statements: Are competitors making statements that indicate they believe the misdirection?
 -   Time gained: Has the misdirection bought the company time to develop its true strategy?
 -   Surprise factor: Is the competition caught off guard when the real strategy is revealed?
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Overuse
 
 Using misdirection too frequently can lead to a loss of credibility.
@@ -111,7 +104,6 @@ If the misdirection is discovered, it can damage trust with stakeholders.
 Competitors might react in unexpected ways, potentially turning the misdirection into a disadvantage.
 
 ## 🧠 **Strategic Insights**
-
 ### Misdirection and Competitive Advantage
 
 Misdirection highlights that competitive advantage can be gained by influencing competitors' actions as well as your own. It's a way to shape the competitive landscape indirectly.
@@ -133,7 +125,6 @@ Misdirection carries the risk of damaging credibility if overused or discovered.
 Misdirection can lead to competitor inertia. If a company consistently signals that it's focusing on incremental or tangential ideas, competitors might ignore the subtle changes in its real core strategy until it's too late.
 
 ## ❓ **Key Questions to Ask**
-
 -   What information do our competitors monitor?
 -   How can we craft a false narrative that will influence their decisions?
 -   How do we balance the need for misdirection with the need to maintain credibility?
@@ -142,17 +133,14 @@ Misdirection can lead to competitor inertia. If a company consistently signals t
 -   How and when will we reveal our true strategy?
 
 ## 🔀 **Related Strategies**
-
 -   [**Reinforcing Competitor Inertia**](/strategies/competitor/reinforcing-competitor-inertia): Misdirection can be used to reinforce competitor inertia by making them underestimate your true strategy
 -   [**Tech Drops**](/strategies/competitor/tech-drops): Misdirection can set up a Tech Drop by concealing your true intentions until the last moment.
 -   [**Signal Distortion**](/strategies/markets/signal-distortion): Misdirection deliberately distorts market signals to mislead competitors.
 -   [**Fear, Uncertainty, and Doubt**](/strategies/user-perception/fear-uncertainty-and-doubt): Misdirection can create fear, uncertainty, and doubt in the minds of competitors.
 
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – influence: decoys buy time while rivals adjust.
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – trigger: confidence in the status quo makes targets overlook the ruse.
 
 ## 📚 **Further Reading & References**
-
 -   *Vaporware - Wikipedia*: Provides information on vaporware, a common form of misdirection.

--- a/docs/strategies/competitor/reinforcing-competitor-inertia/index.md
+++ b/docs/strategies/competitor/reinforcing-competitor-inertia/index.md
@@ -9,7 +9,6 @@ tags: [reinforcing-competitor-inertia, competitor, inertia, change, resistance, 
 This strategy focuses on leveraging a competitor's resistance to change to gain a strategic advantage. It involves identifying areas where a competitor is "stuck" and then driving market changes that reinforce their commitment to an outdated approach.
 
 ## 🤔 **Explanation**
-
 ### What is Reinforcing Competitor Inertia
 
 "Reinforcing Competitor Inertia" is a strategy that exploits a competitor's reluctance or inability to change. Inertia is the resistance to change, often found in successful companies that stick to what worked in the past. This gameplay identifies those areas where the competitor is stuck (due to prior investments, business model, or mindset) and then drives market changes that deepen the rival's commitment to that outdated approach. In other words, you set moves in motion that play to your competitor's weaknesses by taking advantage of their inertia. The competitor, instead of adapting, doubles down on their old ways, which ultimately hurts them. By reinforcing their inertia, you indirectly ensure they stay on a losing strategic path longer. This could mean introducing a new product or model that the competitor finds threatening to their core business, so they respond by clinging even harder to the old model (when, objectively, the market is ready to move on). Essentially, you're tricking or pressuring the rival into accelerating their own obsolescence.
@@ -26,8 +25,12 @@ This strategy is valuable because it turns a competitor's strength (past success
 
 The core idea is to introduce changes that the competitor is likely to resist. This could involve new technologies, business models, or market approaches. By consistently applying pressure and highlighting the competitor's inaction, you can reinforce their inertia and widen the gap between your organization and theirs. This strategy requires keen observation, a deep understanding of the competitor's weaknesses, and the ability to anticipate their reactions.
 
-## 🚦 **When to Use / When to Avoid**
+## 🗺️ **Real-World Examples**
+-   **Kodak and Digital Photography:** Kodak long dominated film photography and was very slow to embrace digital cameras (fearing cannibalization of its film business). Competitors like Sony and Canon exploited this inertia by aggressively advancing digital camera technology and capturing the consumer market. Kodak's leadership, wedded to film, responded by doubling down on film's profitability and only timidly engaging with digital. They effectively reinforced Kodak's inertia by continuing to innovate in digital, which made Kodak cling even more desperately to its fading film sales. Kodak's fear of change ("protect the film business at all costs") was reinforced by the market shift; it kept them stuck until it was too late. In 2012, Kodak filed for bankruptcy, having been unable to overcome its own inertia. Competitors had forced the issue by pushing the new technology that Kodak resisted.
+-   **Blockbuster vs. Netflix:** Blockbuster had huge inertia with its physical video rental stores and the lucrative late-fees model. When Netflix introduced subscription DVD-by-mail (and later streaming), Blockbuster initially responded by emphasizing their stores and downplaying the mail/online trend. Netflix's move forced Blockbuster to confront a model that undercut late fees, but Blockbuster's inertia was strong; they relied on late fees which brought in $800M in revenue in 2000. Even when Blockbuster tried a no-late-fee campaign, it was half-hearted and they stuck to their retail presence. By pushing the subscription model, Netflix reinforced Blockbuster's commitment to its old revenue streams (Blockbuster executives infamously laughed off an offer to buy Netflix in 2000, not adapting in time). That inertia gave Netflix years to grow unopposed in the new model, and Blockbuster's eventual attempts to catch up were too late.
+-   **Smartphone Industry Keyboard vs. Touchscreen:** Research In Motion (BlackBerry) was extremely successful with its physical-keyboard smartphones and had internal inertia believing that business customers needed physical keys. When Apple introduced the iPhone with a full touchscreen, BlackBerry initially responded by sticking to its keyboard-centric designs (even as consumers and then enterprises started shifting preferences). Apple's move to touch interfaces, and later Android following, forced BlackBerry into an inertial trap: they hesitated to make a truly competitive touchscreen device for too long, worried about alienating their existing user base and undermining their secure email niche. By the time they did (the BlackBerry Storm and others), Apple and Android had taken over. In this case, Apple didn't intend to reinforce BlackBerry's inertia per se, but Apple's strategy had that effect; it leveraged BlackBerry's inability to pivot quickly away from their legacy strength, thus sealing BlackBerry's decline.
 
+## 🚦 **When to Use / When to Avoid**
 <Assessment strategyName="Reinforcing Competitor Inertia">
   <MapSignals>
     <li>A dominant competitor is visibly tied to a legacy business model, architecture, or operational approach.</li>
@@ -63,14 +66,7 @@ This strategy is most effective when a competitor exhibits clear resistance to c
 -   The market is stable and not undergoing significant change
 -   Your organization is also vulnerable to the same inertia
 
-## 🗺️ **Real-World Examples**
-
--   **Kodak and Digital Photography:** Kodak long dominated film photography and was very slow to embrace digital cameras (fearing cannibalization of its film business). Competitors like Sony and Canon exploited this inertia by aggressively advancing digital camera technology and capturing the consumer market. Kodak's leadership, wedded to film, responded by doubling down on film's profitability and only timidly engaging with digital. They effectively reinforced Kodak's inertia by continuing to innovate in digital, which made Kodak cling even more desperately to its fading film sales. Kodak's fear of change ("protect the film business at all costs") was reinforced by the market shift; it kept them stuck until it was too late. In 2012, Kodak filed for bankruptcy, having been unable to overcome its own inertia. Competitors had forced the issue by pushing the new technology that Kodak resisted.
--   **Blockbuster vs. Netflix:** Blockbuster had huge inertia with its physical video rental stores and the lucrative late-fees model. When Netflix introduced subscription DVD-by-mail (and later streaming), Blockbuster initially responded by emphasizing their stores and downplaying the mail/online trend. Netflix's move forced Blockbuster to confront a model that undercut late fees, but Blockbuster's inertia was strong; they relied on late fees which brought in $800M in revenue in 2000. Even when Blockbuster tried a no-late-fee campaign, it was half-hearted and they stuck to their retail presence. By pushing the subscription model, Netflix reinforced Blockbuster's commitment to its old revenue streams (Blockbuster executives infamously laughed off an offer to buy Netflix in 2000, not adapting in time). That inertia gave Netflix years to grow unopposed in the new model, and Blockbuster's eventual attempts to catch up were too late.
--   **Smartphone Industry Keyboard vs. Touchscreen:** Research In Motion (BlackBerry) was extremely successful with its physical-keyboard smartphones and had internal inertia believing that business customers needed physical keys. When Apple introduced the iPhone with a full touchscreen, BlackBerry initially responded by sticking to its keyboard-centric designs (even as consumers and then enterprises started shifting preferences). Apple's move to touch interfaces, and later Android following, forced BlackBerry into an inertial trap: they hesitated to make a truly competitive touchscreen device for too long, worried about alienating their existing user base and undermining their secure email niche. By the time they did (the BlackBerry Storm and others), Apple and Android had taken over. In this case, Apple didn't intend to reinforce BlackBerry's inertia per se, but Apple's strategy had that effect; it leveraged BlackBerry's inability to pivot quickly away from their legacy strength, thus sealing BlackBerry's decline.
-
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 The core challenge for leadership is to accurately identify and exploit a competitor's inertia while avoiding the same trap within their own organization. Leaders must foster a culture of adaptability and continuous improvement to ensure their organization remains agile.
@@ -80,7 +76,6 @@ The core challenge for leadership is to accurately identify and exploit a compet
 Strategic observation, adaptability, and the ability to anticipate competitor responses.
 
 ## 📋 **How to Execute**
-
 1.  **Identify the competitor's inertia:** Pinpoint areas where the competitor is resistant to change.
 2.  **Introduce change:** Create market changes that challenge the competitor's assumptions and force them to react.
 3.  **Amplify the change:** Highlight the competitor's inaction and promote the benefits of your approach.
@@ -91,19 +86,16 @@ Strategic observation, adaptability, and the ability to anticipate competitor re
 This strategy can be seen as aggressive, as it involves exploiting a competitor's weakness. It's important to consider the potential consequences of your actions and ensure they align with your organization's ethical standards.
 
 ## 📈 **Measuring Success**
-
 -   Competitor's response: How the competitor reacts to the introduced changes.
 -   Market share: Changes in market share between your organization and the competitor.
 -   Innovation rate: The relative pace of innovation between your organization and the competitor.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 -   Underestimating the competitor: Assuming the competitor will not adapt.
 -   Overestimating your organization's agility: Failing to recognize potential inertia within your own organization.
 -   Market changes: If the market shifts in a way that favors the competitor's existing approach, the strategy may backfire.
 
 ## 🧠 **Strategic Insights**
-
 ### The Innovator's Dilemma
 
 This strategy directly leverages the concept of the innovator's dilemma. Incumbents often ignore disruptive change because it doesn't make sense for their current business. By reinforcing inertia, you create conditions where if they do nothing, they slowly lose relevance, and if they change, they undergo pain.
@@ -117,28 +109,24 @@ This strategy works best when a technological or market shift is clearly underwa
 Reinforcing someone else's inertia often requires that the new paradigm you push is indeed the future. Ensure your read of the landscape is correct before trying to trap others in inertia. Moreover, consider your own adaptability; a strategy that banks on change means you have to be excellent at handling that change internally.
 
 ## ❓ **Key Questions to Ask**
-
 -   Where is the competitor most resistant to change?
 -   What market changes can we introduce to exploit this inertia?
 -   How can we amplify the impact of these changes?
 -   How can we ensure our organization remains agile and avoids the same trap?
 
 ## 🔀 **Related Strategies**
-
 -   [**Managing Inertia**](/strategies/defensive/managing-inertia): Focuses on how to manage inertia within your own organization, the opposite of this strategy.
 -   [**Raising Barriers to Entry**](/strategies/defensive/raising-barriers-to-entry): Can be used in conjunction with reinforcing inertia to further solidify your position by making it harder for competitors to adapt.
 -   [**Exploiting Constraint**](/strategies/decelerators/exploiting-constraint): Similar to reinforcing inertia, this strategy exploits limitations, but it focuses on external constraints rather than a competitor's internal resistance.
 -   [**Tech Drops**](/strategies/competitor/tech-drops): Can be used to capitalize on a competitor's inertia by launching a sudden, unexpected attack when they are least prepared.
 
-## 📚 **Further Reading & References**
-
--   Clayton Christensen, *The Innovator's Dilemma*
-- [The Rise and Fall of Kodak: How an Industry Giant Missed the Digital Revolution - Unlimited Graphic Design Service](https://penji.co/the-rise-and-fall-of-kodak/) (Kodak's focus on traditional film, despite the rise of digital, demonstrates reinforcing their own inertia.)
-- [Lessons from the Rise of Netflix and the Fall of Blockbuster | Cato Institute](https://www.cato.org/commentary/lessons-rise-netflix-fall-blockbuster) (Blockbuster's continued focus on physical stores, while Netflix innovated, is another example.)
-
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) - rel: this pattern is the foundation that this strategy seeks to exploit.
 - [Inertia can kill an organisation](/climatic-patterns/inertia-can-kill-an-organisation) - rel: this strategy accelerates the negative consequences of a competitor's inertia.
 - [Everything evolves](/climatic-patterns/everything-evolves) - rel: understanding that change is constant is key to recognizing when a competitor is failing to adapt, creating an opportunity for this strategy.
 - [Competitors actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) - rel: this strategy is a proactive way to change the game by leveraging a competitor's inertia.
+
+## 📚 **Further Reading & References**
+-   Clayton Christensen, *The Innovator's Dilemma*
+- [The Rise and Fall of Kodak: How an Industry Giant Missed the Digital Revolution - Unlimited Graphic Design Service](https://penji.co/the-rise-and-fall-of-kodak/) (Kodak's focus on traditional film, despite the rise of digital, demonstrates reinforcing their own inertia.)
+- [Lessons from the Rise of Netflix and the Fall of Blockbuster | Cato Institute](https://www.cato.org/commentary/lessons-rise-netflix-fall-blockbuster) (Blockbuster's continued focus on physical stores, while Netflix innovated, is another example.)

--- a/docs/strategies/competitor/restriction-of-movement/index.md
+++ b/docs/strategies/competitor/restriction-of-movement/index.md
@@ -9,7 +9,6 @@ tags: [restriction-of-movement, competitor, circling, ecosystem, cornering, cons
 This strategy, sometimes called "Circling," aims to constrain a competitor by blocking their options to evolve or react effectively.
 
 ## 🤔 **Explanation**
-
 ### What is Restriction of Movement?
 
 Restriction of Movement, or Circling, involves strategically limiting a competitor's ability to adapt or maneuver. It's about cornering them within the market or ecosystem, constraining their choices. If they try to innovate, you've boxed them in with patents or standards. If they try to expand, you're already there. If they seek partnerships, you've secured exclusivity. The competitor faces obstacles at every turn, confined to a limited space.
@@ -22,8 +21,14 @@ This strategy doesn't necessarily eliminate a competitor but restricts their gro
 
 By strategically controlling key aspects of the market, a business can limit a competitor's ability to grow or adapt. This can involve securing exclusive deals, establishing dominant standards, or creating patent thickets. The effect is to limit the competitor's options, forcing them into a constrained position.
 
-## 🚦 **When to Use / When to Avoid**
+## 🗺️ **Real-World Examples**
+-   **Facebook "Circling" Snapchat:** Facebook copied Snapchat's core features across its apps after failing to acquire Snapchat. Instagram Stories, WhatsApp Status, and Facebook Stories effectively encircled Snapchat's niche. This limited Snapchat's growth by restricting its room to maneuver.
 
+-   **Exclusive Deals and Ecosystem Control:** Apple's App Store policies restrict competitors on its platform by prohibiting alternative app stores and certain third-party functionalities. Microsoft's exclusive licensing deals with PC manufacturers in the 1990s limited rival operating systems' distribution.
+
+-   **Patent Fencing:** Companies create "patent thickets" by patenting a broad array of technologies, not just core inventions. This restricts competitors' innovation paths, as seen in the smartphone patent wars.
+
+## 🚦 **When to Use / When to Avoid**
 <Assessment strategyName="Restriction of Movement">
   <MapSignals>
     <li>The competitor depends heavily on a limited set of suppliers, channels, technologies, or partnerships to compete.</li>
@@ -53,16 +58,7 @@ Leadership should use this strategy when they want to holistically control the c
 
 Leaders should be cautious of harming industry relationships or attracting regulatory scrutiny.
 
-## 🗺️ **Real-World Examples**
-
--   **Facebook "Circling" Snapchat:** Facebook copied Snapchat's core features across its apps after failing to acquire Snapchat. Instagram Stories, WhatsApp Status, and Facebook Stories effectively encircled Snapchat's niche. This limited Snapchat's growth by restricting its room to maneuver.
-
--   **Exclusive Deals and Ecosystem Control:** Apple's App Store policies restrict competitors on its platform by prohibiting alternative app stores and certain third-party functionalities. Microsoft's exclusive licensing deals with PC manufacturers in the 1990s limited rival operating systems' distribution.
-
--   **Patent Fencing:** Companies create "patent thickets" by patenting a broad array of technologies, not just core inventions. This restricts competitors' innovation paths, as seen in the smartphone patent wars.
-
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 To pursue this strategy, leadership must think holistically and "surround" the competitive landscape. Leaders identify and control the competitor's critical enablers of flexibility, such as access to suppliers, distribution channels, talent, and technology. This often involves preemptive strikes, like securing exclusive partnerships.
@@ -72,7 +68,6 @@ To pursue this strategy, leadership must think holistically and "surround" the c
 proactive, preemptive, highly strategic
 
 ## 📋 **How to Execute**
-
 1.  **Map avenues of competitor growth**: Identify new markets, target customers, and potential innovations.
 2.  **Devise actions to block or limit each avenue**: This could involve securing distribution rights, introducing competing products, or locking in key partners.
 3.  **Product/Market Front**: Ensure offerings in adjacent spaces to prevent competitor diversification. Maintain multiple brands to cover market segments and eliminate pricing gaps for competitors.
@@ -89,7 +84,6 @@ proactive, preemptive, highly strategic
 Leaders should balance aggression with fair play within legal bounds.
 
 ## 📈 **Measuring Success**
-
 Success is often seen in what doesn't happen, such as a competitor's failure to gain market share or launch new products. Proxy metrics include:
 
 -   Share of key partnerships secured
@@ -97,14 +91,12 @@ Success is often seen in what doesn't happen, such as a competitor's failure to 
 -   Customer churn to competitors
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 -   **Competitor escape attempts**: Leaders must continually monitor competitors and respond quickly to plug any gaps in containment.
 -   **Overkill**: Completely encircling a non-threatening competitor can waste resources.
 -   **Dynamic markets**: Focus on a current competitor might blind you to new entrants or shifts.
 -   **Competitor changing the game**: Competitors might bypass your restrictions by introducing different business models.
 
 ## 🧠 **Strategic Insights**
-
 Restriction of movement is fundamentally about **controlling the competitive landscape** to neutralize competitors.
 
 ###   Competitor Behavior
@@ -128,7 +120,6 @@ Completely encircling a non-threatening competitor can waste resources. The stra
 Ultimately, restriction of movement can create a **stalemate favoring the stronger party**. The competitor remains, but their threat is limited. The company wins by controlling the status quo. It's a strategy of control and denial, limiting competitor options to erode their strength.
 
 ## ❓ **Key Questions to Ask**
-
 -   What are the competitor's potential avenues for growth or adaptation?
 -   How can we effectively block or limit each of these avenues?
 -   What are the potential unintended consequences of this strategy?
@@ -136,7 +127,6 @@ Ultimately, restriction of movement can create a **stalemate favoring the strong
 -   How can we adapt this strategy as the market evolves?
 
 ## 🔀 **Related Strategies**
-
 -   [**Alliances**](/strategies/ecosystem/alliances) - Forming alliances can be a way to restrict a competitor's access to partners.
 -   [**Co-opting**](/strategies/ecosystem/co-opting) - Can be used to influence the ecosystem to restrict a competitor.
 -   [**Raising Barriers to Entry**](/strategies/defensive/raising-barriers-to-entry) - Aims to restrict new competitors, similar to restricting existing ones.
@@ -145,11 +135,9 @@ Ultimately, restriction of movement can create a **stalemate favoring the strong
 -   [**Limitation of Competition**](/strategies/defensive/limitation-of-competition) - The overarching goal of restriction of movement.
 
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – influence: blocking options keeps rivals tied to outdated approaches.
 - [Capital flows to new areas of value](/climatic-patterns/capital-flows-to-new-areas-of-value) – trigger: constrained players may drive investment elsewhere.
 
 ## 📚 **Further Reading & References**
-
 -   *United States v. Microsoft Corp.* - Microsoft's bundling of Internet Explorer with Windows limited Netscape's access to the market.
 -   *Antitrust Division | U.S. V. Microsoft: Proposed Findings Of Fact* - Detailed evidence of how Microsoft restricted competitor movement.

--- a/docs/strategies/competitor/sapping/index.md
+++ b/docs/strategies/competitor/sapping/index.md
@@ -9,7 +9,6 @@ tags: [sapping, competitor, multi-front, attrition, endurance, resource drain, d
 Sapping, inspired by military tactics, involves launching simultaneous attacks across various fronts (product, price, marketing, geography) to stretch a competitor's resources and attention. The core idea is that a competitor capable of defending against a single attack will struggle against a barrage of concurrent challenges. By forcing a rival to divide their focus and resources, their overall effectiveness is degraded. Sapping is a strategy of attrition and distraction, aiming to drain the competitor's energy and induce mistakes or neglect.
 
 ## 🤔 **Explanation**
-
 ### What is Sapping?
 
 Sapping is a strategic approach that involves attacking a competitor on multiple fronts at the same time to reduce their ability to respond effectively. The strategy aims to overwhelm the competitor by forcing them to spread their resources and attention across many areas.
@@ -22,8 +21,14 @@ Sapping works by exploiting the limitations of a competitor's resources and atte
 
 Sapping is most effective when the attacker has superior resources or agility compared to the competitor. It is often used by larger or more diversified companies against narrower ones. The goal is to create a situation where the competitor cannot cope with the volume of challenges.
 
-## 🚦 **When to Use / When to Avoid**
+## 🗺️ **Real-World Examples**
+-   **Microsoft in the 1990s (Multi-Front Attack):** Microsoft competed on many fronts in the mid-1990s, including browsers (vs. Netscape), programming platforms (Java vs. Windows APIs), personal devices (vs. Sony/Palm), and enterprise software (vs. IBM/Novell). Microsoft's resources allowed it to link its attacks, such as Windows + Office integration against Netscape and Lotus/WordPerfect. An antitrust finding noted Microsoft's campaign against "middleware threats" like Netscape and Java, which "raised its rivals' costs, and ultimately, effectively eliminated Netscape as a platform threat" while weakening Sun's Java momentum. By opening simultaneous battles (browser, middleware, applications), Microsoft sapped competitors' abilities to mount a unified response.
 
+-   **Facebook vs. Emerging Social Apps:** Facebook's attack on Snapchat involved multiple fronts, including copying Stories (feature front), leveraging its global reach (geographic front), and using its ad targeting power (business front). This sapping strategy strained Snap, a smaller company, leading to impacts on Snapchat's growth and market cap. Facebook's multi-faceted approach targeted Snap from various angles.
+
+-   **Amazon vs. Retail Competitors:** Amazon often uses multi-front competition. Against traditional retailers like Target and Walmart in the mid-2000s, Amazon attacked through online sales in various product categories (general merchandise front), Amazon Prime with fast shipping (logistics/membership front), undercutting prices (pricing front), expanding into digital goods (new technology front), and entering cloud computing. Retailers faced challenges needing to invest in e-commerce tech, lower prices, improve supply chains, and consider new business lines simultaneously. This sapping strategy impacted many retailers, with survivors like Walmart also becoming multifaceted.
+
+## 🚦 **When to Use / When to Avoid**
 <Assessment strategyName="Sapping">
   <MapSignals>
     <li>The competitor holds a focused position or limited scope, making them vulnerable to attacks from multiple directions.</li>
@@ -53,16 +58,7 @@ Use sapping when you have superior resources or agility and can fight on many fr
 
 Avoid sapping if you lack the resources or agility to sustain a multi-front attack. It is also risky if the competitor has the capacity to counter-attack effectively or if the costs of the strategy outweigh the potential gains.
 
-## 🗺️ **Real-World Examples**
-
--   **Microsoft in the 1990s (Multi-Front Attack):** Microsoft competed on many fronts in the mid-1990s, including browsers (vs. Netscape), programming platforms (Java vs. Windows APIs), personal devices (vs. Sony/Palm), and enterprise software (vs. IBM/Novell). Microsoft's resources allowed it to link its attacks, such as Windows + Office integration against Netscape and Lotus/WordPerfect. An antitrust finding noted Microsoft's campaign against "middleware threats" like Netscape and Java, which "raised its rivals' costs, and ultimately, effectively eliminated Netscape as a platform threat" while weakening Sun's Java momentum. By opening simultaneous battles (browser, middleware, applications), Microsoft sapped competitors' abilities to mount a unified response.
-
--   **Facebook vs. Emerging Social Apps:** Facebook's attack on Snapchat involved multiple fronts, including copying Stories (feature front), leveraging its global reach (geographic front), and using its ad targeting power (business front). This sapping strategy strained Snap, a smaller company, leading to impacts on Snapchat's growth and market cap. Facebook's multi-faceted approach targeted Snap from various angles.
-
--   **Amazon vs. Retail Competitors:** Amazon often uses multi-front competition. Against traditional retailers like Target and Walmart in the mid-2000s, Amazon attacked through online sales in various product categories (general merchandise front), Amazon Prime with fast shipping (logistics/membership front), undercutting prices (pricing front), expanding into digital goods (new technology front), and entering cloud computing. Retailers faced challenges needing to invest in e-commerce tech, lower prices, improve supply chains, and consider new business lines simultaneously. This sapping strategy impacted many retailers, with survivors like Walmart also becoming multifaceted.
-
 ## 🎯 **Leadership**
-
 ### Core Challenge
 
 The core challenge in leading a sapping strategy is to maintain coordination and avoid overextension. Leaders must ensure that each front opened against the competitor is sustainable and that the organization has the resources and agility to support the multi-front campaign.
@@ -72,7 +68,6 @@ The core challenge in leading a sapping strategy is to maintain coordination and
 Coordination, resource management, prioritization, delegation, and maintaining morale are essential leadership skills for a sapping strategy. Leaders must prioritize objectives, delegate effectively, and communicate the overarching intent of the campaign. They must also prepare for counter-attacks and ensure their teams have the necessary support to avoid burnout.
 
 ## 📋 **How to Execute**
-
 1.  **Plan the Fronts:** Identify areas to attack the competitor, such as product offerings, service support, marketing campaigns, or geographic expansion.
 2.  **Initiate Action:** Launch initiatives on multiple fronts nearly simultaneously, such as releasing a competing product, cutting prices, starting a comparative advertising campaign, and forming partnerships that harm the competitor.
 3.  **Synchronize Timing:** Coordinate the timing of attacks to maximize pressure on the competitor, creating a series of impactful hits that weaken their ability to respond.
@@ -82,13 +77,11 @@ Coordination, resource management, prioritization, delegation, and maintaining m
 7.  **Organize Resources:** Consider forming cross-functional teams to coordinate multi-pronged efforts and break down silos within the organization.
 
 ## 📈 **Measuring Success**
-
 -   Impact on competitor: Reduction in competitor's market share, revenue, or profitability.
 -   Progress on each front: Achievement of objectives on individual fronts, such as product adoption, sales growth, or market penetration.
 -   Overall effectiveness: The degree to which the competitor's capacity to respond has been weakened and the extent to which they have been forced into a defensive position.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Overextension
 
 Launching too many fronts without sufficient resources can lead to overextension and weaken the attacker's position.
@@ -102,7 +95,6 @@ Failure to coordinate actions across different fronts can reduce the effectivene
 Assuming the competitor will not be able to respond effectively can lead to complacency and a failure to anticipate counter-attacks.
 
 ## 🧠 **Strategic Insights**
-
 ### Bandwidth vs. Singular Brilliance
 
 Sapping highlights that competition is about bandwidth as much as individual strength. By forcing a competitor to defend multiple areas, their bandwidth is exhausted, regardless of their strengths in any single area.
@@ -124,7 +116,6 @@ A multi-front war can be costly. The value of weakening the competitor should ou
 Sapping should lead to the competitor's collapse in one area or their retreat from some fronts. The attacker should be prepared to capitalize on these outcomes by shifting from attacking to securing wins and preventing the competitor from recovering.
 
 ## ❓ **Key Questions to Ask**
-
 -   What are the competitor's key weaknesses?
 -   What resources do we have to support a multi-front attack?
 -   How can we coordinate our actions across different fronts?
@@ -132,19 +123,16 @@ Sapping should lead to the competitor's collapse in one area or their retreat fr
 -   How will we measure the success of our sapping strategy?
 
 ## 🔀 **Related Strategies**
-
 -   [**Tech Drops**](/strategies/competitor/tech-drops): Sapping can involve elements of Tech Drops by launching surprise attacks on multiple fronts.
 -   [**Restriction of Movement**](/strategies/competitor/restriction-of-movement): Sapping can be used to restrict a competitor's movement and limit their ability to respond to attacks.
 -   [**Circling and Probing**](/strategies/competitor/circling-and-probing): Circling and probing can be used to identify weaknesses in a competitor before launching a sapping attack.
 
-## 📚 **Further Reading & References**
-
--   Clayton Christensen - "The Innovator's Dilemma" (for examples of multi-front competition and disruption).
-
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: The competitor's strengths and weaknesses will change over time, creating new sapping opportunities.
 - [Characteristics change](/climatic-patterns/characteristics-change) – rel: As components of a competitor's offering evolve, their dependencies might become vulnerabilities.
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: A competitor's past success can make them slow to react to sapping efforts.
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Identifying and exploiting a competitor's inefficiencies is a key aspect of sapping.
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: Sapping is a direct action to change the game by weakening a competitor.
+
+## 📚 **Further Reading & References**
+-   Clayton Christensen - "The Innovator's Dilemma" (for examples of multi-front competition and disruption).

--- a/docs/strategies/competitor/talent-raid/index.md
+++ b/docs/strategies/competitor/talent-raid/index.md
@@ -11,7 +11,6 @@ tags: [talent-raid, competitor, talent, human resources, acquisition, poaching, 
 A Talent Raid is a competitive strategy focused on removing or absorbing key talent from a rival organisation. By taking away a competitor's critical human resources — their experts, leaders, engineers or creative minds — you simultaneously strengthen your own company and weaken theirs. This can be done directly by hiring employees away or indirectly by enticing them through acquisitions or partnerships. Talent is often the lifeblood of tech and creative industries; a well‑timed raid can disrupt projects, slow innovation or deprive a competitor of strategic direction. In essence, a talent raid treats top employees as a scarce competitive asset and seeks to control that asset.
 
 ## 🤔 **Explanation**
-
 ### What is Talent Raid
 
 Talent Raid in Wardley's framework is a competitive strategy that involves strategically acquiring key personnel from rival organizations to enhance one's capabilities while diminishing the competitor's capacity to innovate and compete. This strategy views talent as a critical asset and aims to gain a competitive edge by controlling this asset.
@@ -29,8 +28,12 @@ A talent raid is valuable because it directly impacts a competitor's ability to 
 
 Talent Raid can be executed directly by hiring away a competitor's employees or indirectly through acquisitions or partnerships that bring talent in-house. It involves identifying key talent or teams within a competitor's organization, assessing their value, and then enticing them to join your organization. This often requires offering better compensation, career opportunities, or a more appealing work environment.
 
-## 🚦 **When to Use / When to Avoid**
+## 🗺️ **Real-World Examples**
+* **Apple and Tesla:** Apple and Tesla have notoriously traded talent, each looking to bolster their teams for electric cars and related technologies. In 2015, Tesla's CEO Elon Musk quipped that Apple was the "Tesla Graveyard" -- "If you don't make it at Tesla, you go work at Apple", in response to Apple hiring many ex-Tesla engineers. By 2018, Apple had poached at least 46 employees from Tesla in a single year, including key engineers for its secretive car project. This talent raid by Apple aimed to boost its own automotive initiative while undermining Tesla's. Losing dozens of experienced staff (some of whom had deep knowledge of Tesla's battery, software, and Autopilot systems) could slow Tesla's development and force them into a continuous recruitment and training mode. Conversely, Tesla has also raided Apple for talent in areas like user interface and chip design, hiring over 150 former Apple employees at one point. These raids indicate both companies see each other's talent as prime targets in the competition for electric and autonomous vehicle leadership.
+* **Google's Acqui-hiring:** Google has a history of "acqui-hiring" -- acquiring startups primarily to get their engineers and designers. For example, Google acquired a small team working on a mobile email app (SlideMail) not just for the product, but to bring the talented developers in-house (indirectly removing talent that could have been employed by competitors). Another case: when Google bought DeepMind in 2014, it wasn't just acquiring technology, but also scooping up some of the world's leading AI researchers, thereby denying that talent to competitors like Facebook or Microsoft. This is an indirect talent raid via acquisition, which gave Google a leap in AI capability and left others to either try to poach from Google or find talent elsewhere.
+* **Finance and Big Law Talent Moves:** In sectors like investment banking or law firms, it's common for a firm to lure star performers (a rainmaking banker or a celebrated trial lawyer) from a competitor with huge compensation packages. The reasoning is the same: that individual brings over clients or deals and leaves the former employer weakened (perhaps clients follow the person, or the competitor loses a unique skill set). For instance, when a top trading team or portfolio manager exits a hedge fund to join another, it's effectively a talent raid that can shake the original firm (investors might withdraw funds in that manager's absence).
 
+## 🚦 **When to Use / When to Avoid**
 <Assessment strategyName="Talent Raid">
   <MapSignals>
     <li>The competitor’s capabilities heavily depend on identifiable individuals or elite teams rather than scalable systems.</li>
@@ -62,14 +65,7 @@ Talent Raid is most effective when key talent or teams within a competitor's org
 * The cost of acquiring the talent outweighs the potential benefits.
 * A blatant raid can sour relationships when you still need to cooperate with that competitor in other areas.
 
-## 🗺️ **Real-World Examples**
-
-* **Apple and Tesla:** Apple and Tesla have notoriously traded talent, each looking to bolster their teams for electric cars and related technologies. In 2015, Tesla's CEO Elon Musk quipped that Apple was the "Tesla Graveyard" -- "If you don't make it at Tesla, you go work at Apple", in response to Apple hiring many ex-Tesla engineers. By 2018, Apple had poached at least 46 employees from Tesla in a single year, including key engineers for its secretive car project. This talent raid by Apple aimed to boost its own automotive initiative while undermining Tesla's. Losing dozens of experienced staff (some of whom had deep knowledge of Tesla's battery, software, and Autopilot systems) could slow Tesla's development and force them into a continuous recruitment and training mode. Conversely, Tesla has also raided Apple for talent in areas like user interface and chip design, hiring over 150 former Apple employees at one point. These raids indicate both companies see each other's talent as prime targets in the competition for electric and autonomous vehicle leadership.
-* **Google's Acqui-hiring:** Google has a history of "acqui-hiring" -- acquiring startups primarily to get their engineers and designers. For example, Google acquired a small team working on a mobile email app (SlideMail) not just for the product, but to bring the talented developers in-house (indirectly removing talent that could have been employed by competitors). Another case: when Google bought DeepMind in 2014, it wasn't just acquiring technology, but also scooping up some of the world's leading AI researchers, thereby denying that talent to competitors like Facebook or Microsoft. This is an indirect talent raid via acquisition, which gave Google a leap in AI capability and left others to either try to poach from Google or find talent elsewhere.
-* **Finance and Big Law Talent Moves:** In sectors like investment banking or law firms, it's common for a firm to lure star performers (a rainmaking banker or a celebrated trial lawyer) from a competitor with huge compensation packages. The reasoning is the same: that individual brings over clients or deals and leaves the former employer weakened (perhaps clients follow the person, or the competitor loses a unique skill set). For instance, when a top trading team or portfolio manager exits a hedge fund to join another, it's effectively a talent raid that can shake the original firm (investors might withdraw funds in that manager's absence).
-
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 The core leadership challenge is balancing tactical stealth with strategic workforce planning. Leaders must identify key talent, justify acquisition costs, and manage integration while mitigating risks and ethical concerns.
@@ -83,7 +79,6 @@ The core leadership challenge is balancing tactical stealth with strategic workf
 * Change management
 
 ## 📋 **How to Execute**
-
 ### Covert Approach
 
 * Use recruiters to discreetly approach target individuals.
@@ -111,7 +106,6 @@ The core leadership challenge is balancing tactical stealth with strategic workf
 * Manage the integration of new talent to ensure their success and minimize disruption to existing teams.
 
 ## 📈 **Measuring Success**
-
 * Impact on competitor's performance (e.g., project delays, loss of market share).
 * Performance and contribution of the acquired talent.
 * Retention rate of the acquired talent.
@@ -120,7 +114,6 @@ The core leadership challenge is balancing tactical stealth with strategic workf
 * Morale and productivity of existing employees.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 * Over-reliance on talent raids can lead to neglect in developing internal talent.
 * Poached talent may not perform as expected in the new environment.
 * Talent raids can be costly and may not always yield the desired results.
@@ -128,7 +121,6 @@ The core leadership challenge is balancing tactical stealth with strategic workf
 * Talent raids can damage relationships with competitors and impact future collaborations.
 
 ## 🧠 **Strategic Insights**
-
 ### Strategic Insights
 
 Talent raids are rooted in the understanding that **companies are fundamentally collections of people and their knowledge**. By strategically redirecting the flow of talent, a company can significantly alter the balance of power within a competitive landscape.
@@ -158,7 +150,6 @@ In industries characterized by scarce expertise, such as AI or chip design, succ
 It's essential to consider the potential optics and impact on relationships with competitors. A blatant or overly aggressive talent raid can strain relationships and damage trust, particularly if there's an expectation of cooperation in other areas. While talent raiding may be considered fair play in intense rivalries, it's important to weigh the potential consequences for broader industry relationships and future collaborations.
 
 ## ❓ **Key Questions to Ask**
-
 * Which key talent or teams within competitor organizations would significantly benefit our company?
 * What are the potential costs and benefits of acquiring this talent?
 * How will we integrate the new talent and ensure their success?
@@ -167,7 +158,6 @@ It's essential to consider the potential optics and impact on relationships with
 * What is our plan for developing and retaining our existing talent?
 
 ## 🔀 **Related Strategies**
-
 * [**Restriction of Movement**](/strategies/competitor/restriction-of-movement) - Aims to prevent talent from leaving or joining competitors, the opposite of Talent Raid.
 * [**Tech Drops**](/strategies/competitor/tech-drops) - Can be used in conjunction with a Talent Raid to exploit a competitor's weakened position after the raid.
 * [**Threat Acquisition**](/strategies/defensive/threat-acquisition) - Acquiring a company to eliminate a potential competitor can also bring in valuable talent.
@@ -175,11 +165,9 @@ It's essential to consider the potential optics and impact on relationships with
 * [**Market Enablement**](/strategies/accelerators/market-enablement) - If the talent raid brings in individuals with strong market connections or expertise, it can enable market growth.
 
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Future value is inversely proportional to the certainty we have over it](/climatic-patterns/future-value-is-inversely-proportional-to-the-certainty-we-have-over-it) – influence: securing key talent helps navigate uncertain markets.
 - [Inertia can kill an organisation](/climatic-patterns/inertia-can-kill-an-organisation) – trigger: poaching exposes a rival's slow response to change.
 
 ## 📚 **Further Reading & References**
-
-  * [Tesla Employees Are Getting Poached by Apple, Which Elon Musk Called a 'Tesla Graveyard' - Business Insider](https://www.google.com/search?q=https://www.businessinsider.com/apple-poaching-tesla-employees-elon-musk-tesla-graveyard-2021-12)
+* [Tesla Employees Are Getting Poached by Apple, Which Elon Musk Called a 'Tesla Graveyard' - Business Insider](https://www.google.com/search?q=https://www.businessinsider.com/apple-poaching-tesla-employees-elon-musk-tesla-graveyard-2021-12)
   * [Elon Musk Has Raided 150 People From Apple For Tesla - Forbes](https://www.google.com/search?q=https://www.forbes.com/sites/qai/2022/01/05/elon-musk-has-raided-150-people-from-apple-for-tesla/)

--- a/docs/strategies/competitor/tech-drops/index.md
+++ b/docs/strategies/competitor/tech-drops/index.md
@@ -11,7 +11,6 @@ tags: [competitor, surprise, innovation, technology, tech-drop, disruption, proa
 > - Simon Wardley
 
 ## 🤔 **Explanation**
-
 ### What is Tech Drops?
 
 Tech Drops is a proactive competitive strategy where a company launches a significant, market-shaping technological innovation with little to no prior warning. The primary aim is to create a new paradigm or fundamentally alter market expectations, thereby seizing the initiative and compelling competitors to adapt to a new reality defined by the innovator. These "tech drops" are characterized by their novelty and scale, introducing a substantial leap in capability or value that bypasses incremental development cycles. A successful Tech Drop establishes the initiator as a market leader, sets new technological standards, and can reshape the entire competitive landscape by creating new sources of value.
@@ -24,8 +23,16 @@ Tech Drops allows an organization to proactively define the future trajectory of
 
 The strategy hinges on visionary innovation, rigorous development in secrecy, and flawless execution. A novel technological concept is typically incubated away from public view (e.g., in a dedicated R&D lab or "skunkworks" project) to ensure the element of surprise. Simultaneously, the organization prepares for mass adoption by ensuring scalability of infrastructure, marketing, and support services. The launch is a high-impact, coordinated event designed to maximize market awareness and demonstrate the clear superiority or novelty of the innovation. The goal is to make the new technology appear as a sudden breakthrough, fundamentally changing what customers expect from products or services in that category.
 
-## 🚦 **When to Use / When to Avoid**
+## 🗺️ **Real-World Examples**
+### Apple's iPhone Launch (2007)
 
+The introduction of the iPhone is a masterclass in the Tech Drops strategy. While competitors like Nokia, BlackBerry, and Microsoft were focused on incremental improvements to physical keyboards and enterprise features, Apple secretly developed a device that combined a multi-touch screen, a full-featured web browser, and an iPod into a single product. The launch caught the entire industry by surprise, instantly making existing "smartphones" feel obsolete and forcing every competitor to abandon their roadmaps and start over.
+
+### AWS Lambda Launch (2014)
+
+At its re:Invent conference, AWS frequently uses Tech Drops tactics. The launch of AWS Lambda in 2014 is a prime example. While the industry was focused on virtual machines and containers, AWS introduced "serverless" computing, a completely new paradigm for building applications. This move created a new market category out of thin air, established AWS as the leader, and forced competitors like Google and Microsoft to spend years developing their own competing offerings (Google Cloud Functions and Azure Functions).
+
+## 🚦 **When to Use / When to Avoid**
 <Assessment strategyName="Tech Drops">
   <MapSignals>
     <li>We have a capability that competitors see as low-evolution, but we've industrialized it.</li>
@@ -42,18 +49,7 @@ The strategy hinges on visionary innovation, rigorous development in secrecy, an
   </Readiness>
 </Assessment>
 
-## 🗺️ **Real-World Examples**
-
-### Apple's iPhone Launch (2007)
-
-The introduction of the iPhone is a masterclass in the Tech Drops strategy. While competitors like Nokia, BlackBerry, and Microsoft were focused on incremental improvements to physical keyboards and enterprise features, Apple secretly developed a device that combined a multi-touch screen, a full-featured web browser, and an iPod into a single product. The launch caught the entire industry by surprise, instantly making existing "smartphones" feel obsolete and forcing every competitor to abandon their roadmaps and start over.
-
-### AWS Lambda Launch (2014)
-
-At its re:Invent conference, AWS frequently uses Tech Drops tactics. The launch of AWS Lambda in 2014 is a prime example. While the industry was focused on virtual machines and containers, AWS introduced "serverless" computing, a completely new paradigm for building applications. This move created a new market category out of thin air, established AWS as the leader, and forced competitors like Google and Microsoft to spend years developing their own competing offerings (Google Cloud Functions and Azure Functions).
-
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 The core challenge is managing the high-stakes trade-off between secrecy and speed. Developing a major innovation in secret can be slow and expensive, and it risks the project becoming disconnected from market needs. Leaders must have the conviction to fund and protect these secret projects, while also ensuring they are ready for a flawless, high-impact launch.
@@ -71,7 +67,6 @@ The core challenge is managing the high-stakes trade-off between secrecy and spe
 While Tech Drops is a legitimate competitive strategy, it can be seen as aggressive. The primary ethical consideration is to ensure the surprise is based on genuine innovation, not on deceptive practices or spreading misinformation about competitors. The goal is to win by out-innovating, not by misleading the market.
 
 ## 📋 **How to Execute**
-
 1.  **Identify Leverage Points**: Use mapping to find unmet needs or areas where competitor inertia creates an opening for a surprise move.
 2.  **Plan in Secret**: Use isolated "skunkworks" teams and enforce strict information control to prevent leaks.
 3.  **Ensure Readiness**: Prepare supply chains, infrastructure, and customer support to handle the demand generated by a successful launch.
@@ -92,7 +87,6 @@ sequenceDiagram
 ```
 
 ## 📈 **Measuring Success**
-
 - **Shift in Market Share:** A measurable increase in your market share following the launch.
 - **Competitor Reaction Time:** How long it takes for competitors to launch a comparable offering.
 - **Adoption Rate:** The speed at which customers adopt your new innovation.
@@ -100,7 +94,6 @@ sequenceDiagram
 - **Customer Feedback:** Positive reviews and feedback confirming the value of the innovation.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Weak Innovation
 
 If the "surprise" is not significant or valuable enough, competitors may simply ignore it, and the Tech Drop will fail.
@@ -114,7 +107,6 @@ A buggy product, a weak supply chain, or inadequate customer support can turn a 
 A well-executed Tech Drop can be quickly copied by an agile competitor. If your innovation is not defensible, your advantage may be short-lived.
 
 ## 🧠 **Strategic Insights**
-
 ### Resetting the Competitive Clock
 
 A successful Tech Drop doesn't just put you ahead; it resets the entire competitive clock. It forces all players back to a new starting line that you have defined, making their previous roadmaps and investments irrelevant. This is a powerful way to neutralize an incumbent's advantage.
@@ -144,7 +136,6 @@ It's important to distinguish Tech Drops from [Ambush](/strategies/competitor/am
 | **Surprise From**  | The novelty/scale of the innovation itself.                               | The timing and nature of the counter-attack.                                                           |
 
 ## ❓ **Key Questions to Ask**
-
 - **Significance:** Is this innovation truly a leap forward, or just an incremental improvement?
 - **Defensibility:** How will we defend our position after the surprise wears off?
 - **Execution Readiness:** Are all parts of our organization truly ready to support this launch at scale?
@@ -152,19 +143,16 @@ It's important to distinguish Tech Drops from [Ambush](/strategies/competitor/am
 - **Ethical Stance:** Are we winning through superior innovation or through tactics that could damage our reputation?
 
 ## 🔀 **Related Strategies**
-
 - [**Circling and Probing**](/strategies/competitor/circling-and-probing): Can be used to identify market weaknesses or test competitor reactions to signals before committing to a full Tech Drop.
 - [**Misdirection**](/strategies/competitor/misdirection): Can be employed to divert market attention while the core innovation for the Tech Drop is being developed in secret.
 - [**Undermining Barriers to Entry**](/strategies/attacking/undermining-barriers-to-entry): A successful Tech Drop often inherently undermines existing barriers by creating a new playing field or rendering old advantages irrelevant.
 - [**Ambush**](/strategies/competitor/ambush): Contrasts with Tech Drops in its reactive nature. Understanding Ambush helps clarify the proactive, market-creating intent of Tech Drops.
 
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Change is not always linear](/climatic-patterns/change-is-not-always-linear) – influence: a Tech Drop creates a punctuated equilibrium, a sudden leap in evolution.
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – trigger: a Tech Drop is a direct attempt to change the game on your own terms.
 
 ## 📚 **Further Reading & References**
-
 - [The Innovator's Dilemma](https://www.goodreads.com/book/show/2618.The_Innovator_s_Dilemma) by Clayton Christensen - Explains the theory of disruptive innovation, which is often the basis for a Tech Drop.
 - [The Art of War](https://www.goodreads.com/book/show/10534.The_Art_of_War) by Sun Tzu - The classic text on strategy, with timeless insights on the importance of surprise and deception.
 - [Apple's iPhone launch 2007](https://www.youtube.com/watch?v=vN4U5FqrOdQ) - A video of the event, showcasing how a masterfully executed Tech Drop can reshape an industry.

--- a/docs/strategies/dealing-with-toxicity/disposal-of-liability/index.md
+++ b/docs/strategies/dealing-with-toxicity/disposal-of-liability/index.md
@@ -14,7 +14,6 @@ id of the toxic."*
 > - Simon Wardley
 
 ## 🤔 **Explanation**
-
 ### What is Disposal of Liability?
 Disposal of Liability is the strategic removal of components, such as products, services, or operations, that have become
 burdensome or harmful to an organization’s evolution. These components may be outdated, costly to maintain, or generate inertia
@@ -30,7 +29,6 @@ risk, and strategic fit. Develop a disposal plan, which may include divestiture,
 communicate with stakeholders, and manage the transition carefully.
 
 ## 🗺️ **Real-World Examples**
-
 ### IBM’s PC Division Sale to Lenovo (2005)
 IBM sold its commoditized PC division to Lenovo to shed a low-margin business and focus on services and software, enabling it
 to reallocate resources to higher-growth areas.
@@ -44,7 +42,6 @@ A telecom operator divests its legacy copper infrastructure to a specialized fir
 investment in broadband and wireless networks.
 
 ## 🚦 **When to Use / When to Avoid**
-
 <Assessment strategyName="Disposal of Liability">
   <MapSignals>
     <li>Our map shows key components stuck in a mature or commodity stage.</li>
@@ -67,7 +64,6 @@ utweighs the benefits, and you have leadership support for disposal.
 stakeholder alignment to execute a disposal plan.
 
 ## 🎯 **Leadership**
-
 ### Core challenge
 Navigating internal resistance and ensuring organizational alignment when proposing the removal of long-standing assets that
 employees and customers may be attached to.
@@ -83,7 +79,6 @@ Ensure that disposal does not abandon stakeholders, such as employees, customers
 severance, or transition support.
 
 ## 📋 **How to Execute**
-
 1. Map and identify liabilities in your value chain.
 2. Evaluate cost, risk, and strategic fit of each component.
 3. Develop a disposal plan (divestiture, shutdown, or sale).
@@ -92,14 +87,12 @@ severance, or transition support.
 6. Manage transition and monitor outcomes.
 
 ## 📈 **Measuring Success**
-
 - Reduction in maintenance and operational costs.
 - Resources reallocated to strategic initiatives.
 - Percentage of legacy components successfully removed.
 - Improvement in organizational agility and focus.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Underestimating hidden costs
 Disposal can incur unforeseen expenses—legal fees, severance, or environmental cleanup—that jeopardize the plan.
 
@@ -113,7 +106,6 @@ Ignoring contractual obligations or regulatory requirements can result in fines 
 Removing a component too quickly may deprive the organization of essential skills or knowledge.
 
 ## 🧠 **Strategic Insights**
-
 ### Evolution acceleration
 Removing outdated components accelerates organizational evolution by clearing bottlenecks.
 
@@ -124,7 +116,6 @@ Disposal clarifies strategy, directing attention and investment toward future-fa
 While disposal reduces systemic drag, it can concentrate risk if overused or poorly planned.
 
 ## ❓ **Key Questions to Ask**
-
 - What assets are dragging our evolution?
 - Where are we investing resources to maintain obsolete components?
 - Who will be affected by disposal and how will we support them?
@@ -132,22 +123,19 @@ While disposal reduces systemic drag, it can concentrate risk if overused or poo
 - What is the timeline and criteria for success?
 
 ## 🔀 **Related Strategies**
-
 - [Sweat & Dump](/strategies/dealing-with-toxicity/sweat-and-dump) - Outsource toxic assets to third parties when direct
 disposal isn’t feasible.
 - [Pig in a Poke](/strategies/dealing-with-toxicity/pig-in-a-poke) - Misrepresent toxic assets as valuable to offload them.
 - [Refactoring](/strategies/dealing-with-toxicity/refactoring) - Internally transform or repurpose components as an
 alternative to disposal.
 
-## 📚 **Further Reading & References**
-
-- HBR: [“Pruning the Corporate Portfolio”](https://hbr.org/2017/12/case-study-should-a-hotel-giant-eliminate-some-brands-and-refocus) - Guidance on divestment timing and execution.
-- [General Electric rids itself of financial unit in $26.5bn deal as it hones focus](https://www.theguardian.com/business/2015/apr/10/general-electric-sell-financial-unit-26-billion-deal) - GE’s divestiture of GE Capital (2015) - Case study of reducing complexity by divesting a non-core business.
-
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: What was once an asset can become a liability as the market and technology landscape changes.
 - [Characteristics change](/climatic-patterns/characteristics-change) – rel: The characteristics of a component or business unit can shift, making it toxic to the parent company.
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Holding onto a liability due to past success can be detrimental; disposal is necessary.
 - [Creative Destruction](/climatic-patterns/creative-destruction) – rel: Disposing of a liability can be a form of creative destruction, allowing resources to be reallocated to more promising areas.
 - [Capital flows to new areas of value](/climatic-patterns/capital-flows-to-new-areas-of-value) – rel: Freeing up capital by disposing of liabilities allows investment in new value-creating opportunities.
+
+## 📚 **Further Reading & References**
+- HBR: [“Pruning the Corporate Portfolio”](https://hbr.org/2017/12/case-study-should-a-hotel-giant-eliminate-some-brands-and-refocus) - Guidance on divestment timing and execution.
+- [General Electric rids itself of financial unit in $26.5bn deal as it hones focus](https://www.theguardian.com/business/2015/apr/10/general-electric-sell-financial-unit-26-billion-deal) - GE’s divestiture of GE Capital (2015) - Case study of reducing complexity by divesting a non-core business.

--- a/docs/strategies/dealing-with-toxicity/pig-in-a-poke/index.md
+++ b/docs/strategies/dealing-with-toxicity/pig-in-a-poke/index.md
@@ -13,7 +13,6 @@ tags: [dealing-with-toxicity, pig-in-a-poke, deception, misrepresentation, exit-
 > - Simon Wardley
 
 ## 🤔 **Explanation**
-
 ### What is Pig in a Poke?
 Pig in a Poke is a strategy where an organization packages a declining, problematic, or toxic asset as if it still holds growth potential. By crafting a positive narrative and timing the sale, you transfer liability to a buyer who believes they are acquiring something valuable.
 
@@ -28,7 +27,6 @@ This tactic allows you to extract maximum value from an asset that would otherwi
 - Execute the sale swiftly before the asset’s issues become widely known.
 
 ## 🗺️ **Real-World Examples**
-
 ### AOL–Time Warner Merger (2000)
 AOL’s overvalued dial-up subscriber base was used as currency to merge with Time Warner at the peak of dot-com optimism. When the bubble burst, Time Warner realized it had acquired a “pig in a poke.”
 
@@ -39,7 +37,6 @@ Banks bundled risky home loans into complex CDOs rated as high quality. Investor
 Mark Cuban sold Broadcast.com to Yahoo at the height of internet hype. The technology quickly became obsolete, but Cuban had already “sold the pig” for a hefty profit.
 
 ## 🚦 **When to Use / When to Avoid**
-
 <Assessment strategyName="Pig in a Poke">
   <MapSignals>
     <li>Our map shows an asset in decline but with residual market excitement.</li>
@@ -60,7 +57,6 @@ Mark Cuban sold Broadcast.com to Yahoo at the height of internet hype. The techn
 **Avoid when:** Due diligence processes are thorough, regulatory scrutiny is high, or you cannot absorb the legal and reputational fallout if discovered.
 
 ## 🎯 **Leadership**
-
 ### Core challenge
 Convincing buyers of future value while suppressing or downplaying evidence of decline, all without exposing the scheme prematurely.
 
@@ -74,7 +70,6 @@ Convincing buyers of future value while suppressing or downplaying evidence of d
 Pig in a Poke borders on fraud if misrepresentation is intentional. Consider long-term brand damage and legal consequences before choosing this approach.
 
 ## 📋 **How to Execute**
-
 1. Map the asset’s lifecycle stage and identify signs of decline.
 2. Audit metrics to highlight positive anomalies.
 3. Craft marketing materials emphasizing potential upside and urgency.
@@ -83,14 +78,12 @@ Pig in a Poke borders on fraud if misrepresentation is intentional. Consider lon
 6. Close the transaction swiftly and hand over all agreed documentation.
 
 ## 📈 **Measuring Success**
-
 - Sale price relative to current asset value
 - Speed of transaction completion
 - Legal or regulatory incidents avoided post-sale
 - Retention of buyer relationships for future transactions
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Due Diligence Detection
 If buyers uncover inconsistent data or hidden risks, they may renegotiate or cancel the deal.
 
@@ -104,7 +97,6 @@ News of a deceptive sale can erode trust and harm future ventures.
 Performance-based earn-outs can leave you on the hook if the asset fails post-sale.
 
 ## 🧠 **Strategic Insights**
-
 ### The "Known Unknown" Buyer Gambit
 While "Pig in a Poke" often implies deceiving a naive buyer, a more nuanced version involves a buyer who is partially aware of potential issues—a "known unknown." Such buyers might possess specific expertise, believe they have unique turnaround capabilities, or see potential synergies that could neutralize the asset's toxicity or unlock value others cannot perceive. The seller's strategy here is not pure misdirection but rather a subtle highlighting of "untapped potential" or framing the asset as a "diamond in the rough" that requires a special kind of vision or capability. This shifts the dynamic from outright deception to a calculated gamble by the buyer, who hopes their unique strengths can overcome the inherent risks they partially perceive. The seller facilitates this by providing just enough positive framing to encourage the buyer's optimistic self-assessment.
 
@@ -118,7 +110,6 @@ In industries or market segments facing secular decline, the "Pig in a Poke" str
 Executing a "Pig in a Poke" directly can inflict significant, long-lasting reputational damage upon the seller. To mitigate this, sophisticated actors may employ intermediaries to obscure the asset's trail and their connection to it. This can involve transferring the toxic asset to a newly created subsidiary with a clean slate, using specialized brokers known for handling distressed or opaque assets, or even embedding the sale within a larger, more complex M&A transaction where the "pig" is a less scrutinized component. The intermediary acts as a buffer, "laundering" the asset by creating distance and complexity. The goal is to break the chain of custody in a way that obscures the seller's intent and the asset's problematic origins. By the time the asset's true nature is revealed, its problematic history and the identity of the original seller aiming to offload a liability are more difficult to trace, thereby protecting the seller's broader market reputation.
 
 ## ❓ **Key Questions to Ask**
-
 - What signals can we amplify to mask decline?
 - Which buyers are most susceptible to hype?
 - Can we structure the sale to limit future liability?
@@ -126,20 +117,17 @@ Executing a "Pig in a Poke" directly can inflict significant, long-lasting reput
 - Do we have the legal cover for our disclosure strategy?
 
 ## 🔀 **Related Strategies**
-
 - [Disposal of Liability](/strategies/dealing-with-toxicity/disposal-of-liability) – A direct exit by divestment or shutdown.
 - [Sweat & Dump](/strategies/dealing-with-toxicity/sweat-and-dump) – Outsource asset operation to third parties before exiting.
 - [Refactoring](/strategies/dealing-with-toxicity/refactoring) – Internally transform or repurpose assets as an alternative.
 
-## 📚 **Further Reading & References**
-
-- [Pump and Dump](https://en.wikipedia.org/wiki/Pump_and_dump) – Overview of the practice in financial markets.
-- Case Study: Cuban’s [Broadcast.com Sale](https://en.wikipedia.org/wiki/Broadcast.com) – Timing an exit at peak hype for maximum gain.
-
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: A component that was once valuable can become less so, tempting a seller to offload it deceptively.
 - [Characteristics change](/climatic-patterns/characteristics-change) – rel: The declining characteristics of an asset might motivate its misrepresentation.
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Buyers might be blinded by the past reputation of an asset, failing to see its current toxicity.
 - [Most competitors have poor situational awareness](/climatic-patterns/most-competitors-have-poor-situational-awareness) – rel: The seller exploits the buyer's lack of awareness or due diligence.
 - [Future value is inversely proportional to the certainty we have over it](/climatic-patterns/future-value-is-inversely-proportional-to-the-certainty-we-have-over-it) – rel: The seller creates a false sense of certainty about future value.
+
+## 📚 **Further Reading & References**
+- [Pump and Dump](https://en.wikipedia.org/wiki/Pump_and_dump) – Overview of the practice in financial markets.
+- Case Study: Cuban’s [Broadcast.com Sale](https://en.wikipedia.org/wiki/Broadcast.com) – Timing an exit at peak hype for maximum gain.

--- a/docs/strategies/dealing-with-toxicity/refactoring/index.md
+++ b/docs/strategies/dealing-with-toxicity/refactoring/index.md
@@ -11,15 +11,26 @@ Internally **reorganizing and repurposing components of a legacy system** to sal
 :::
 
 ## 🤔 **Explanation**
-
 Rather than outright disposal or sale, refactoring keeps the asset in-house but **transforms it**. Origin is from programming (improving internal structure without changing external behavior). In business, it might mean dividing a legacy operation into components: some can merge into other departments, some tasks automated or given new purpose, and only the truly unusable parts are shed.
 
 Purpose: *reduce losses and integrate leftover value* into the organization in a leaner way.
 
 Key principles: identify components (people, tech, processes) that can be useful elsewhere. For example, maybe the product is dead but the underlying database could support another service, or the team can be moved to a different project with slight retraining. By refactoring, you gradually wind down the old structure while not wasting everything.
 
-## 🚦 **When to Use / When to Avoid**
+## 🗺️ **Real-World Examples**
+### Software/Tech
 
+Many companies "refactor" their legacy IT. E.g., taking an old mainframe application and breaking it into microservices or migrating functions to modern systems one piece at a time (some parts might be turned into APIs for new apps). In doing so, they preserve critical logic or data (value) but eliminate the monolithic, hard-to-maintain structure. IBM's example with moving combustion engine production offshore (per forum) was partly a physical refactoring, shifting location and focusing that unit solely on being a cost-efficient piece until shut down.
+
+### Industrial
+
+A car manufacturer phasing out combustion engines might refactor its production: move older engine production lines to a lower-cost factory (like VW moving them to Poland) and repurpose some facilities to build electric components. They aren't scrapping everything: they reassign factories or workers to new tasks where possible (e.g., train engine designers to work on electric drive trains). Ultimately, when combustion ends, they have minimized domestic impact and squeezed remaining value from those engines in a cheaper setting. They have a mix of sweat (in cheaper plant) and integration (transition workforce to new tech).
+
+### Hypothetical
+
+A publishing company has a huge staff for print magazine layout, a diminishing need. Instead of mass layoffs, it refactors: it retrains a chunk of them in digital content layout and transfers them to the web team (useful skill reuse), it automates some layout tasks with software, and for the purely excess roles, it offers either internal transfers (some designers might move to marketing department) or packages out. The physical space freed by a smaller print team is converted into a multimedia studio for new digital content. This way, the company gradually morphs the legacy print operation into a leaner, partly repurposed unit that complements the digital side, rather than a sudden chop.
+
+## 🚦 **When to Use / When to Avoid**
 <Assessment strategyName="Refactoring">
   <MapSignals>
     <li>We are managing a legacy system or operation whose relevance or value is declining.</li>
@@ -50,22 +61,7 @@ The legacy asset has **subcomponents of value** that you can clearly redeploy. O
 
 The toxic asset is hemorrhaging so badly that incremental changes won't stop the bleeding -- sometimes you need a quick cut (disposal) rather than gentle refactor. Also avoid if the effort to refactor is too high or distracts too much from core (sometimes dismantling internally can consume a lot of management attention -- if that's the case, might be better to do sweat & dump or pig in poke). If no part of the old is really salvageable or compatible with new directions, refactoring may just delay the inevitable.
 
-## 🗺️ **Real-World Examples**
-
-### Software/Tech
-
-Many companies "refactor" their legacy IT. E.g., taking an old mainframe application and breaking it into microservices or migrating functions to modern systems one piece at a time (some parts might be turned into APIs for new apps). In doing so, they preserve critical logic or data (value) but eliminate the monolithic, hard-to-maintain structure. IBM's example with moving combustion engine production offshore (per forum) was partly a physical refactoring, shifting location and focusing that unit solely on being a cost-efficient piece until shut down.
-
-### Industrial
-
-A car manufacturer phasing out combustion engines might refactor its production: move older engine production lines to a lower-cost factory (like VW moving them to Poland) and repurpose some facilities to build electric components. They aren't scrapping everything: they reassign factories or workers to new tasks where possible (e.g., train engine designers to work on electric drive trains). Ultimately, when combustion ends, they have minimized domestic impact and squeezed remaining value from those engines in a cheaper setting. They have a mix of sweat (in cheaper plant) and integration (transition workforce to new tech).
-
-### Hypothetical
-
-A publishing company has a huge staff for print magazine layout, a diminishing need. Instead of mass layoffs, it refactors: it retrains a chunk of them in digital content layout and transfers them to the web team (useful skill reuse), it automates some layout tasks with software, and for the purely excess roles, it offers either internal transfers (some designers might move to marketing department) or packages out. The physical space freed by a smaller print team is converted into a multimedia studio for new digital content. This way, the company gradually morphs the legacy print operation into a leaner, partly repurposed unit that complements the digital side, rather than a sudden chop.
-
 ## 🎯 **Leadership**
-
 ### Core Challenge
 
 The primary leadership challenge is **managing the transition sensitively and decisively**. This involves identifying true value amidst the legacy, overcoming internal resistance attached to the old ways, and effectively reallocating resources (especially people) without excessive disruption or loss of morale. It requires balancing the need to shed toxicity with the desire to preserve useful elements and knowledge.
@@ -79,7 +75,6 @@ The primary leadership challenge is **managing the transition sensitively and de
 - **Empathy:** Understanding the impact on employees tied to the legacy system.
 
 ## 📋 **How to Execute**
-
 1.  **Map the Legacy System:** Use Wardley Mapping or similar techniques to break down the legacy asset (product, service, process) into its core components (technology, data, skills, customer segments).
 2.  **Assess Component Value & Evolution:** Evaluate each component. Is it still valuable? Can it be reused? Where is it on the evolution axis (Genesis, Custom, Product, Commodity)?
 3.  **Identify Reusable Parts:** Pinpoint components (e.g., a specific dataset, a skilled team, a modular piece of tech) that can be integrated into newer, strategic initiatives.
@@ -95,7 +90,6 @@ The primary leadership challenge is **managing the transition sensitively and de
 - **Data Handling:** Ensure any data migrated or repurposed is handled according to privacy regulations and ethical guidelines.
 
 ## 📈 **Measuring Success**
-
 - **Cost Reduction:** Reduced operational or maintenance costs associated with the legacy system.
 - **Resource Redeployment:** Successful transfer of staff, technology, or capital to new strategic areas.
 - **Improved Agility:** Increased organizational speed or flexibility due to removal of legacy constraints.
@@ -104,21 +98,18 @@ The primary leadership challenge is **managing the transition sensitively and de
 - **Timeline Adherence:** Completion of refactoring stages according to the plan.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 - **Scope creep:** Refactoring can turn into a never-ending project if not clearly bounded ("while we're at it, let's also overhaul X..."). Need discipline to ensure it serves the purpose of winding down legacy gracefully, not becoming an excuse to tinker indefinitely.
 - **Parallel costs:** During refactoring, you often run old and new in parallel (to keep things running while transitioning parts). This can be costly. If not managed, you might double spend for a while and upper management could lose patience.
 - **Internal confusion/Resistance:** Employees may be unsure of their future roles during the reassignments, or actively resist the change if attached to the old system. Clear communication and strong change leadership are needed.
 - **Technical Debt Accumulation:** Sometimes refactoring is done hastily, creating new forms of technical debt in the "repurposed" components.
 
 ## 🧠 **Strategic Insights**
-
 - **Value Preservation:** Unlike simple disposal, refactoring acknowledges that legacy systems often contain trapped value (knowledge, data, skills) that can be unlocked.
 - **Gradual Evolution:** It allows for a less abrupt transition, managing inertia by evolving components rather than just cutting them off. Useful when a sudden stop is too disruptive.
 - **Internal Focus:** It's an internally focused strategy for dealing with toxicity, contrasting with external plays like 'Sweat & Dump' or 'Pig in a Poke'.
 - **Enabler for Future Growth:** By cleaning up legacy constraints and redeploying resources, refactoring frees up capacity for innovation and focus on future value streams.
 
 ## ❓ **Key Questions to Ask**
-
 - What specific components make up this legacy system?
 - Which of these components still hold value or could be repurposed?
 - What is the true cost of maintaining the legacy system vs. the cost of refactoring?
@@ -128,20 +119,16 @@ The primary leadership challenge is **managing the transition sensitively and de
 - How long will the refactoring process take, and what are the key milestones?
 
 ## 🔀 **Related Strategies**
-
-
 - [**Disposal of Liability**](/strategies/dealing-with-toxicity/disposal-of-liability) refactoring is an approach to disposal by reuse
 - [**Sweat & Dump**](/strategies/dealing-with-toxicity/sweat-and-dump) as an alternative - instead of third-party, you internally transform
 
-## 📚 **Further Reading & References**
-
-- Agile/DevOps analogies - Many tech companies apply refactoring to processes: e.g., breaking a legacy business process into agile teams. Business literature on **business process re-engineering** touches similar ideas (though BPR often aimed at improvement, here aim is also removal).
-- *"Dual Transformation" (Anthony, Johnson)* - a strategy book that talks about running a legacy business (Transformation B) while building new (Transformation A), and how to transfer capabilities from B to A. It's essentially how to refactor an organization during disruption, moving old capabilities to new growth, similar to refactoring concept described here.
-
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: Legacy systems inevitably reach a point where they need refactoring or disposal due to evolution.
 - [Characteristics change](/climatic-patterns/characteristics-change) – rel: Components of a system change, making some parts obsolete (toxic) while others remain valuable and can be refactored.
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Inertia towards successful legacy systems can delay necessary refactoring.
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Refactoring can improve efficiency by removing outdated components, freeing resources for innovation.
 - [Higher order systems create new sources of worth](/climatic-patterns/higher-order-systems-create-new-sources-of-worth) – rel: Refactoring can involve integrating salvaged components into new, higher-order systems.
+
+## 📚 **Further Reading & References**
+- Agile/DevOps analogies - Many tech companies apply refactoring to processes: e.g., breaking a legacy business process into agile teams. Business literature on **business process re-engineering** touches similar ideas (though BPR often aimed at improvement, here aim is also removal).
+- *"Dual Transformation" (Anthony, Johnson)* - a strategy book that talks about running a legacy business (Transformation B) while building new (Transformation A), and how to transfer capabilities from B to A. It's essentially how to refactor an organization during disruption, moving old capabilities to new growth, similar to refactoring concept described here.

--- a/docs/strategies/dealing-with-toxicity/sweat-and-dump/index.md
+++ b/docs/strategies/dealing-with-toxicity/sweat-and-dump/index.md
@@ -13,7 +13,6 @@ tags: [dealing-with-toxicity, sweat-and-dump, outsourcing, third-party, exit-str
 > - Simon Wardley
 
 ## 🤔 **Explanation**
-
 ### What is Sweat & Dump?
 Sweat & Dump is a two-phase strategy for dealing with technology toxicity. First, you sweat the asset: outsource the operation of a legacy system to a third party, ideally one willing to shoulder ongoing investment. Then, once you’ve extracted residual value and built your replacement, you dump — exiting, decommissioning, or walking away.
 
@@ -26,7 +25,6 @@ This tactic transfers capex risk to someone else while you buy time to modernise
 - Buy time without being trapped by past systems.
 
 ## 🗺️ **Real-World Examples**
-
 ### Telecom Legacy Infrastructure Outsourcing
 Telecom operators sold their aging copper networks to infrastructure firms that “sweat” the assets with minimal investment, while enabling the operators to focus on fiber and 5G. The infrastructure firms took on the capex of maintaining the copper network.
 
@@ -37,7 +35,6 @@ Conglomerates spin off declining production plants to private equity firms that 
 A legacy on-premises software division is transferred to a specialized support partner that charges premium maintenance fees and handles ongoing operational investments, enabling the original firm to prioritize its cloud offerings.
 
 ## 🚦 **When to Use / When to Avoid**
-
 <Assessment strategyName="Sweat & Dump">
   <MapSignals>
     <li>Key components are mature or in decline but still producing revenue.</li>
@@ -59,7 +56,6 @@ A legacy on-premises software division is transferred to a specialized support p
 **Avoid when:** Partner performance could damage your brand irreparably, contractual/regulatory constraints prevent a clean transfer, or the asset is too intertwined with strategic future systems to fully decouple.
 
 ## 🎯 **Leadership**
-
 ### Core challenge
 Transitioning control and capex liability without eroding customer trust or brand integrity, while balancing short-term gains against long-term strategic goals and the development of replacement systems.
 
@@ -74,7 +70,6 @@ Transitioning control and capex liability without eroding customer trust or bran
 Ensure transparent communication with customers about the change and safeguard service levels to avoid harming end users. Be mindful of the impact on employees of the legacy system and manage the transition humanely. Consider the long-term viability of the partner to avoid sudden service collapse.
 
 ## 📋 **How to Execute**
-
 1. Identify legacy systems with high inertia, ongoing capex demands, and low strategic value.
 2. Shift operations (and ideally capex responsibility) to a partner who will run them as-is (MSP, “enterprise cloud”, specialist operator).
 3. Avoid long-term commitments or refactoring traps that reinvest you in the legacy asset.
@@ -82,7 +77,6 @@ Ensure transparent communication with customers about the change and safeguard s
 5. Exit cleanly (decommission, sell, walk away) once your transition to modern systems is viable. No apologies.
 
 ## 📈 **Measuring Success**
-
 - Cost savings compared to in-house management, including avoided capex.
 - Revenue extracted during the sweating phase.
 - Customer satisfaction and service continuity post-transfer.
@@ -90,7 +84,6 @@ Ensure transparent communication with customers about the change and safeguard s
 - Speed and success of modern system development due to freed resources.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Partner Insolvency or Underinvestment
 If the third party goes bankrupt or fails to make necessary operational investments, you may need to reintegrate operations unexpectedly or face service collapse.
 
@@ -107,7 +100,6 @@ Transfers and layoffs can undermine morale among remaining staff if not handled 
 The partner arrangement becomes so entrenched or complex that "dumping" becomes as hard as the original problem.
 
 ## 🧠 **Strategic Insights**
-
 ### Externalising Capex and Inertia for Strategic Agility
 A core tenet of Sweat & Dump is the deliberate transfer of not just operational burden, but also financial liability for ongoing investment—particularly capital expenditure (Capex)—to the third-party operator. Legacy systems often become black holes for investment, demanding upgrades and maintenance that offer diminishing returns. By shifting these to a partner, the organisation frees up significant capital and, crucially, cognitive load. This externalises the system's inherent inertia, allowing internal teams to sidestep the drag of legacy technology and redirect their focus and resources towards developing modern, strategically aligned systems. This buys invaluable time and agility, enabling a smoother transition to the future state without being anchored by past commitments.
 
@@ -130,7 +122,6 @@ While extracting residual financial value and offloading capex are primary goals
 While operational burdens and capex are offloaded, significant reputational risk remains. Poor performance, service failures, or unethical behavior by the partner can directly tarnish the original brand. Vigilant oversight, clear contractual service levels (including investment commitments), and robust partner governance are essential.
 
 ## ❓ **Key Questions to Ask**
-
 - Who can operate this asset (and its capex) more effectively than us?
 - What incentives align partner profitability with asset care and necessary investment?
 - How will customers perceive the operational handover and potential service changes?
@@ -139,20 +130,17 @@ While operational burdens and capex are offloaded, significant reputational risk
 - Are we truly buying time for modernization, or just delaying an inevitable problem?
 
 ## 🔀 **Related Strategies**
-
 - [Disposal of Liability](/strategies/dealing-with-toxicity/disposal-of-liability) – Direct divestment or shutdown of toxic assets, often without a "sweat" phase.
 - [Pig in a Poke](/strategies/dealing-with-toxicity/pig-in-a-poke) – Sell liabilities under false pretenses (ethically dubious and risky).
 - [Refactoring](/strategies/dealing-with-toxicity/refactoring) – Internally transform or repurpose assets, retaining control and capex.
 - [Innovate-Leverage-Commoditize](/strategies/ecosystem/innovate-leverage-commoditize) - Could be the end-goal that Sweat & Dump enables resources for.
 
-## 📚 **Further Reading & References**
-
-- Case Study: [Nortel](https://en.wikipedia.org/wiki/Timeline_of_Nortel) Support Spin-offs – Real-world legacy IT sweat & dump scenario.
-
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: Legacy systems become candidates for Sweat & Dump as they reach the end of their lifecycle.
 - [Characteristics change](/climatic-patterns/characteristics-change) – rel: Declining characteristics of an asset make it suitable for outsourcing to a specialist.
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Inertia can prevent organizations from divesting toxic assets, making Sweat & Dump a necessary strategy.
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Offloading a legacy system allows the organization to focus resources on innovation.
 - [Capital flows to new areas of value](/climatic-patterns/capital-flows-to-new-areas-of-value) – rel: Sweat & Dump frees up capital from legacy systems to be invested in new, higher-value areas.
+
+## 📚 **Further Reading & References**
+- Case Study: [Nortel](https://en.wikipedia.org/wiki/Timeline_of_Nortel) Support Spin-offs – Real-world legacy IT sweat & dump scenario.

--- a/docs/strategies/ecosystem/alliances/index.md
+++ b/docs/strategies/ecosystem/alliances/index.md
@@ -9,7 +9,6 @@ tags: [alliances, ecosystem, partnerships, consortia, collaboration, standards, 
 # Alliances
 
 ## 🤔 **Explanation**
-
 ### What are Alliances?
 
 Forming formal partnerships or consortia with other companies to pursue a shared objective or market. An alliance pools resources or market access to achieve something none of the members could easily do alone.
@@ -35,8 +34,20 @@ Key principles for effective alliances:
 
 Alliances are particularly effective as ecosystem plays, allowing collective action in environments of high uncertainty or where first-mover advantage matters.
 
-## 🚦 **When to Use / When to Avoid**
+## 🗺️ **Real-World Examples**
+### Star Alliance (airlines)
 
+Dozens of airlines allied to extend reach through code-sharing and integrated frequent flyer benefits. This enabled a global network under a single brand, driving the evolution of air travel connectivity.
+
+### AllSeen Alliance (IoT)
+
+Qualcomm, Microsoft, LG and others formed an alliance to promote AllJoyn as an open standard for device interoperability. Similar efforts include the Zigbee Alliance.
+
+### Hypothetical EV Alliance
+
+Several mid-sized electric vehicle startups create a joint venture for charging infrastructure. This allows them to rival Tesla’s Supercharger network and accelerate EV adoption.
+
+## 🚦 **When to Use / When to Avoid**
 <Assessment strategyName="Alliances">
   <MapSignals>
     <li>The competitive environment includes dominant players or high barriers that are difficult to tackle alone.</li>
@@ -72,22 +83,7 @@ Alliances are particularly effective as ecosystem plays, allowing collective act
 - alliance could slow you down unnecessarily
 - you have a dominant position and don't need others
 
-## 🗺️ **Real-World Examples**
-
-### Star Alliance (airlines)
-
-Dozens of airlines allied to extend reach through code-sharing and integrated frequent flyer benefits. This enabled a global network under a single brand, driving the evolution of air travel connectivity.
-
-### AllSeen Alliance (IoT)
-
-Qualcomm, Microsoft, LG and others formed an alliance to promote AllJoyn as an open standard for device interoperability. Similar efforts include the Zigbee Alliance.
-
-### Hypothetical EV Alliance
-
-Several mid-sized electric vehicle startups create a joint venture for charging infrastructure. This allows them to rival Tesla’s Supercharger network and accelerate EV adoption.
-
 ## 🎯 **Leadership**
-
 ### Core Challenge
 
 Balancing coordination and speed across multiple organisations with differing goals and cultures.
@@ -101,7 +97,6 @@ Balancing coordination and speed across multiple organisations with differing go
 - ecosystem thinking
 
 ## 📋 **How to Execute**
-
 - clearly define scope, contributions and benefits
 - create governance structures that ensure fairness and decision-making agility
 - manage relationships actively and continually evaluate alignment
@@ -112,21 +107,18 @@ Balancing coordination and speed across multiple organisations with differing go
 - avoid alliances that mask monopolistic control
 
 ## 📈 **Measuring Success**
-
 - progress toward shared goals (e.g. adoption of standard, market share gains)
 - sustainability of the alliance
 - balance of contributions and benefits across members
 - speed of collective impact versus going solo
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 - decision gridlock due to too many players
 - unequal contributions leading to resentment
 - defection by members with changing incentives
 - loss of strategic direction if governance is weak
 
 ## 🧠 **Strategic Insights**
-
 - alliances are ecosystem strategies for evolution
 - powerful in the standards game where network effects matter
 - can shift the center of gravity in an industry
@@ -143,7 +135,6 @@ Alliances are a formalised, structured subset of broader cooperation. Where coop
 If cooperation is about joint exploration, alliances are about jointly steering an ecosystem.
 
 ## ❓ **Key Questions to Ask**
-
 - Do we share a clear and durable interest with potential partners?
 - Can we agree on governance and conflict resolution?
 - Are we better off together than alone?
@@ -151,18 +142,15 @@ If cooperation is about joint exploration, alliances are about jointly steering 
 - How will we handle success and changing power dynamics?
 
 ## 🔀 **Related Strategies**
-
 - [Cooperation](/strategies/accelerators/cooperation) - alliances are a structured form of cooperation for shared goals.
 - [Standards Game](/strategies/markets/standards-game) - alliances often form to promote or defend a shared standard.
 - [Center of Gravity](/strategies/attacking/centre-of-gravity) - alliances can shift the industry's center of gravity against a rival.
 
 ## ⛅ **Relevant Climatic Patterns**
-
 - [A 'war' causes organisations to evolve](/climatic-patterns/a-war-causes-organisations-to-evolve) – trigger: intense competition often pushes companies to form alliances.
 - [Components can co-evolve](/climatic-patterns/components-can-co-evolve) – influence: alliances can guide how related capabilities evolve together.
 
 ## 📚 **Further Reading & References**
-
 - Wardley, S. – *"Alliances: working with other companies to drive evolution of a specific activity/data set."*
 - Case Study: **IBM PC (1981)** – IBM, Microsoft and Intel formed a de facto alliance to create a standard PC architecture, setting the stage for an ecosystem.
 - *"Alliances & Joint Ventures"* (Harvard Business Review) – discusses reasons alliances fail, such as cultural mismatches and lack of leadership.

--- a/docs/strategies/markets/buyer-supplier-power/index.md
+++ b/docs/strategies/markets/buyer-supplier-power/index.md
@@ -13,7 +13,6 @@ tags: [markets, power-dynamics, negotiation, value-chain, leverage, commoditisat
 > - Simon Wardley
 
 ## 🤔 **Explanation**
-
 ### What is Buyer-Supplier Power?
 
 Buyer-Supplier Power refers to the influence that buyers and suppliers have over each other within a value chain. This power balance is not static; it shifts as components in the value chain evolve. In the early, unevolved stages of a market, suppliers of a novel component often hold significant power. As the market matures and the component commoditizes, power can shift to large buyers who can command lower prices due to high volume. A strategic approach involves analyzing these dynamics across your entire value chain and making moves to increase your own power while reducing the power of those you transact with.
@@ -28,7 +27,6 @@ Actively managing these power dynamics is crucial for:
 *   **Controlling the Market:** Influencing the power dynamics can allow you to shape the evolution of the market to your own advantage.
 
 ## 🗺️ **Real-World Examples**
-
 ### Intel in the PC Market ("Intel Inside")
 
 For many years, Intel was the dominant supplier of microprocessors for personal computers. PC manufacturers (the buyers) had very little power, as there were few viable alternatives to Intel's chips. Intel leveraged this supplier power to command high prices and launch the "Intel Inside" co-branding campaign, further solidifying their dominant position in the minds of consumers and increasing their power over the PC manufacturers.
@@ -42,7 +40,6 @@ Walmart, as a massive buyer, exerts enormous power over its suppliers. Due to it
 Apple acts as a powerful intermediary between app developers (suppliers) and iPhone users (buyers). By controlling the App Store, the sole distribution channel for iOS apps, Apple exerts significant power over developers. It dictates the terms, sets the commission rate (the "App Store tax"), and can remove any app at its discretion. This creates a chokepoint in the value chain, giving Apple immense power.
 
 ## 🚦 **When to Use / When to Avoid**
-
 <Assessment strategyName="Buyer-Supplier Power">
   <MapSignals>
     <li>Your map shows a dependency on a single, powerful supplier for a critical component.</li>
@@ -72,7 +69,6 @@ Apple acts as a powerful intermediary between app developers (suppliers) and iPh
 *   The cost of the power play (e.g., acquiring a supplier) is greater than the potential long-term benefit.
 
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 The core leadership challenge is to see the business not as a standalone entity, but as part of a complex, interconnected system. Leaders must be able to map out the entire value chain, identify the key leverage points, and make strategic moves that may not pay off immediately but will shift the balance of power in their favor over the long term. This requires a shift from tactical thinking to systemic, strategic thinking.
@@ -89,7 +85,6 @@ The core leadership challenge is to see the business not as a standalone entity,
 Exercising power over buyers or suppliers can lead to accusations of unfair or anti-competitive behavior. Squeezing suppliers too hard can drive them out of business, leading to a less resilient and innovative supply chain. Abusing a chokepoint position can attract regulatory scrutiny and damage your reputation. Leaders must consider the long-term health of the ecosystem, not just their own short-term advantage.
 
 ## 📋 **How to Execute**
-
 1.  **Map Your Value Chain:** Use Wardley Maps to visualize all the components and actors involved in delivering value to your end customer.
 2.  **Analyze the Power Dynamics:** For each link in the chain, assess the balance of power. Who depends on whom? Who has more options? Who has higher switching costs?
 3.  **Identify Leverage Points:** Look for opportunities to increase your power. This could involve:
@@ -101,14 +96,12 @@ Exercising power over buyers or suppliers can lead to accusations of unfair or a
 5.  **Monitor and Adapt:** The balance of power is constantly shifting. Continuously monitor the landscape and be prepared to adapt your strategy.
 
 ## 📈 **Measuring Success**
-
 *   **Improved Margins:** Are you able to negotiate better prices from your suppliers or command higher prices from your buyers?
 *   **Reduced Switching Costs:** Have you made it easier for you to switch suppliers, or harder for your customers to switch away from you?
 *   **Increased Dependency:** Have you made other players in the value chain more dependent on you?
 *   **Control over Standards:** Are you able to influence the standards and protocols used in your industry?
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Starting a War You Can't Win
 Attempting to exert power over a much stronger player can result in severe retaliation, such as being cut off from a critical supply.
 
@@ -122,7 +115,6 @@ Building a powerful chokepoint or monopoly position can lead to antitrust invest
 Focusing on the power dynamics in one part of the value chain while ignoring others can leave you vulnerable to threats from unexpected places.
 
 ## 🧠 **Strategic Insights**
-
 ### Power is Fluid
 The balance of power is not a fixed attribute of a market; it is constantly in flux. The evolution of technology and business models creates new opportunities to shift the balance. The savvy strategist is always looking for these opportunities.
 
@@ -130,7 +122,6 @@ The balance of power is not a fixed attribute of a market; it is constantly in f
 Every value chain is also a power chain. Understanding this allows you to see the strategic landscape in a new light. It's not just about what you do, but about your position relative to others.
 
 ## ❓ **Key Questions to Ask**
-
 *   **Dependencies:** Who are we most dependent on in our value chain? Who is most dependent on us?
 *   **Options:** What are our options if a key supplier raises prices or a key buyer leaves? What are their options?
 *   **Chokepoints:** Where are the chokepoints in our value chain? Do we control any of them? Can we create one?
@@ -138,21 +129,18 @@ Every value chain is also a power chain. Understanding this allows you to see th
 *   **Second-Order Effects:** If we make a move to increase our power, what are the likely reactions from other players in the system?
 
 ## 🔀 **Related Strategies**
-
 *   **[Raising Barriers to Entry](/strategies/defensive/raising-barriers-to-entry)**: Accumulating supplier power is a way to raise barriers to entry for new competitors.
 *   **[Tower and Moat](/strategies/ecosystem/tower-and-moat)**: A strategy focused on building a powerful, defensible position that often grants significant supplier power.
 *   **[Standards Game](/strategies/markets/standards-game)**: A way to shift power dynamics by making your technology the industry standard.
 *   **[Vertical Integration](/terms/value-chain)**: A common tactic for directly controlling more of the value chain and altering power dynamics.
 
-## 📚 **Further Reading & References**
-
-*   **[Competitive Strategy](https://www.goodreads.com/book/show/236901.Competitive_Strategy)** by Michael E. Porter. The classic text that introduced the "Five Forces" framework, which is central to understanding buyer-supplier power.
-*   **[The Everything Store: Jeff Bezos and the Age of Amazon](https://www.goodreads.com/book/show/17660462-the-everything-store)** by Brad Stone. Provides many examples of how Amazon has masterfully managed buyer-supplier power.
-
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: The balance of power between buyers and suppliers shifts as markets and components evolve.
 - [Characteristics change](/climatic-patterns/characteristics-change) – rel: As components commoditize, power often shifts from suppliers to buyers, or to those who control the new standard.
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Increased efficiency in a part of the value chain can alter power dynamics, e.g., by making suppliers more interchangeable.
 - [Higher order systems create new sources of worth](/climatic-patterns/higher-order-systems-create-new-sources-of-worth) – rel: New higher-order systems can create new chokepoints and shift power, like platform ecosystems.
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: Competitors' moves to consolidate power or form alliances will impact the buyer-supplier landscape.
+
+## 📚 **Further Reading & References**
+*   **[Competitive Strategy](https://www.goodreads.com/book/show/236901.Competitive_Strategy)** by Michael E. Porter. The classic text that introduced the "Five Forces" framework, which is central to understanding buyer-supplier power.
+*   **[The Everything Store: Jeff Bezos and the Age of Amazon](https://www.goodreads.com/book/show/17660462-the-everything-store)** by Brad Stone. Provides many examples of how Amazon has masterfully managed buyer-supplier power.

--- a/docs/strategies/markets/harvesting/index.md
+++ b/docs/strategies/markets/harvesting/index.md
@@ -13,7 +13,6 @@ tags: [markets, ecosystem, innovation, scaling, acquisition, replication, platfo
 > - Simon Wardley
 
 ## 🤔 **Explanation**
-
 ### What is Harvesting?
 
 Harvesting is a platform strategy where a company creates an ecosystem that encourages third parties to build new products and services on top of its core offering. The platform owner then acts as a "sensing engine," monitoring the ecosystem to see which of these third-party innovations gain the most traction with customers. Once a winner emerges, the platform owner can choose to "harvest" it by acquiring the company, replicating the functionality, or tightly integrating it into the core platform. This allows the platform owner to benefit from a wide range of experimentation without bearing all the costs and risks.
@@ -28,7 +27,6 @@ This strategy offers several powerful advantages:
 *   **Increased Agility:** It allows a large company to innovate and respond to market needs much faster than if it relied solely on its internal development processes.
 
 ## 🗺️ **Real-World Examples**
-
 ### Apple's App Store
 
 Apple provides the iOS platform and the App Store, but it doesn't create most of the apps. It observes which apps and features become popular. Over the years, Apple has integrated functionality that was once the domain of third-party apps directly into iOS. For example, features like flashlight apps, screen recording, and keyboard enhancements were all pioneered by third-party developers before being harvested by Apple and built into the operating system.
@@ -42,7 +40,6 @@ AWS constantly monitors how its customers are using its primitive services (like
 For decades, Microsoft has observed the vast ecosystem of software built for Windows. When a particular category of utility or application becomes indispensable for a large number of users, Microsoft has often chosen to build a similar feature directly into Windows. This has happened with disk compression, file search, and many other utilities.
 
 ## 🚦 **When to Use / When to Avoid**
-
 <Assessment strategyName="Harvesting">
   <MapSignals>
     <li>Your map shows a platform with a growing ecosystem of third-party developers and solutions.</li>
@@ -72,7 +69,6 @@ For decades, Microsoft has observed the vast ecosystem of software built for Win
 *   The legal or technical barriers to acquiring or replicating the innovation are too high.
 
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 The most significant leadership challenge is managing the relationship with the ecosystem. If developers feel that their best ideas will simply be stolen, they will stop innovating on your platform. Leaders must find a way to harvest successfully while still ensuring the ecosystem remains a vibrant and attractive place for third parties to build. This requires a delicate touch and a long-term perspective.
@@ -92,7 +88,6 @@ Harvesting is ethically complex. On one hand, you are providing the platform tha
 *   Are we leaving enough room for a healthy ecosystem to thrive after we have harvested an idea?
 
 ## 📋 **How to Execute**
-
 1.  **Build and Nurture the Platform:** Create a robust and open platform that makes it easy for third parties to build on.
 2.  **Establish Sensing Engines:** Implement mechanisms to monitor the ecosystem. This could include tracking API usage, analyzing app store data, running developer competitions, or actively engaging with the community.
 3.  **Identify Successful Innovations:** Look for signals of traction: high user adoption, strong developer interest, or significant revenue generation.
@@ -101,14 +96,12 @@ Harvesting is ethically complex. On one hand, you are providing the platform tha
 6.  **Manage the Ecosystem Response:** Communicate your decision clearly and transparently to the developer community. Emphasize the benefits to the overall platform and its users.
 
 ## 📈 **Measuring Success**
-
 *   **Ecosystem Health:** Is the number of developers and applications on your platform still growing after a harvest?
 *   **Pace of Innovation:** Are you able to bring new, market-validated features to your users more quickly?
 *   **Platform Value:** Has the harvested feature increased the overall value and stickiness of your platform?
 *   **Acquisition ROI:** If you acquired a company, is it delivering a positive return on investment?
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Poisoning the Well
 If you are too aggressive or unfair in your harvesting, you will destroy the trust of your developer community, and they will abandon your platform.
 
@@ -122,7 +115,6 @@ You may fail to recognize a significant innovation in your ecosystem until it is
 Even if you successfully acquire or replicate a feature, a poor integration can fail to deliver the expected value to users.
 
 ## 🧠 **Strategic Insights**
-
 ### The Platform as a Sensing Engine
 This strategy reframes the purpose of a platform. It is not just a foundation for your own products, but a powerful sensing engine for detecting and capitalizing on market trends. The more open your platform, the more signals you can receive.
 
@@ -130,7 +122,6 @@ This strategy reframes the purpose of a platform. It is not just a foundation fo
 At its best, harvesting is a symbiotic relationship. The ecosystem provides innovation and market validation, while the platform provides scale and distribution. The challenge is to maintain this balance and not allow it to become parasitic.
 
 ## ❓ **Key Questions to Ask**
-
 *   **Ecosystem Trust:** How can we harvest this innovation without damaging the trust of our developer community?
 *   **Build vs. Buy:** Does it make more sense to acquire this company or to replicate their functionality ourselves?
 *   **Strategic Importance:** Is this feature so important that it needs to be part of our core platform?
@@ -138,22 +129,19 @@ At its best, harvesting is a symbiotic relationship. The ecosystem provides inno
 *   **Long-Term Impact:** What will be the long-term impact of this decision on the health and vibrancy of our ecosystem?
 
 ## 🔀 **Related Strategies**
-
 *   **[Innovate-Leverage-Commoditize (ILC)](/strategies/ecosystem/innovate-leverage-commoditize)**: The underlying engine that drives a Harvesting strategy.
 *   **[Open Approaches](/strategies/accelerators/open-approaches)**: Creating an open platform is a prerequisite for a healthy ecosystem that can be harvested.
 *   **[Co-creation](/strategies/ecosystem/co-creation)**: Working with partners to build new services can be an early signal of what to harvest later.
 *   **[Co-opting](/strategies/ecosystem/co-opting)**: A related strategy where you might absorb a competitor's differentiation into your platform.
 *   **[Threat Acquisition](/strategies/defensive/threat-acquisition)**: Harvesting can sometimes be a defensive move to acquire a company that is becoming a threat.
 
-## 📚 **Further Reading & References**
-
-*   **[Platform Revolution](https://www.goodreads.com/book/show/26899832-platform-revolution)** by Geoffrey G. Parker, Marshall W. Van Alstyne, and Sangeet Paul Choudary. A comprehensive guide to platform business models.
-*   **[The Business of Platforms](https://www.goodreads.com/book/show/43688225-the-business-of-platforms)** by Michael A. Cusumano, Annabelle Gawer, and David B. Yoffie. Explores the strategies of platform companies.
-
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: The ecosystem around a platform evolves, creating new opportunities for harvesting.
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Third-party innovations on a platform often seek to improve efficiency or offer new capabilities, which can then be harvested.
 - [Higher order systems create new sources of worth](/climatic-patterns/higher-order-systems-create-new-sources-of-worth) – rel: Successful harvested features often become part of a higher-order system (the platform), increasing its overall value.
 - [No choice on evolution](/climatic-patterns/no-choice-on-evolution) – rel: Platforms must evolve by incorporating successful ecosystem innovations (harvesting) to stay relevant.
 - [Capital flows to new areas of value](/climatic-patterns/capital-flows-to-new-areas-of-value) – rel: Harvesting directs the platform owner's capital (build or buy) towards validated areas of value.
+
+## 📚 **Further Reading & References**
+*   **[Platform Revolution](https://www.goodreads.com/book/show/26899832-platform-revolution)** by Geoffrey G. Parker, Marshall W. Van Alstyne, and Sangeet Paul Choudary. A comprehensive guide to platform business models.
+*   **[The Business of Platforms](https://www.goodreads.com/book/show/43688225-the-business-of-platforms)** by Michael A. Cusumano, Annabelle Gawer, and David B. Yoffie. Explores the strategies of platform companies.

--- a/docs/strategies/markets/signal-distortion/index.md
+++ b/docs/strategies/markets/signal-distortion/index.md
@@ -13,7 +13,6 @@ tags: [markets, perception, information-warfare, competitor, influence, hype, si
 > - Simon Wardley
 
 ## 🤔 **Explanation**
-
 ### What is Signal Distortion?
 
 Signal Distortion is the practice of deliberately manipulating information channels to create a false or misleading perception of the market, your company's capabilities, or your strategic intentions. The goal is to influence the behavior of competitors, causing them to make poor decisions, invest in fruitless ventures, or misallocate their resources based on the distorted signals you have created. It is a form of information warfare applied to a business context.
@@ -28,7 +27,6 @@ The primary motivation for using this strategy is to gain a competitive advantag
 *   **Damage a competitor's reputation:** Subtly spread information that undermines a competitor's credibility or the perceived quality of their products.
 
 ## 🗺️ **Real-World Examples**
-
 ### "Vaporware" Announcements
 
 A classic example of signal distortion is the announcement of "vaporware" – a product that is announced to the public but is never actually manufactured or officially cancelled. In the 1990s, Microsoft was often accused of using this tactic to discourage customers from buying competitors' products, by creating the expectation that a superior Microsoft alternative was just around the corner.
@@ -42,7 +40,6 @@ Companies can feed into technology hype cycles (e.g., AI, the Metaverse, Web3) t
 A company might selectively release data that paints a misleadingly positive picture of its performance. For example, a software company could highlight a high number of downloads while omitting low user engagement rates, creating a false signal of success that could influence competitor strategy and investor perception.
 
 ## 🚦 **When to Use / When to Avoid**
-
 <Assessment strategyName="Signal Distortion">
   <MapSignals>
     <li>Your competitors are known to be heavily influenced by industry analysts and media reports.</li>
@@ -72,7 +69,6 @@ A company might selectively release data that paints a misleadingly positive pic
 *   Your company culture does not support deceptive practices.
 
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 The central leadership challenge is to navigate the significant ethical grey areas of this strategy. Leaders must weigh the potential for strategic advantage against the risk of severe reputational damage and the potential to create a toxic market environment based on mistrust. Deciding where to draw the line between clever marketing and unethical deception is critical.
@@ -93,7 +89,6 @@ This is an inherently deceptive strategy. It involves intentionally misleading o
 *   Is this a "killer acquisition" in disguise, aimed at destroying a competitor through misinformation?
 
 ## 📋 **How to Execute**
-
 1.  **Identify the Target and Objective:** Be precise about which competitor you are targeting and what specific action or inaction you want to provoke.
 2.  **Craft the Deceptive Narrative:** Develop a believable but misleading story. This could be about a new (but fake) product, a change in strategic direction, or a misinterpretation of market trends.
 3.  **Select Your Channels:** Choose the most effective channels to disseminate the signal. This could involve "leaking" information to friendly journalists, using social media, publishing white papers, or presenting at industry conferences.
@@ -101,13 +96,11 @@ This is an inherently deceptive strategy. It involves intentionally misleading o
 5.  **Monitor and Adapt:** Closely monitor your competitors' reactions. If they are not taking the bait, you may need to adjust the narrative or amplify the signal further. Be prepared to pull back if the risks become too high.
 
 ## 📈 **Measuring Success**
-
 *   **Competitor Action:** The most direct measure of success is seeing the targeted competitor take the desired action (e.g., announcing a competing product to your "vaporware").
 *   **Media and Analyst Reports:** Success can be measured by the extent to which the distorted signal is repeated and accepted as fact by the media and industry analysts.
 *   **Resource Misallocation:** Evidence that a competitor has allocated significant resources to counter your feint.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Being Exposed
 If the deception is uncovered, the reputational damage can be immense and long-lasting. Trust is hard to win back.
 
@@ -121,7 +114,6 @@ The distorted signal could be misinterpreted in a way you didn't intend, causing
 Your distorted signal could inadvertently create a real market for a product or service that you have no intention of building, which a competitor then successfully exploits.
 
 ## 🧠 **Strategic Insights**
-
 ### Information as a Weapon
 This strategy treats information not as a tool for enlightenment, but as a weapon to be deployed against competitors. It's about shaping the competitive landscape by controlling the narrative.
 
@@ -129,7 +121,6 @@ This strategy treats information not as a tool for enlightenment, but as a weapo
 Signal Distortion is a powerful reminder that in many markets, the perception of reality can be more influential than reality itself, at least in the short term. The company that controls the story can often control the market.
 
 ## ❓ **Key Questions to Ask**
-
 *   **Objective:** What specific action do we want our competitor to take as a result of this deception?
 *   **Plausibility:** Is our fabricated narrative believable and sustainable?
 *   **Risk/Reward:** Does the potential strategic gain justify the significant ethical and reputational risks?
@@ -137,21 +128,18 @@ Signal Distortion is a powerful reminder that in many markets, the perception of
 *   **Exit Strategy:** How will we wind down this deception if it is discovered or no longer serves our purpose?
 
 ## 🔀 **Related Strategies**
-
 *   **[Misdirection](/strategies/competitor/misdirection)**: A closely related strategy, but often broader than just distorting market signals.
 *   **[Creating Artificial Needs](/strategies/user-perception/creating-artificial-needs)**: Manipulating perception on the user side, rather than the competitor side.
 *   **[First Mover](/strategies/positional/first-mover)**: The *perception* of being a first mover can be a powerful signal, even if it's not entirely true.
 *   **[Fear, Uncertainty, and Doubt (FUD)](/terms/fear-uncertainty-and-doubt)**: A specific tactic of signal distortion focused on creating negative perceptions about a competitor.
 
-## 📚 **Further Reading & References**
-
-*   **[Trust Me, I'm Lying: Confessions of a Media Manipulator](https://www.goodreads.com/book/show/13542853-trust-me-i-m-lying)** by Ryan Holiday. A stark look at how media can be manipulated.
-*   **[The Art of War](https://www.goodreads.com/book/show/10534.The_Art_of_War)** by Sun Tzu. The ancient text is full of wisdom on deception and misdirection.
-
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Most competitors have poor situational awareness](/climatic-patterns/most-competitors-have-poor-situational-awareness) – rel: This strategy exploits the poor situational awareness of competitors by feeding them misleading signals.
 - [Economy has cycles](/climatic-patterns/economy-has-cycles) – rel: Hype cycles and economic bubbles can be amplified or created through signal distortion.
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Competitors relying on past successful signals may be easily misled by distorted new signals.
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: The goal of signal distortion is to influence competitors' actions to your advantage.
 - [The less evolved something is the more uncertain it becomes](/climatic-patterns/the-less-evolved-something-is-then-the-more-uncertain-it-becomes) – rel: Uncertainty in early-stage markets makes them more susceptible to signal distortion.
+
+## 📚 **Further Reading & References**
+*   **[Trust Me, I'm Lying: Confessions of a Media Manipulator](https://www.goodreads.com/book/show/13542853-trust-me-i-m-lying)** by Ryan Holiday. A stark look at how media can be manipulated.
+*   **[The Art of War](https://www.goodreads.com/book/show/10534.The_Art_of_War)** by Sun Tzu. The ancient text is full of wisdom on deception and misdirection.

--- a/docs/strategies/markets/standards-game/index.md
+++ b/docs/strategies/markets/standards-game/index.md
@@ -13,7 +13,6 @@ tags: [standards, markets, dominance, competition, differentiation, switching co
 <AssessmentToolAdvert strategyName="Standards Game" />
 
 ## 🤔 **Explanation**
-
 ### What is the Standards Game?
 
 The Standards Game is the deliberate effort to establish your technology, process, or specification as the de facto or de jure benchmark for an industry. By steering a market toward your standard, you create high switching costs and reduce competitors’ freedom to innovate outside your framework. This can be done openly—through collaborative bodies and open approaches—or covertly by leveraging market dominance until your way becomes unavoidable.
@@ -34,7 +33,6 @@ The Standards Game is the deliberate effort to establish your technology, proces
 5. Provide tooling, certification, or compatibility programs to keep participants aligned.
 
 ## 🗺️ **Real-World Examples**
-
 ### USB and universal compatibility
 
 Intel and partners promoted the USB interface as an open standard, displacing a range of proprietary connectors. Once adoption reached critical mass, hardware makers had little choice but to follow.
@@ -48,7 +46,6 @@ European regulators and telecom companies cooperated on the GSM standard, enabli
 Amazon’s S3 object storage interface has become a de facto standard. Competing clouds often implement S3-compatible APIs so existing tools and applications continue to work, effectively locking users into the S3 model.
 
 ## 🚦 **When to Use / When to Avoid**
-
 <Assessment strategyName="Standards Game">
   <MapSignals>
     <li>The market suffers from fragmentation or competing formats.</li>
@@ -75,7 +72,6 @@ Amazon’s S3 object storage interface has become a de facto standard. Competing
 - The market is still exploring radically different solutions and premature standardisation would stifle innovation.
 
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 Balancing openness to drive adoption with enough control to keep the standard aligned with your strategic interests.
@@ -93,7 +89,6 @@ Balancing openness to drive adoption with enough control to keep the standard al
 Leaders must ensure the standard genuinely serves user and industry needs rather than merely entrenching their own power. Transparency in governance helps avoid accusations of lock-in or anticompetitive behaviour.
 
 ## 📋 **How to Execute**
-
 1. Map the landscape and identify fragmentation or emerging consensus.
 2. Publish or open-source a reference implementation or specification.
 3. Recruit partners and form or join a standards consortium.
@@ -102,7 +97,6 @@ Leaders must ensure the standard genuinely serves user and industry needs rather
 6. Continually evolve the standard to address new needs while maintaining backward compatibility.
 
 ## 📈 **Measuring Success**
-
 - Market share of products or services conforming to your standard
 - Number of partners or third parties certified or adopting the standard
 - Frequency of regulatory or industry references to your standard
@@ -110,7 +104,6 @@ Leaders must ensure the standard genuinely serves user and industry needs rather
 - Influence over roadmap and direction of the wider ecosystem
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Lack of adoption
 If early uptake is weak, the standard may never reach critical mass and could be abandoned.
 
@@ -124,7 +117,6 @@ Standards require ongoing stewardship; neglecting updates or compatibility erode
 Attempts to force a standard can attract antitrust scrutiny or political opposition.
 
 ## 🧠 **Strategic Insights**
-
 ### Standards as chokepoints
 When you define the interface everyone uses, you control the pace of change and become difficult to displace. Others innovate on top of your foundation, not against it.
 
@@ -135,7 +127,6 @@ Standardise too early and you may freeze an immature approach. Too late and a ri
 Competitors may attempt embrace-and-extend tactics or create alternative alliances. Monitoring and engaging with these efforts is essential to keep your standard central.
 
 ## ❓ **Key Questions to Ask**
-
 - **Influence:** Which organisations or regulators must we convince to legitimise our standard?
 - **Adoption:** What incentives can we offer developers or partners to adopt it?
 - **Differentiation:** Does controlling this standard truly strengthen our position, or could it commoditise us?
@@ -143,23 +134,20 @@ Competitors may attempt embrace-and-extend tactics or create alternative allianc
 - **Counterplay:** How might competitors respond, and do we have a plan for their alternative standards?
 
 ## 🔀 **Related Strategies**
-
 - [Open Approaches](/strategies/accelerators/open-approaches) – Opening code or processes can accelerate adoption and make your approach the default.
 - [Defensive Regulation](/strategies/defensive/defensive-regulation) – Embedding a standard in law cements your advantage.
 - [Lobbying](/strategies/user-perception/lobbying) – Persuading policymakers or industry bodies to endorse your approach.
 - [Raising Barriers to Entry](/strategies/defensive/raising-barriers-to-entry) – Standards can raise compliance costs for newcomers.
 - [Designed to Fail](/strategies/poison/designed-to-fail) – Poisoning rival standards can clear the field for your own.
 
-## 📚 **Further Reading & References**
-
-- [USB Implementers Forum](https://www.usb.org/) – Example of industry coordination driving a ubiquitous standard.
-- [GSM Association](https://www.gsma.com/) – Case study of regulators and industry collaborating on a global mobile standard.
-- [RFC 2026 – The Internet Standards Process](https://www.rfc-editor.org/rfc/rfc2026) – Insight into how open standards bodies govern technical specifications.
-
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: Standards emerge as components evolve towards commodity; playing the standards game is a way to influence this evolution.
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Standards often arise to improve efficiency and interoperability, which then enables higher-order innovation.
 - [Shifts from product to utility show punctuated equilibrium](/climatic-patterns/shifts-from-product-to-utility-tend-to-demonstrate-a-punctuated-equilibrium) – rel: The establishment of a standard can be a punctuation point in the shift of a component to a utility.
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: Competitors will fight to establish their own standards or resist yours.
 - [No one size fits all](/climatic-patterns/no-one-size-fits-all) – rel: While a standard aims for uniformity, its application might still vary, or competing standards may serve different niches.
+
+## 📚 **Further Reading & References**
+- [USB Implementers Forum](https://www.usb.org/) – Example of industry coordination driving a ubiquitous standard.
+- [GSM Association](https://www.gsma.com/) – Case study of regulators and industry collaborating on a global mobile standard.
+- [RFC 2026 – The Internet Standards Process](https://www.rfc-editor.org/rfc/rfc2026) – Insight into how open standards bodies govern technical specifications.

--- a/docs/strategies/poison/designed-to-fail/index.md
+++ b/docs/strategies/poison/designed-to-fail/index.md
@@ -11,7 +11,6 @@ tags: [poison, denial, sabotage, ecosystem-manipulation]
 > - Simon Wardley
 
 ## 🤔 **Explanation**
-
 ### What is Designed to Fail?
 
 This is a strategy of tactical sabotage: deliberately introducing a doomed initiative into an emerging space to distort perception, drain competitor resources, and reduce the likelihood of serious market formation.
@@ -36,7 +35,6 @@ Deploy this strategy when an adjacent or emerging market may threaten your core 
 - Shape market perceptions to your advantage.
 
 ## 🗺️ **Real-World Examples**
-
 ### HD DVD Format
 
 Toshiba's HD DVD was launched alongside Blu-ray, fragmenting the high-definition disc market. Although technically competent, lack of studio support and deliberate confusion led to its swift decline, deterring new entrants.
@@ -46,7 +44,6 @@ Toshiba's HD DVD was launched alongside Blu-ray, fragmenting the high-definition
 A vendor-funded IoT API with inadequate security standards is released. Early adopters face breaches, tarnishing the space and discouraging competitors from similar efforts.
 
 ## 🚦 **When to Use / When to Avoid**
-
 <Assessment strategyName="Designed to Fail">
   <MapSignals>
     <li>An adjacent market is forming, but lacks standards or strong leaders.</li>
@@ -73,7 +70,6 @@ A vendor-funded IoT API with inadequate security standards is released. Early ad
 - Stakeholders demand transparency that undermines the tactic.
 
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 Leadership tension: Playing dirty without eroding trust or morale. This tactic rewards dispassionate analysis and ruthless prioritisation. Leaders who hesitate to pull the trigger, or can’t contain the fallout, should avoid it.
@@ -89,9 +85,7 @@ Leadership tension: Playing dirty without eroding trust or morale. This tactic r
 
 This strategy walks a line between cunning and deception. Overuse breeds cynicism inside and outside your oranisation. If discovered, you risk brand damage and trust collapse.
 
-
 ## 📋 **How to Execute**
-
 1. Identify a vulnerable or emerging market segment.
 2. Design an initiative with surface credibility but hidden flaws.
 3. Launch with marketing or partnerships to appear legitimate.
@@ -100,14 +94,12 @@ This strategy walks a line between cunning and deception. Overuse breeds cynicis
 6. Allow the initiative to collapse once competitors are deterred.
 
 ## 📈 **Measuring Success**
-
 - Competitors refrain from entering the target space.
 - Initiative adoption appears sufficient to signal occupancy.
 - Resource expenditure stays within planned bounds.
 - Competitors divert resources from strategic projects.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Unintended Adoption
 
 Competitors or communities may fix flaws, turning the initiative into a viable offering.
@@ -125,7 +117,6 @@ Exposure of the tactic can erode trust with customers and partners.
 Maintaining a deceptive initiative may consume more resources than planned.
 
 ## 🧠 **Strategic Insights**
-
 ### Governance Vacuum is Key
 This strategy thrives where no one yet has control. A lack of established standards, dominant players, or clear leadership in an emerging market allows a "Designed to Fail" initiative to more easily shape perceptions and create confusion. The ambiguity of a nascent space is the fertile ground for such a ploy.
 
@@ -148,29 +139,25 @@ These initiatives are not meant to last. Their purpose is to occupy space, creat
 "Designed to Fail" should generally be a tactical, peripheral move rather than core to a company's primary strategy. Its utility lies in specific, often defensive, contexts. Over-reliance on such "poisoning" tactics can distract from genuine value creation, damage reputation if discovered, and foster a cynical internal culture.
 
 ## ❓ **Key Questions to Ask**
-
 - **Threat Identification:** Which adjacent emerging markets pose strategic risks?
 - **Sustainability:** Can we maintain a credible surface while embedding flaws?
 - **Exit Strategy:** How will we decommission the initiative without collateral damage?
 - **Risk-Reward Balance:** Do potential benefits justify reputational and legal risks?
 
 ## 🔀 **Related Strategies**
-
 - [Misdirection](/strategies/competitor/misdirection) — using narrative to divert attention.
 - [Sweat & Dump](/strategies/dealing-with-toxicity/sweat-and-dump) — handing off toxic projects.
 - [Insertion](/strategies/poison/insertion) — embedding flawed influence via people.
 - [Licensing](/strategies/poison/licensing) — controlling ecosystems through legal terms.
 
-## 📚 **Further Reading & References**
-
-- [HD DVD vs Blu-ray (Wikipedia)](https://en.wikipedia.org/wiki/HD_DVD) — a case of market fragmentation leading to failure.
-- [Betamax vs VHS (Wikipedia)](https://en.wikipedia.org/wiki/Betamax) — example of proprietary format wars.
-- *Blue Ocean Strategy* (W. Chan Kim & Renée Mauborgne) — insights into creating and defending market spaces.
-
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: This strategy aims to disrupt the natural evolution of a nascent market.
 - [The less evolved something is the more uncertain it becomes](/climatic-patterns/the-less-evolved-something-is-then-the-more-uncertain-it-becomes) – rel: The uncertainty of early markets makes them vulnerable to "designed to fail" initiatives.
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: This is a direct attempt to influence and derail competitors' actions.
 - [Most competitors have poor situational awareness](/climatic-patterns/most-competitors-have-poor-situational-awareness) – rel: Exploits competitors' inability to discern a deliberately flawed initiative from a genuine one.
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: A company might use this to protect a successful but aging core business from a disruptive new market.
+
+## 📚 **Further Reading & References**
+- [HD DVD vs Blu-ray (Wikipedia)](https://en.wikipedia.org/wiki/HD_DVD) — a case of market fragmentation leading to failure.
+- [Betamax vs VHS (Wikipedia)](https://en.wikipedia.org/wiki/Betamax) — example of proprietary format wars.
+- *Blue Ocean Strategy* (W. Chan Kim & Renée Mauborgne) — insights into creating and defending market spaces.

--- a/docs/strategies/poison/insertion/index.md
+++ b/docs/strategies/poison/insertion/index.md
@@ -11,7 +11,6 @@ tags: [poison, sabotage, influence, misdirection, competitor-manipulation]
 > - Simon Wardley
 
 ## 🤔 **Explanation**
-
 ### What is Insertion?
 
 Insertion involves placing or influencing individuals, partnerships, or narratives within a competitor’s ecosystem to distort their decision-making processes.
@@ -29,7 +28,6 @@ This strategy allows you to:
 - Gain indirect control over market narratives and priorities.
 
 ## 🗺️ **Real-World Examples**
-
 ### Reverse Mentoring in Tech
 
 A dominant platform hires open-source advocates to slow feature rollouts or introduce bureaucratic hurdles, delaying competitor innovation.
@@ -39,7 +37,6 @@ A dominant platform hires open-source advocates to slow feature rollouts or intr
 You contract analysts to publish optimistic forecasts about a competitor’s nascent technology, prompting them to over-invest in an unproven niche.
 
 ## 🚦 **When to Use / When to Avoid**
-
 <Assessment strategyName="Insertion">
   <MapSignals>
     <li>The map shows a competitor gaining momentum in a key component or capability.</li>
@@ -68,7 +65,6 @@ You contract analysts to publish optimistic forecasts about a competitor’s nas
 - Detection would cause unacceptable reputation or regulatory harm.
 
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 Maintaining covert operations while measuring impact and avoiding detection or blowback.
@@ -85,7 +81,6 @@ Maintaining covert operations while measuring impact and avoiding detection or b
 Covert influence can breach trust and legal boundaries. Leaders must assess long-term brand and regulatory impacts.
 
 ## 📋 **How to Execute**
-
 1. Identify the target competitor and strategic inflection points.
 2. Develop an influence plan (personnel, media, partnerships).
 3. Insert agents or narratives with plausible roles.
@@ -94,14 +89,12 @@ Covert influence can breach trust and legal boundaries. Leaders must assess long
 6. Withdraw assets gracefully to minimize detection.
 
 ## 📈 **Measuring Success**
-
 - Competitor shifts away from optimal strategic paths.
 - Resources allocated by competitor to low-value initiatives.
 - Level of uncertainty or delay introduced in their roadmap.
 - Minimal detection and exposure of operations.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Exposure Risks
 
 Discovery leads to legal action, reputational damage, or regulatory scrutiny.
@@ -119,7 +112,6 @@ Excessive insertion activities increase complexity and detection likelihood.
 Target may ignore inserted assets or narratives, wasting resources.
 
 ## 🧠 **Strategic Insights**
-
 ### Evolution Stage and Fluidity
 
 Insertion tactics are often most potent when applied to components or strategies in the mid-stages of their evolution, specifically transitioning from custom-built to product or even early rental services. During these phases, decisions are still fluid, standards are not yet fully set, and organizations are more susceptible to external narratives or influences that can steer them towards ultimately suboptimal paths before they achieve a more robust, commoditized state. The uncertainty inherent in these evolutionary stages creates fertile ground for doubt and misdirection.
@@ -157,7 +149,6 @@ While difficult, competitors can mitigate hidden influences by fostering open fo
 Insertion is rarely a standalone play. Its effectiveness is often amplified when combined with other strategies like [Misdirection](/strategies/competitor/misdirection) (to create noise and divert attention from the actual insertion point), [Fragmentation](/strategies/competitor/fragmentation) (to create internal divisions that an inserted agent can exploit), or even [Designed to Fail](/strategies/poison/designed-to-fail) (where an inserted narrative convinces a competitor to adopt a flawed initiative).
 
 ## ❓ **Key Questions to Ask**
-
 - **Target Selection:** Which competitor controls components critical to our map?
 - **Access:** Can we infiltrate people or media channels effectively?
 - **Deniability:** How will we mask our involvement?
@@ -165,22 +156,19 @@ Insertion is rarely a standalone play. Its effectiveness is often amplified when
 - **Withdrawal Plan:** How will we remove inserted assets without leaving traces?
 
 ## 🔀 **Related Strategies**
-
 - [Misdirection](/strategies/competitor/misdirection) — redirecting attention through narrative.
 - [Talent Raid](/strategies/competitor/talent-raid) — the inverse: pulling people away.
 - [Fragmentation](/strategies/competitor/fragmentation) — sowing division for confusion.
 - [Press Release Process](/strategies/attacking/press-release-process) — public signals to manipulate perception.
 - [Designed to Fail](/strategies/poison/designed-to-fail) — pre-seeding flawed initiatives.
 
-## 📚 **Further Reading & References**
-
-- Cialdini, R. — [*Influence: The Psychology of Persuasion*](https://www.amazon.co.uk/Influence-Psychology-Robert-Cialdini-PhD/dp/006124189X) — foundational concepts of behavioral influence.
-- Mitnick, K. — [*The Art of Deception*](https://www.amazon.co.uk/Art-Deception-Controlling-Element-Security/dp/076454280X) — case studies on social engineering and covert operations.
-
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: The methods of insertion and the vulnerabilities of competitors evolve over time.
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: Insertion aims to directly influence and manipulate competitors' actions.
 - [Most competitors have poor situational awareness](/climatic-patterns/most-competitors-have-poor-situational-awareness) – rel: This strategy exploits the target's lack of awareness about being influenced.
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Competitors relying on past successful decision-making frameworks can be vulnerable to inserted narratives that fit those frameworks.
 - [The less evolved something is the more uncertain it becomes](/climatic-patterns/the-less-evolved-something-is-then-the-more-uncertain-it-becomes) – rel: Uncertainty in a competitor's strategy or market understanding provides fertile ground for insertion.
+
+## 📚 **Further Reading & References**
+- Cialdini, R. — [*Influence: The Psychology of Persuasion*](https://www.amazon.co.uk/Influence-Psychology-Robert-Cialdini-PhD/dp/006124189X) — foundational concepts of behavioral influence.
+- Mitnick, K. — [*The Art of Deception*](https://www.amazon.co.uk/Art-Deception-Controlling-Element-Security/dp/076454280X) — case studies on social engineering and covert operations.

--- a/docs/strategies/poison/licensing/index.md
+++ b/docs/strategies/poison/licensing/index.md
@@ -13,7 +13,6 @@ tags: [poison, intellectual-property, restriction, lock-in]
 > - Simon Wardley
 
 ## 🤔 **Explanation**
-
 ### What is Licensing?
 
 Licensing uses legal agreements like patents, copyrights, or trademarks, to control how others can use, modify, or distribute a technology or component. Terms may include field-of-use restrictions, revocable licenses, or dual-licensing models.
@@ -36,7 +35,6 @@ By structuring licenses strategically, you can:
 - Lock in partners or customers through exclusive rights.
 
 ## 🗺️ **Real-World Examples**
-
 ### MySQL Dual Licensing
 
 Oracle’s MySQL offers GPL-licensed open source and paid proprietary licenses. Projects requiring commercial terms must purchase a license, generating revenue and controlling adoption.
@@ -46,7 +44,6 @@ Oracle’s MySQL offers GPL-licensed open source and paid proprietary licenses. 
 Google releases Android under open-source licenses but retains key services under proprietary licenses, guiding ecosystem development under its terms.
 
 ## 🚦 **When to Use / When to Avoid**
-
 <Assessment strategyName="Licensing">
   <MapSignals>
     <li>Our map highlights critical components that competitors must use.</li>
@@ -75,7 +72,6 @@ Google releases Android under open-source licenses but retains key services unde
 - Legal risks or enforcement costs exceed benefits.
 
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 Crafting license terms that effectively deter competitors without alienating legitimate users or developers.
@@ -92,7 +88,6 @@ Crafting license terms that effectively deter competitors without alienating leg
 Overly restrictive licensing can stifle innovation and erode trust. Leaders should assess broader community impact and balance control with collaboration.
 
 ## 📋 **How to Execute**
-
 1. Audit core IP assets and dependencies.
 2. Define strategic objectives for licensing (protection, revenue, lock-in).
 3. Select license models: field-of-use, dual-licensing, revocable.
@@ -102,7 +97,6 @@ Overly restrictive licensing can stifle innovation and erode trust. Leaders shou
 7. Review and iterate licenses as market and technology evolve.
 
 ## 📈 **Measuring Success**
-
 - Reduced competitor use or replication of core assets.
 - Licensing revenue and renewal rates.
 - Partner and customer satisfaction under license terms.
@@ -110,7 +104,6 @@ Overly restrictive licensing can stifle innovation and erode trust. Leaders shou
 - Sustained market share and ecosystem stability.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Over-Complexity
 
 Excessively detailed terms can deter all adopters, including loyal partners.
@@ -128,7 +121,6 @@ Open-source communities may fork or abandon overly restrictive licenses.
 Excessive restrictions may create incompatible ecosystems.
 
 ## 🧠 **Strategic Insights**
-
 ### Dual-Licensing Models
 Offering both open source (e.g., GPL) and commercial licenses can be a powerful "Trojan horse." The open version drives adoption and community engagement, while the commercial option captures value from enterprises unwilling or unable to comply with open source terms, effectively segmenting the market.
 
@@ -154,7 +146,6 @@ A sophisticated licensing strategy can use graduated models to first seed a mark
 In complex ecosystems where multiple patented technologies are required to create a final product (e.g., smartphones), strategic licensing can lead to "royalty stacking." A company holding key patents can license them in a way that, while seemingly reasonable in isolation, contributes to an overall high cost for manufacturers when combined with licenses from other patent holders. If a single entity controls a significant portion of these essential patents, their licensing strategy can effectively "tax" the entire ecosystem. The "poison" here is the cumulative burden on implementers, which can stifle innovation, raise prices for consumers, and make it difficult for new entrants to compete, thereby reinforcing the power of the dominant patent holder(s). This is a high-stakes game often seen in standards-essential patent disputes.
 
 ## ❓ **Key Questions to Ask**
-
 - **Dependency:** Which of our assets are critical bottlenecks in the map?
 - **Leverage:** How can license terms create sustainable competitive advantage?
 - **Risk:** What is the litigation and reputational risk?
@@ -162,22 +153,19 @@ In complex ecosystems where multiple patented technologies are required to creat
 - **Evolution:** How will our licensing model adapt to market changes?
 
 ## 🔀 **Related Strategies**
-
 - [Patents & IPR](/strategies/decelerators/ipr) — using patents and IPR for control.
 - [Open Approaches](/strategies/accelerators/open-approaches) — the inverse: open standards and licenses.
 - [Designed to Fail](/strategies/poison/designed-to-fail) — seeding flawed initiatives.
 - [Exploiting Network Effects](/strategies/accelerators/exploiting-network-effects) — using network lock-in.
 - [Limitation of Competition](/strategies/defensive/limitation-of-competition) — structural barriers to entry.
 
-## 📚 **Further Reading & References**
-
-- [GPLv3 License](https://www.gnu.org/licenses/gpl-3.0.html) — example of strong copyleft.
-- [Multi-licensing](https://en.wikipedia.org/wiki/Multi-licensing) — overview of dual and multi-licensing strategies.
-
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: Licensing terms must adapt as technologies evolve and commoditize.
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Restrictive licensing can stifle innovation by preventing efficient use or combination of technologies.
 - [Higher order systems create new sources of worth](/climatic-patterns/higher-order-systems-create-new-sources-of-worth) – rel: Licensing can control access to components needed to build higher-order systems, thus capturing value.
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: Competitors may challenge licenses or create alternatives, forcing changes in licensing strategy.
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: A company successful with a particular licensing model might be slow to adapt it as the market changes.
+
+## 📚 **Further Reading & References**
+- [GPLv3 License](https://www.gnu.org/licenses/gpl-3.0.html) — example of strong copyleft.
+- [Multi-licensing](https://en.wikipedia.org/wiki/Multi-licensing) — overview of dual and multi-licensing strategies.

--- a/docs/strategies/positional/weak-signal-horizon/index.md
+++ b/docs/strategies/positional/weak-signal-horizon/index.md
@@ -11,7 +11,6 @@ tags: [weak-signal-horizon, positional, sensing, anticipation, foresight, market
 > - Simon Wardley
 
 ## 🤔 **Explanation**
-
 ### What is Weak Signal (Horizon)?
 
 Weak Signal (Horizon) is the organised practice of scanning for early indicators—economic anomalies, nascent behaviours, or emerging technologies—that reveal impending shifts in market landscapes or value chains.
@@ -34,7 +33,6 @@ Anticipating change before it becomes mainstream provides crucial lead time for 
 4. Translate insights into hypotheses and small-scale experiments.
 
 ## 🗺️ **Real-World Examples**
-
 ### Netflix’s Streaming Pivot
 
 Netflix detected early indicators of broadband adoption and shifting consumer preferences, transitioning from DVD rental to streaming before many competitors, gaining market leadership.
@@ -48,7 +46,6 @@ ARM recognised emerging demand for low-power processors in mobile devices and po
 A healthcare provider correlates subtle increases in patient data from wearables, anticipating broader adoption of remote monitoring and launching integrated telehealth services ahead of peers.
 
 ## 🚦 **When to Use / When to Avoid**
-
 <Assessment strategyName="Weak Signal (Horizon)">
   <MapSignals>
     <li>Value chain mapping shows components nearing transition points.</li>
@@ -66,7 +63,6 @@ A healthcare provider correlates subtle increases in patient data from wearables
 </Assessment>
 
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 Distinguishing meaningful early signals from noise and orchestrating strategic responses without overcommitting.
@@ -83,7 +79,6 @@ Distinguishing meaningful early signals from noise and orchestrating strategic r
 Ensuring data collection respects privacy, avoiding bias in signal interpretation, and preventing premature decisions that harm stakeholders.
 
 ## 📋 **How to Execute**
-
 1. Deploy sensors (data streams, user interviews, market scans).
 2. Aggregate and visualise signals on evolution maps.
 3. Convene cross-functional teams to review and prioritise signals.
@@ -91,7 +86,6 @@ Ensuring data collection respects privacy, avoiding bias in signal interpretatio
 5. Iterate sensing and experimentation cycles.
 
 ## 📈 **Measuring Success**
-
 - Number of actionable insights generated.
 - Time saved in strategic decision-making.
 - Early initiative success rates from sensed signals.
@@ -99,7 +93,6 @@ Ensuring data collection respects privacy, avoiding bias in signal interpretatio
 - ROI on sensing and foresight investments.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Noise overwhelm
 
 Collecting too many signals without effective filtering leads to analysis paralysis.
@@ -117,7 +110,6 @@ Delays between sensing and action erode the value of early indicators.
 Investing heavily in unvalidated signals can drain resources from core operations.
 
 ## 🧠 **Strategic Insights**
-
 ### Signal integration
 
 Combining diverse data sources uncovers patterns invisible in isolation.
@@ -131,7 +123,6 @@ Focusing on signals that precede market shifts, not those that confirm them afte
 Effective sensing requires an organisational culture that values and acts on early insights.
 
 ## ❓ **Key Questions to Ask**
-
 - **Signal quality:** How credible and diverse are our data sources?
 - **Interpretation:** Are we challenging assumptions in our analysis?
 - **Action readiness:** Can we rapidly prototype based on insights?
@@ -139,22 +130,19 @@ Effective sensing requires an organisational culture that values and acts on ear
 - **Resource balance:** Are we allocating enough to core operations?
 
 ## 🔀 **Related Strategies**
-
 - [Land Grab](/strategies/positional/land-grab) – using signals to guide where to stake claims.
 - [First Mover](/strategies/positional/first-mover) – to act on signals by industrialising early.
 - [Fast Follower](/strategies/positional/fast-follower) – to time entry based on pioneer signals.
 - [Innovate-Leverage-Commoditize (ILC)](/strategies/ecosystem/innovate-leverage-commoditize) – building infrastructure for systematic data collection.
 
-## 📚 **Further Reading & References**
-
-- Wardley, S. – [*Anticipation*](https://blog.gardeviance.org/2016/12/anticipation.html) – foundational concepts on sensing and foresight.
-- Kahneman, D. – [*Thinking, Fast and Slow*](https://www.amazon.co.uk/Thinking-Fast-Slow-Daniel-Kahneman/dp/0141033576#:~:text=Book%20details&text=Nobel%20Prize%20winner%20Daniel%20Kahneman,%2C%20and%20slow%2C%20rational%20thinking.) – for insights on bias and signal interpretation.
-- [*Horizon Scanning*](https://en.wikipedia.org/wiki/Horizon_scanning), Wikipedia - methodologies in foresight practice.
-
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: Weak signals often indicate the early stages of a component's evolution or a shift in its trajectory.
 - [Characteristics change](/climatic-patterns/characteristics-change) – rel: Subtle changes in component characteristics can be weak signals of broader market shifts.
 - [The less evolved something is the more uncertain it becomes](/climatic-patterns/the-less-evolved-something-is-then-the-more-uncertain-it-becomes) – rel: Weak signals are inherently uncertain but crucial for navigating early, unevolved spaces.
 - [Economy has cycles](/climatic-patterns/economy-has-cycles) – rel: Recognizing cyclical patterns can help identify weak signals related to market peaks, troughs, and transitions.
 - [Not everything is random](/climatic-patterns/not-everything-is-random) – rel: The core belief of weak signal detection is that underlying patterns, not randomness, drive market changes.
+
+## 📚 **Further Reading & References**
+- Wardley, S. – [*Anticipation*](https://blog.gardeviance.org/2016/12/anticipation.html) – foundational concepts on sensing and foresight.
+- Kahneman, D. – [*Thinking, Fast and Slow*](https://www.amazon.co.uk/Thinking-Fast-Slow-Daniel-Kahneman/dp/0141033576#:~:text=Book%20details&text=Nobel%20Prize%20winner%20Daniel%20Kahneman,%2C%20and%20slow%2C%20rational%20thinking.) – for insights on bias and signal interpretation.
+- [*Horizon Scanning*](https://en.wikipedia.org/wiki/Horizon_scanning), Wikipedia - methodologies in foresight practice.

--- a/docs/strategies/user-perception/artificial-competition/index.md
+++ b/docs/strategies/user-perception/artificial-competition/index.md
@@ -11,7 +11,6 @@ tags: [artificial-competition, user-perception, illusion of choice, market contr
 > - Simon Wardley
 
 ## 🤔 **Explanation**
-
 ### What is Artificial Competition?
 
 Artificial competition is a strategy where an organisation creates or supports a secondary entity that appears to compete with its own offerings. The two entities—though ultimately controlled or influenced by the same leadership—are positioned as rivals. This illusion reshapes market perception, giving the appearance of healthy competition while maintaining internal control.
@@ -35,8 +34,12 @@ Used effectively, artificial competition offers multiple layers of strategic ben
 
 This is about **shaping the environment in which decisions are made**. Skilled leaders use this strategy to create optionality, reduce volatility, and consolidate advantage
 
-## 🚦 **When to Use / When to Avoid**
+## 🗺️ **Real-World Examples**
+### MediaMarkt and Saturn
 
+The consumer electronics retailers **MediaMarkt and Saturn** in Europe are perceived as fierce competitors. However, both belong to the *same holding company*. This strategy consolidates market share within the holding company while blocking out other entrants.
+
+## 🚦 **When to Use / When to Avoid**
 <Assessment strategyName="Artifical Competition">
   <MapSignals>
     <li>We dominate a market or segment where regulatory or public scrutiny over monopoly risk is increasing.</li>
@@ -69,15 +72,7 @@ This is about **shaping the environment in which decisions are made**. Skilled l
 - Maintaining two entities is prohibitively costly or complex.
 - Transparency in your industry makes affiliations easy to uncover, risking trust erosion.
 
-
-## 🗺️ **Real-World Examples**
-
-### MediaMarkt and Saturn
-
-The consumer electronics retailers **MediaMarkt and Saturn** in Europe are perceived as fierce competitors. However, both belong to the *same holding company*. This strategy consolidates market share within the holding company while blocking out other entrants.
-
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 Balancing the illusion of competition while maintaining operational efficiency and avoiding exposure.
@@ -93,7 +88,6 @@ Balancing the illusion of competition while maintaining operational efficiency a
 Leaders must consider the ethical implications of misleading customers and regulators. Transparency and fairness should guide decision-making.
 
 ## 📋 **How to Execute**
-
 1. Identify the market segment where artificial competition would be most effective.
 2. Establish or acquire a secondary entity with plausible independence.
 3. Develop distinct branding and messaging for both entities.
@@ -101,7 +95,6 @@ Leaders must consider the ethical implications of misleading customers and regul
 5. Regularly assess risks of exposure and adjust strategies accordingly.
 
 ## 📈 **Measuring Success**
-
 - Increased market share across both entities.
 - Reduced entry of genuine competitors.
 - Positive customer perception of choice.
@@ -109,7 +102,6 @@ Leaders must consider the ethical implications of misleading customers and regul
 - Operational efficiency in managing both entities.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Exposure
 
 If affiliations are uncovered, it can lead to accusations of "astroturfing" and loss of trust.
@@ -123,7 +115,6 @@ Running two entities may result in internal cannibalization or duplicated effort
 The secondary entity may underperform, making the strategy unconvincing.
 
 ## 🧠 **Strategic Insights**
-
 ### Shape Perception, Not Just Structure
 
 Success hinges on how others perceive the relationship between your entities. Brand differentiation, messaging, tone, and even company culture must be designed to appear independent. Surface-level separation is not enough—perceived rivalry must feel real.
@@ -153,20 +144,17 @@ Deniability requires preparation. Separate legal entities, distinct leadership t
 There is a line between strategic positioning and market distortion. Regularly test your reasoning with trusted peers. If the strategy erodes trust or harms your ecosystem in the long run, the short-term gain may not be worth it.
 
 ## ❓ **Key Questions to Ask**
-
 - **Independence:** How plausible is the independence of the secondary entity?
 - **Market impact:** Does this strategy effectively block genuine competitors?
 - **Risk management:** What measures are in place to mitigate exposure risks?
 - **Customer perception:** How do customers perceive the competition?
 
 ## 🔀 **Related Strategies**
-
 - [Playing Both Sides](/strategies/attacking/playing-both-sides) - Benefiting from both ends of a competition.
 - [Market Enablement](/strategies/accelerators/market-enablement) - Enabling more competition under your control.
 - [Misdirection](/strategies/competitor/misdirection) - Misleading customers about the true competitive landscape.
 
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Two different forms of disruption](/climatic-patterns/two-different-forms-of-disruption) – trigger: fabricated rivalry can set off unexpected market shifts.
 - [Components can co-evolve](/climatic-patterns/components-can-co-evolve) – influence: staged contests steer user expectations and related products.
 

--- a/docs/strategies/user-perception/brand-and-marketing/index.md
+++ b/docs/strategies/user-perception/brand-and-marketing/index.md
@@ -9,7 +9,6 @@ tags: [brand-and-marketing, user-perception, branding, marketing, positioning, c
 <AssessmentToolAdvert strategyName="Brand and Marketing" />
 
 ## 🤔 **Explanation**
-
 ### What is Brand and Marketing?
 
 Brand and marketing involve using advertising, branding, and messaging to create an emotional connection or image that influences customer behavior. This strategy focuses on:
@@ -36,8 +35,16 @@ In markets saturated with similar offerings, a compelling brand narrative provid
 
 Effective application begins with a deep, empathetic understanding of the target customer segment – their motivations, pain points, values, and identity. This insight is the foundation for crafting authentic brand messages and narratives that genuinely resonate, creating a meaningful connection and sense of relevance. Implementation involves strategically positioning the brand within the market landscape, sometimes requiring sophisticated tactics like dual branding to effectively engage diverse niches without compromising the main brand's integrity. Consistent execution of this brand strategy across all customer touchpoints is vital for building and reinforcing the desired perception.
 
-## 🚦 **When to Use / When to Avoid**
+## 🗺️ **Real-World Examples**
+### BlackBerry's "It's not a toy" Campaign
 
+BlackBerry positioned its phones as professional tools, implicitly labeling iPhones as frivolous. This branding aimed to keep corporate users loyal by appealing to their professional identity.
+
+### Orange's "NJU Mobile" Sub-Brand
+
+Orange launched "NJU Mobile" to target youth while maintaining its main brand's integrity. This dual branding strategy allowed it to cover all bases.
+
+## 🚦 **When to Use / When to Avoid**
 <Assessment strategyName="Brand and Marketing">
   <MapSignals>
     <li>The market is saturated with functionally similar offerings, creating a premium on perceived differentiation.</li>
@@ -70,18 +77,7 @@ Effective application begins with a deep, empathetic understanding of the target
 - The product has quality issues that marketing cannot fix.
 - Innovation is needed more than branding.
 
-## 🗺️ **Real-World Examples**
-
-### BlackBerry's "It's not a toy" Campaign
-
-BlackBerry positioned its phones as professional tools, implicitly labeling iPhones as frivolous. This branding aimed to keep corporate users loyal by appealing to their professional identity.
-
-### Orange's "NJU Mobile" Sub-Brand
-
-Orange launched "NJU Mobile" to target youth while maintaining its main brand's integrity. This dual branding strategy allowed it to cover all bases.
-
 ## 🎯 **Leadership**
-
 ### Core challenge
 
 Balancing brand messaging with product quality and innovation.
@@ -97,21 +93,18 @@ Balancing brand messaging with product quality and innovation.
 Avoid misleading or over-promising in marketing campaigns.
 
 ## 📋 **How to Execute**
-
 1. Research and understand your target audience.
 2. Develop a clear and resonant brand message.
 3. Implement dual branding strategies if targeting multiple segments.
 4. Monitor and adjust campaigns based on feedback and results.
 
 ## 📈 **Measuring Success**
-
 - Increased customer loyalty and retention.
 - Positive brand perception in target segments.
 - Growth in market share or sales.
 - Effective differentiation from competitors.
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
-
 ### Mis-targeting
 
 Messaging that does not resonate with the intended audience can alienate customers.
@@ -125,7 +118,6 @@ Setting unrealistic expectations through aggressive marketing can lead to backla
 Relying solely on branding to carry a subpar product rarely works beyond initial sales.
 
 ## 🧠 **Strategic Insights**
-
 ### Branding as a Differentiator
 
 A strong brand can transcend product features, creating emotional loyalty even in highly commoditized markets. This is particularly effective when customers perceive the brand as an extension of their identity or values. For example, luxury brands often rely on this emotional connection to justify premium pricing.
@@ -147,21 +139,17 @@ Branding can amplify the perceived value of a product within a value chain. For 
 Effective branding requires thinking beyond immediate sales. It involves aligning the brand with broader organizational goals, such as market leadership, long-term customer loyalty, or societal impact. This strategic alignment ensures that branding efforts contribute to sustainable growth.
 
 ## ❓ **Key Questions to Ask**
-
 - **Target Audience:** Who are we trying to reach, and what resonates with them?
 - **Messaging:** Does our messaging align with our product and audience values?
 - **Competitors:** How does our branding differentiate us from competitors?
 
 ## 🔀 **Related Strategies**
-
 - [Education](/strategies/user-perception/education) - Informative marketing to build trust.
 - [Fear, Uncertainty and Doubt](/strategies/user-perception/fear-uncertainty-and-doubt) - Counterplay competitors might use.
 - [Differentiation](/strategies/markets/differentiation) - Highlighting unique selling points.
 
 ## ⛅ **Relevant Climatic Patterns**
-
 - [Everything evolves](/climatic-patterns/everything-evolves) – influence: brand messages must adapt as products mature.
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – trigger: marketing shifts when rivals redefine markets.
 
 ## 📚 **Further Reading & References**
-

--- a/reorder_markdown_sections.py
+++ b/reorder_markdown_sections.py
@@ -1,0 +1,221 @@
+import re
+import sys
+import os
+
+REQUIRED_STRATEGY_HEADINGS = [
+    "## 🤔 **Explanation**",
+    "## 🗺️ **Real-World Examples**",
+    "## 🚦 **When to Use / When to Avoid**",
+    "## 🎯 **Leadership**",
+    "## 📋 **How to Execute**",
+    "## 📈 **Measuring Success**",
+    "## ⚠️ **Common Pitfalls and Warning Signs**",
+    "## 🧠 **Strategic Insights**",
+    "## ❓ **Key Questions to Ask**",
+    "## 🔀 **Related Strategies**",
+    "## ⛅ **Relevant Climatic Patterns**",
+    "## 📚 **Further Reading & References**",
+]
+REQUIRED_STRATEGY_HEADINGS_SET = set(REQUIRED_STRATEGY_HEADINGS)
+
+# Generic H2 pattern (ensures it starts a line, allows leading spaces)
+GENERIC_H2_PATTERN = re.compile(r"(?:^|\n)(\s*##\s+[^#\n][^\n]*?)(?=\n|$)", re.MULTILINE)
+
+
+def reorder_sections_in_file_v5(filepath):
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            content = f.read()
+    except FileNotFoundError:
+        print(f"Error: File not found: {filepath}")
+        return
+
+    sections = {}
+    non_standard_sections = {}
+    ordered_headings_in_file = [] # Will store (stripped_heading, original_text_of_heading, content_for_heading)
+
+    markers = [] # List of (position, stripped_heading_text, original_heading_text)
+
+    # 1. Find all REQUIRED headings by exact string match
+    for req_heading in REQUIRED_STRATEGY_HEADINGS:
+        start_index = 0
+        while True:
+            pos = content.find(req_heading, start_index)
+            if pos == -1:
+                break
+            # Ensure this found heading isn't part of a larger, non-standard heading
+            # e.g. prevent matching "## Foo" inside "## Foo Bar" if "## Foo Bar" is also a generic H2 marker
+            # This is complex; for now, assume direct matches are primary.
+            markers.append((pos, req_heading, req_heading)) # pos, canonical, original
+            start_index = pos + len(req_heading)
+
+    # 2. Find all generic H2 headings that start a line
+    for match in GENERIC_H2_PATTERN.finditer(content):
+        pos = match.start(1) # Start of the heading text itself (group 1)
+        original_heading = match.group(1) # Includes leading spaces
+        stripped_heading = original_heading.strip()
+
+        # Avoid adding if it's a required heading already found by exact match at nearly the same position
+        # (exact match for required headings is preferred)
+        is_already_marked_as_required = False
+        for m_pos, m_canon, _ in markers:
+            if m_canon == stripped_heading and abs(m_pos - pos) < len(original_heading) : # If same heading text and nearby
+                is_already_marked_as_required = True
+                break
+        if not is_already_marked_as_required and stripped_heading not in REQUIRED_STRATEGY_HEADINGS_SET:
+            markers.append((pos, stripped_heading, original_heading))
+
+    # Sort markers by position, then by length of original heading descending (to prioritize longer matches if overlapping)
+    markers.sort(key=lambda x: (x[0], -len(x[2])))
+
+    # Filter overlapping/duplicate markers: if two markers start at same pos, keep the one that's a required heading,
+    # or the longer one if neither/both are.
+    # A simpler filter: keep unique positions, prioritizing required ones.
+    unique_pos_markers = {}
+    for pos, stripped_h, original_h in markers:
+        if pos not in unique_pos_markers:
+            unique_pos_markers[pos] = (pos, stripped_h, original_h)
+        else:
+            # Preference: if current is required and stored isn't, replace.
+            # Or if current is longer. (This logic can be refined if needed)
+            is_current_req = stripped_h in REQUIRED_STRATEGY_HEADINGS_SET
+            is_stored_req = unique_pos_markers[pos][1] in REQUIRED_STRATEGY_HEADINGS_SET
+            if is_current_req and not is_stored_req:
+                unique_pos_markers[pos] = (pos, stripped_h, original_h)
+            elif not is_current_req and not is_stored_req and len(original_h) > len(unique_pos_markers[pos][2]):
+                 unique_pos_markers[pos] = (pos, stripped_h, original_h)
+            # If both required, or current is not req and stored is, keep stored.
+
+    sorted_markers = sorted(list(unique_pos_markers.values()), key=lambda x: x[0])
+
+    # 3. Extract sections based on sorted markers
+    preamble = ""
+    if not sorted_markers:
+        preamble = content
+    else:
+        preamble = content[:sorted_markers[0][0]] # Content before the first marker's original start
+
+        for i, (pos, stripped_h, original_h) in enumerate(sorted_markers):
+            content_start_pos = pos + len(original_h) # Content starts after the original heading text
+            content_end_pos = sorted_markers[i+1][0] if (i + 1) < len(sorted_markers) else len(content)
+            section_content = content[content_start_pos:content_end_pos]
+
+            if stripped_h in REQUIRED_STRATEGY_HEADINGS_SET:
+                sections[stripped_h] = section_content # Use canonical form as key
+            elif stripped_h.startswith("## "): # Must be a non-standard one
+                if stripped_h not in non_standard_sections: # Keep first encountered
+                    non_standard_sections[stripped_h] = section_content
+                    ordered_headings_in_file.append(stripped_h) # This list is for non-standard ones
+
+    # 4. Reconstruct the document
+    new_content_parts = [preamble.rstrip() + ('\n' if preamble.strip() else '')] # Ensure preamble ends with one newline if not empty
+
+    for req_heading in REQUIRED_STRATEGY_HEADINGS:
+        if req_heading in sections:
+            # Ensure there's a blank line before the new heading if content exists already
+            if new_content_parts and new_content_parts[-1].strip():
+                 if not new_content_parts[-1].endswith('\n\n'):
+                    new_content_parts[-1] = new_content_parts[-1].rstrip() + '\n\n'
+
+            new_content_parts.append(req_heading + "\n") # Canonical heading on its own line
+            # Content should also start on a new line, and be trimmed
+            section_body = sections[req_heading].strip()
+            if section_body: # Only add content if it's not just whitespace
+                new_content_parts.append(section_body + "\n")
+
+    if non_standard_sections:
+        if new_content_parts and new_content_parts[-1].strip() and not new_content_parts[-1].endswith('\n\n'):
+            new_content_parts[-1] = new_content_parts[-1].rstrip() + '\n\n'
+
+        for heading in ordered_headings_in_file: # This list contains non-standard headings
+            if heading in non_standard_sections:
+                new_content_parts.append(heading + "\n")
+                section_body = non_standard_sections[heading].strip()
+                if section_body:
+                    new_content_parts.append(section_body + "\n")
+
+
+    final_content = "".join(new_content_parts)
+    # Final normalization: strip trailing spaces from all lines, ensure single trailing newline for the whole file
+    final_content_lines = [l.rstrip() for l in final_content.splitlines()]
+    final_content = "\n".join(final_content_lines)
+
+    if final_content.strip(): # If there's any actual content
+        final_content = final_content.strip() + "\n"
+    else: # If all content was whitespace or empty
+        final_content = ""
+
+
+    try:
+        with open(filepath, 'w', encoding='utf-8') as f:
+            f.write(final_content)
+    except IOError:
+        print(f"Error: Could not write to file: {filepath}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python reorder_markdown_sections.py <path_to_markdown_file_or_keyword>")
+        sys.exit(1)
+
+    current_failing_slugs = [
+        "/strategies/markets/harvesting", "/strategies/markets/buyer-supplier-power",
+        "/strategies/markets/signal-distortion", "/strategies/competitor/circling-and-probing",
+        "/strategies/dealing-with-toxicity/refactoring", "/strategies/dealing-with-toxicity/disposal-of-liability",
+        "/strategies/dealing-with-toxicity/pig-in-a-poke",
+    ]
+    initial_failing_slugs = [
+            "/strategies/poison/designed-to-fail", "/strategies/poison/licensing", "/strategies/poison/insertion",
+            "/strategies/ecosystem/alliances", "/strategies/positional/weak-signal-horizon",
+            "/strategies/attacking/press-release-process", "/strategies/markets/harvesting",
+            "/strategies/markets/buyer-supplier-power", "/strategies/markets/signal-distortion",
+            "/strategies/markets/standards-game", "/strategies/accelerators/exploiting-network-effects",
+            "/strategies/accelerators/cooperation", "/strategies/accelerators/industrial-policy",
+            "/strategies/user-perception/brand-and-marketing", "/strategies/user-perception/artificial-competition",
+            "/strategies/competitor/circling-and-probing", "/strategies/competitor/ambush",
+            "/strategies/competitor/tech-drops", "/strategies/competitor/misdirection",
+            "/strategies/competitor/restriction-of-movement", "/strategies/competitor/sapping",
+            "/strategies/competitor/talent-raid", "/strategies/competitor/reinforcing-competitor-inertia",
+            "/strategies/competitor/fragmentation", "/strategies/dealing-with-toxicity/refactoring",
+            "/strategies/dealing-with-toxicity/disposal-of-liability", "/strategies/dealing-with-toxicity/sweat-and-dump",
+            "/strategies/dealing-with-toxicity/pig-in-a-poke",
+        ]
+
+    base_dir = "docs"
+    files_to_process_paths = []
+    args = sys.argv[1:]
+
+    slugs_for_processing = []
+    if "ALL_FAILING" in args:
+        slugs_for_processing = current_failing_slugs
+        args = [arg for arg in args if arg != "ALL_FAILING"]
+    elif "PREVIOUS_ALL_FAILING" in args:
+        slugs_for_processing = initial_failing_slugs
+        args = [arg for arg in args if arg != "PREVIOUS_ALL_FAILING"]
+
+    if slugs_for_processing:
+        files_to_process_paths.extend(f"{base_dir}{slug}/index.md" for slug in slugs_for_processing)
+
+    for arg in args:
+        # A bit more robust check for file paths
+        path_candidate = arg
+        if not os.path.isabs(path_candidate) and not path_candidate.startswith(base_dir) and arg.startswith("/strategies"):
+             path_candidate = f"{base_dir}{arg}/index.md" # Convert slug-like arg to full path
+
+        if os.path.exists(path_candidate) and path_candidate.endswith(".md"):
+            files_to_process_paths.append(path_candidate)
+        elif arg.endswith(".md"): # Allow adding .md files even if not initially existing (e.g. if script creates them)
+             files_to_process_paths.append(path_candidate)
+
+
+    files_to_process_paths = sorted(list(set(files_to_process_paths)))
+
+    if not files_to_process_paths:
+        print("No files specified or matched by keywords for reordering.")
+        sys.exit(0)
+
+    for md_file in files_to_process_paths:
+        print(f"Reordering {md_file} with V5 script...")
+        reorder_sections_in_file_v5(md_file)
+
+    print(f"Done reordering {len(files_to_process_paths)} file(s) with V5 script.")


### PR DESCRIPTION
Processed strategy documents to ensure all required H2 headings are present, correctly formatted to start on new lines, and appear in the standard order.

This resolves failures in the test_strategy_headings_in_order test by:
1. Identifying all required H2 headings, even if initially malformed (e.g., not starting on a new line).
2. Reconstructing the documents with these headings correctly formatted and in the specified order.
3. Preserving all other content and any non-standard H2 sections.