### PR TITLE
Add quote test and doc guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,13 +20,16 @@ Strategies should aim to follow this format as closely as possible.
 
 1. Front matter YAML
 2. 1 single senence accessible description in bold (`**`)
-3. Quote from Simon Wardley. Eg
+3. Quote from Simon Wardley if he directly references the strategy. Eg
 
    ```md
    > *"Driving a market to a standard to create a cost of transition for others or remove the ability of others to differentiate."*
    >
    > - Simon Wardley
    ```
+
+   If Wardley hasn't mentioned the strategy, add a note after the description saying it
+   "isn't explicitly mentioned" in his [On 61 different forms of gameplay](https://blog.gardeviance.org/2015/05/on-61-different-forms-of-gameplay.html). Refactoring is an example of this approach.
 
 4. `## 🤔 **Explanation**`
    - Start with a subsection `## What is <strategy name>?`, which should be a paragraph or 2 and could include a few bullet points if a list is helpful. Only link to other strategies here if it is helpful to understand where it sits, eg if it is a sub-strategy or very closely related.

--- a/tests/test_content_quality.py
+++ b/tests/test_content_quality.py
@@ -463,3 +463,32 @@ def test_internal_links_are_in_related_strategies():
 
     assert not issues_found, \
         "Found internal strategy links not listed in 'Related Strategies' sections:\n\n" + "\n\n".join(issues_found)
+
+
+def test_strategy_has_quote_or_explicit_unmentioned_note():
+    """Ensure each strategy either quotes Simon Wardley or states it isn't explicitly mentioned."""
+    strategy_files = find_markdown_files(STRATEGY_DIR, filename_pattern='index.md')
+    missing = []
+
+    for filepath in strategy_files:
+        relative_path = os.path.relpath(filepath, STRATEGY_DIR)
+        if len(os.path.normpath(relative_path).split(os.sep)) < 3:
+            continue
+
+        slug = get_file_slug(filepath, 'docs')
+        try:
+            with open(filepath, 'r', encoding='utf-8') as f:
+                content = f.read()
+        except FileNotFoundError:
+            missing.append(f"File not found: {slug}")
+            continue
+
+        has_quote = re.search(r'^>.*Simon Wardley', content, re.MULTILINE)
+        has_unmentioned = "isn't explicitly mentioned" in content
+
+        if not (has_quote or has_unmentioned):
+            missing.append(slug)
+
+    assert not missing, (
+        "Strategies missing a Wardley quote or 'isn't explicitly mentioned' note:\n" + "\n".join(missing)
+    )


### PR DESCRIPTION
## Summary
- enforce that each strategy includes either a Simon Wardley quote or states it "isn't explicitly mentioned"
- document how to handle strategies Wardley hasn't covered

## Testing
- `npm install`
- `npm test`
- `pytest -q` *(fails: Strategies missing a Wardley quote or unexplained links)*

------
https://chatgpt.com/codex/tasks/task_e_6861c6b4f2f4832b9ea052e4a6dda68b