### PR TITLE
Fix: Add Wardley quotes or 'not mentioned' notes to strategies

### DIFF
--- a/docs/strategies/accelerators/cooperation/index.md
+++ b/docs/strategies/accelerators/cooperation/index.md
@@ -17,7 +17,11 @@ core_challenge: Balancing control and openness.
 
 **Working with others, even competitors, to achieve a goal**.
 
-It sounds straightforward, but as Wardley wryly notes, "sounds easy, actually it's not." This strategy is about forming partnerships, joint ventures, or industry collaborations where mutual benefit can be found.
+> *"Working with others. Sounds easy, actually it's not."*
+>
+> - Simon Wardley
+
+This strategy is about forming partnerships, joint ventures, or industry collaborations where mutual benefit can be found.
 
 <AssessmentToolAdvert strategyName="Cooperation" />
 

--- a/docs/strategies/accelerators/exploiting-network-effects/index.md
+++ b/docs/strategies/accelerators/exploiting-network-effects/index.md
@@ -14,6 +14,10 @@ core_challenge:
 
 **Leveraging tactics that increase the value of your product as more users join.**
 
+> *"Techniques which increases the marginal value of something with increased number of users."*
+>
+> - Simon Wardley
+
 This accelerates adoption in a self-reinforcing loop. In practice, it means structuring offerings or incentives so that each new customer boosts utility for all, creating a positive feedback growth cycle.
 
 <AssessmentToolAdvert strategyName="Network Effects" />

--- a/docs/strategies/competitor/fragmentation/index.md
+++ b/docs/strategies/competitor/fragmentation/index.md
@@ -2,9 +2,11 @@
 tags: [competitor, fragmentation, markets, underdog, disruption, divide and conquer]
 ---
 
-# Fragmentation
-
 **Splintering a rival's market to erode their stronghold**.
+
+> *"Exploiting pricing effects, constraints and co-opting to fragment a competitor's market."*
+>
+> - Simon Wardley
 
 It involves exploiting weaknesses to break the competitor's market into smaller pieces.
 

--- a/docs/strategies/competitor/misdirection/index.md
+++ b/docs/strategies/competitor/misdirection/index.md
@@ -2,9 +2,11 @@
 tags: [misdirection, competitor, deception, assumptions, signals, influence, competitor intelligence]
 ---
 
-# Misdirection
-
 **Deliberately sending false or misleading signals to competitors to obscure your true intentions**.
+
+> *"Sending false signals to competitors or future competitors including investment focused on the wrong direction."*
+>
+> - Simon Wardley
 
 It's about appearing to go one way while secretly moving another.
 

--- a/docs/strategies/competitor/reinforcing-competitor-inertia/index.md
+++ b/docs/strategies/competitor/reinforcing-competitor-inertia/index.md
@@ -2,9 +2,11 @@
 tags: [reinforcing-competitor-inertia, competitor, inertia, change, resistance, obsolescence, innovation]
 ---
 
-# Reinforcing Competitor Inertia
-
 **Exploiting a competitor's reluctance or inability to change**.
+
+> *"Identifying inertia within a competitor and forcing market changes that reinforce this."*
+>
+> - Simon Wardley
 
 This strategy focuses on leveraging a competitor's resistance to change to gain a strategic advantage. It involves identifying areas where a competitor is "stuck" and then driving market changes that reinforce their commitment to an outdated approach.
 

--- a/docs/strategies/competitor/restriction-of-movement/index.md
+++ b/docs/strategies/competitor/restriction-of-movement/index.md
@@ -2,9 +2,11 @@
 tags: [restriction-of-movement, competitor, circling, ecosystem, cornering, constraint, control, limitation]
 ---
 
-# Restriction of Movement
-
 **Limiting a rival's ability to maneuver or adapt**.
+
+> *"Limiting a competitors ability to adapt."*
+>
+> - Simon Wardley
 
 This strategy, sometimes called "Circling," aims to constrain a competitor by blocking their options to evolve or react effectively.
 

--- a/docs/strategies/competitor/sapping/index.md
+++ b/docs/strategies/competitor/sapping/index.md
@@ -2,9 +2,11 @@
 tags: [sapping, competitor, multi-front, attrition, endurance, resource drain, distraction]
 ---
 
-# Sapping
-
 **Attacking a competitor on multiple fronts simultaneously to weaken their capacity to respond**.
+
+> *"Opening up multiple fronts on a competitor to weaken their ability to react."*
+>
+> - Simon Wardley
 
 Sapping, inspired by military tactics, involves launching simultaneous attacks across various fronts (product, price, marketing, geography) to stretch a competitor's resources and attention. The core idea is that a competitor capable of defending against a single attack will struggle against a barrage of concurrent challenges. By forcing a rival to divide their focus and resources, their overall effectiveness is degraded. Sapping is a strategy of attrition and distraction, aiming to drain the competitor's energy and induce mistakes or neglect.
 

--- a/docs/strategies/competitor/talent-raid/index.md
+++ b/docs/strategies/competitor/talent-raid/index.md
@@ -4,9 +4,11 @@ description: Removing or absorbing key talent from a rival organisation.
 tags: [talent-raid, competitor, talent, human resources, acquisition, poaching, expertise, weakening rivals]
 ---
 
-# Talent Raid
-
 **Removing or absorbing key talent from a rival organization**.
+
+> *"Removing core talent from a competitor either directly or indirectly."*
+>
+> - Simon Wardley
 
 A Talent Raid is a competitive strategy focused on removing or absorbing key talent from a rival organisation. By taking away a competitor's critical human resources — their experts, leaders, engineers or creative minds — you simultaneously strengthen your own company and weaken theirs. This can be done directly by hiring employees away or indirectly by enticing them through acquisitions or partnerships. Talent is often the lifeblood of tech and creative industries; a well‑timed raid can disrupt projects, slow innovation or deprive a competitor of strategic direction. In essence, a talent raid treats top employees as a scarce competitive asset and seeks to control that asset.
 

--- a/docs/strategies/defensive/managing-inertia/index.md
+++ b/docs/strategies/defensive/managing-inertia/index.md
@@ -4,11 +4,11 @@ description: A defensive strategy focused on proactively identifying and overcom
 tags: [defensive, inertia, change-management, adaptation, organizational-change, resistance, culture]
 ---
 
-# Managing Inertia
-
 **A defensive strategy focused on proactively identifying and overcoming an organization's internal resistance to change to enable adaptation and agility.**
 
-
+> *"Implementation of cell based & PST structures along with multiple cultures to deal with aptitude and attitude. Both autonomy and mastery can be enabled by these forms of structure and they avoid the silos and inertia created by traditional structures."*
+>
+> - Simon Wardley
 
 ## 🤔 **Explanation**
 

--- a/docs/strategies/ecosystem/alliances/index.md
+++ b/docs/strategies/ecosystem/alliances/index.md
@@ -6,7 +6,9 @@ tags: [alliances, ecosystem, partnerships, consortia, collaboration, standards, 
 
 **Forming formal partnerships to pursue common objectives.**
 
-# Alliances
+> *"Working with other companies to drive evolution of a specific activity, practice or data set."*
+>
+> - Simon Wardley
 
 ## 🤔 **Explanation**
 

--- a/docs/strategies/ecosystem/channel-conflict-and-disintermediation/index.md
+++ b/docs/strategies/ecosystem/channel-conflict-and-disintermediation/index.md
@@ -4,11 +4,11 @@ description: A strategy of deliberately creating tension between distribution ch
 tags: [ecosystem, channel-conflict, disintermediation, distribution, direct-to-consumer, partners, leverage]
 ---
 
-# Channel Conflict and Disintermediation
-
 **A strategy of deliberately creating tension between distribution channels to gain control, reshape value flows, and own the customer relationship.**
 
-
+> *"Exploiting new channels and conflict within existing channels to create favourable terms."*
+>
+> - Simon Wardley
 
 ## 🤔 **Explanation**
 

--- a/docs/strategies/markets/last-man-standing/index.md
+++ b/docs/strategies/markets/last-man-standing/index.md
@@ -4,11 +4,9 @@ description: A strategy of outlasting competitors in a commoditizing market to c
 tags: [markets, commoditisation, attrition, scale, efficiency, price-war, market-consolidation]
 ---
 
-# Last Man Standing
-
 **A strategy of outlasting competitors in a commoditizing market to capture remaining market share.**
 
-
+This strategy isn't explicitly mentioned by Simon Wardley in his [On 61 different forms of gameplay](https://blog.gardeviance.org/2015/05/on-61-different-forms-of-gameplay.html).
 
 ## 🤔 **Explanation**
 

--- a/docs/strategies/user-perception/brand-and-marketing/index.md
+++ b/docs/strategies/user-perception/brand-and-marketing/index.md
@@ -6,6 +6,10 @@ tags: [brand-and-marketing, user-perception, branding, marketing, positioning, c
 
 **Using traditional marketing and brand positioning to shape user perception.**
 
+> *"Creating and elevating an artificial need through marketing and behavioural influence. Take a rock and make it a pet etc."*
+>
+> - Simon Wardley
+
 <AssessmentToolAdvert strategyName="Brand and Marketing" />
 
 ## 🤔 **Explanation**


### PR DESCRIPTION
Ensures all strategy documents comply with CONTRIBUTING.md guidelines by including either a direct quote from Simon Wardley's 'On 61 different forms of gameplay' blog post or a note stating the strategy isn't explicitly mentioned.

This addresses failures in the `test_strategy_has_quote_or_explicit_unmentioned_note` test.