### PR TITLE
Integrate Strategic Divestment concepts into Disposal of Liability st…

### DIFF
--- a/docs/strategies/dealing-with-toxicity/disposal-of-liability/index.md
+++ b/docs/strategies/dealing-with-toxicity/disposal-of-liability/index.md
@@ -1,35 +1,51 @@
 ---
-title: Disposal of Liability
-description: Eliminating toxic or obsolete components by divesting or shutting down burdensome assets.
-tags: [dealing-with-toxicity, legacy, divestment, exit-strategy, inertia, obsolescence, risk-mitigation]
+title: Strategic Divestment and Disposal of Liability
+description: Strategically restructuring by separating or selling off business units, assets, or divisions to unlock value, enhance focus, or dispose of liabilities.
+tags: [dealing-with-toxicity, legacy, divestment, exit-strategy, inertia, obsolescence, risk-mitigation, strategic-divestment, spin-off, carve-out, restructuring]
 ---
 
-# Disposal of Liability
+# Strategic Divestment and Disposal of Liability
 
-**Eliminating toxic or obsolete components from your value chain to reduce drag and reclaim focus.**
+**Strategically restructuring through actions like spin-offs, split-offs, carve-outs, or direct disposal to unlock shareholder value, enhance strategic focus, reduce debt, streamline operations, or eliminate burdensome components from your value chain.**
 
 > *"Overcoming the internal inertia to disposal. Your own organisation is likely to fight you even when you're trying to get
 id of the toxic."*
 >
-> - Simon Wardley
+> - Simon Wardley (Note: This quote relates more specifically to the 'disposal of liability' aspect)
 
 ## 🤔 **Explanation**
 
-### What is Disposal of Liability?
-Disposal of Liability is the strategic removal of components, such as products, services, or operations, that have become
-burdensome or harmful to an organization’s evolution. These components may be outdated, costly to maintain, or generate inertia
-that hinders growth and innovation.
+### What is Strategic Divestment and Disposal of Liability?
+Strategic Divestment encompasses a range of corporate restructuring actions, including spin-offs (creating a new independent company from a subsidiary), split-offs (offering shareholders stock in a subsidiary in exchange for parent company stock), and carve-outs (selling a minority stake in a subsidiary via an IPO). It also includes the more direct Disposal of Liability, which is the strategic removal of components—such as products, services, or operations—that have become burdensome, obsolete, or harmful to an organization’s evolution.
 
-### Why use Disposal of Liability?
-Eliminating liabilities frees resources (financial, human, and strategic) to focus on higher-value activities. It reduces
-complexity, cuts maintenance costs, and mitigates risks associated with obsolete or non-strategic assets.
+The overarching goal of these actions can be to unlock shareholder value, enhance the strategic focus of both the parent and the separated entity, reduce debt, or streamline overall operations. Divested components may be outdated, costly to maintain, strategically misaligned, or generate inertia that hinders growth and innovation.
 
-### How to use Disposal of Liability?
-Begin by mapping your value chain to identify components that are no longer evolving or are causing drag. Evaluate their cost,
-risk, and strategic fit. Develop a disposal plan, which may include divestiture, shutdown, or sale. Secure leadership buy-in,
-communicate with stakeholders, and manage the transition carefully.
+### Why use Strategic Divestment and Disposal of Liability?
+Organizations undertake divestments and disposals for multiple strategic reasons. These include:
+- **Unlocking Shareholder Value:** Separating a business unit can allow it to be valued more appropriately by the market, potentially benefiting shareholders of both entities.
+- **Enhancing Strategic Focus:** It allows the separated entity to pursue focused growth unconstrained by the parent's broader objectives. Simultaneously, it enables the parent company to re-align its focus and resources on its core business areas.
+- **Streamlining Operations & Reducing Debt:** Divestment can be a way to raise capital, significantly reduce debt, or simplify a complex organizational structure, making the parent company leaner and more agile.
+- **Eliminating Burdensome Components:** Removing liabilities frees resources (financial, human, and strategic) to focus on higher-value activities. It reduces complexity, cuts maintenance costs, and mitigates risks associated with obsolete, underperforming, or non-strategic assets.
+- **Proactive Transformation:** It is often a proactive and transformative move to optimize the overall portfolio of capabilities and value chains within a dynamic market, rather than simply a reactive measure.
 
-## 🗺️ **Real-World Examples**
+### How to approach Strategic Divestment and Disposal of Liability?
+Applying this strategy involves a careful assessment of your organization's portfolio against its strategic objectives. It requires identifying units or assets that might be candidates for divestment (to unlock value or improve focus) or disposal (to eliminate drag). This evaluation should consider financial performance, strategic alignment, market position, and potential for future growth, either within or outside the parent company. The process is iterative and requires strong analytical backing, stakeholder engagement, and clear decision-making.
+
+For detailed, actionable steps, refer to the [**How to Execute Strategic Divestment or Disposal**](#-how-to-execute-strategic-divestment-or-disposal) section.
+
+## 🗺️ **Manifestation on a Wardley Map**
+Strategic Divestment represents a profound "moving of pieces" as it literally removes or reconfigures entire segments of an organization's Wardley Map.
+
+- **Creation of New Maps:** A spun-off entity, for example, effectively creates a new, independent Wardley Map for its operations.
+- **Leaner Parent Map:** The parent company's map becomes leaner and more concentrated on its remaining core activities. Capabilities, user needs, and associated value chains linked to the divested unit are systematically removed from the parent company's map.
+- **Re-evaluation and Focus:** This process allows the remaining components on the parent's map to be re-evaluated for their strategic importance, evolutionary stage, and potential for accelerated development. It can reveal new opportunities for investment or highlight areas for consolidation and efficiency within the streamlined map.
+- **Streamlined Value Chains:** By divesting non-core, underperforming, or strategically misaligned assets, the parent company's value chain becomes more streamlined, efficient, and better aligned with its redefined core purpose. Concurrently, the spun-off entity gains the autonomy to build and optimize its own distinct value chain tailored to its specific market and objectives.
+- **Unlocking Value and Accelerating Evolution:** The act of separation can unlock significant hidden value by allowing the divested entity to operate with greater agility, focus, and dedicated resources, potentially accelerating the evolution of its core components. This is a strategic move to create two potentially more valuable entities from one.
+- **Map Simplification and Re-centering:** A Wardley Map can become "unfocused" or "diluted" with non-core or peripheral components over time. Strategic Divestment is thus a gameplay of map simplification and re-centering. It involves deliberately removing components (and their associated needs and users) that create strategic drag or distract from the core strategic purpose. This allows the remaining components on the map to be more effectively understood, managed, and evolved. It is a strategic "pruning" that enables faster evolution and innovation of core capabilities by eliminating the inertia or resource drain of unrelated or underperforming parts.
+
+This makes Strategic Divestment a powerful gameplay for achieving clarity and accelerating progress on a map that has become overly complex or diversified.
+
+## 🏷️ **Real-World Examples**
 
 ### IBM’s PC Division Sale to Lenovo (2005)
 IBM sold its commoditized PC division to Lenovo to shed a low-margin business and focus on services and software, enabling it
@@ -37,15 +53,29 @@ to reallocate resources to higher-growth areas.
 
 ### Kodak’s Film Business (1990s)
 Kodak struggled to divest its legacy film operations in time, highlighting how delayed disposal can lead to missed
-opportunities and decline.
+opportunities and decline. This is a classic example of the perils of not disposing of a liability when market conditions change.
 
-### Telecom Copper Network Decommissioning (Hypothetical)
-A telecom operator divests its legacy copper infrastructure to a specialized firm, reducing maintenance costs and allowing
-investment in broadband and wireless networks.
+### General Electric’s Divestiture of GE Capital (2015)
+General Electric significantly divested parts of its financial services division, GE Capital, aiming to refocus the conglomerate on its core industrial operations and reduce the risks associated with its large financial arm. This move was intended to simplify the company and unlock value.
+
+### PayPal’s Spin-off from eBay (2015)
+eBay spun off PayPal, allowing both companies to pursue distinct growth trajectories tailored to their specific markets. PayPal, as an independent entity, could focus on expanding its payment services globally, while eBay could concentrate on its core e-commerce marketplace. This separation was aimed at unlocking greater value for both businesses.
+
+### Baxter International’s Spin-off of Baxalta (2015)
+Baxter International spun off its biopharmaceuticals business into a new company, Baxalta Incorporated. This allowed Baxter to focus on its medical products business, while Baxalta could concentrate on developing and marketing biopharmaceuticals, leading to more focused investment and strategic clarity for both.
+
+### Bristol-Myers Squibb’s Split-off of Mead Johnson (2009)
+Bristol-Myers Squibb executed a split-off of its holdings in Mead Johnson Nutrition. This allowed BMS shareholders to exchange their BMS shares for shares in Mead Johnson, enabling BMS to divest its nutrition business and focus on its core biopharmaceutical strategy.
+
+### Carve-out (Illustrative Example)
+A parent company might conduct a carve-out by selling a minority stake (e.g., 20%) of a subsidiary through an Initial Public Offering (IPO). This raises capital for the parent or the subsidiary, establishes a public market valuation for the subsidiary's stock, and can be a precursor to a full spin-off. It allows the parent to retain control while still unlocking some value and strategic flexibility.
+
+### Telecom Copper Network Decommissioning (Hypothetical - Disposal Focus)
+A telecom operator divests or decommissions its legacy copper infrastructure, which is costly to maintain and becoming obsolete. This allows the company to reduce operational drag and focus investment on modern fiber optic and wireless networks. This can be managed by selling to a specialized firm or through a phased shutdown.
 
 ## 🚦 **When to Use / When to Avoid**
 
-<Assessment strategyName="Disposal of Liability">
+<Assessment strategyName="Strategic Divestment and Disposal of Liability">
   <MapSignals>
     <li>Our map shows key components stuck in a mature or commodity stage.</li>
     <li>Maintaining these components ties up significant resources.</li>
@@ -60,11 +90,24 @@ investment in broadband and wireless networks.
   </Readiness>
 </Assessment>
 
-**Use when:** A part of your value chain is mature or commoditized, draining resources, and the cost of maintaining it
-utweighs the benefits, and you have leadership support for disposal.
+**Use when:**
+- A part of your value chain is mature or commoditized, draining resources, and the cost of maintaining it outweighs the benefits (classic disposal of liability).
+- There's an opportunity to unlock significant shareholder value by separating a business unit, allowing it to pursue a more focused strategy (strategic divestment).
+- The parent company needs to streamline operations, reduce debt, or sharpen its focus on core, high-growth areas.
+- A business unit, while potentially viable, is strategically misaligned with the parent company's long-term vision or capabilities.
+- You have leadership support for the divestment or disposal and a clear plan for managing the transition for all stakeholders.
 
-**Avoid when:** The asset still generates critical revenue that funds your strategic initiatives, or you lack the authority or
-stakeholder alignment to execute a disposal plan.
+**Avoid when:**
+- The asset or business unit is still critical to your core strategy and value proposition, or generates essential revenue/cash flow that funds strategic initiatives, and alternatives are not viable.
+- You lack the authority, resources, stakeholder alignment, or a clear execution plan for such a complex undertaking.
+- The short-term disruption, costs (financial, operational, reputational), or loss of capabilities from divestment significantly outweigh the anticipated long-term strategic benefits.
+- The separated entity would not be viable on its own, or the divestment would critically weaken the parent company's remaining operations or market position.
+- Market conditions are unfavorable for achieving a fair value for the divested asset or entity.
+
+## ⚠️ **Distinction from Doctrines and Climate**
+Strategic Divestment (including disposal of liability) is a highly complex, high-impact decision, not a routine or universally applicable best practice (i.e., not a doctrine). It involves intricate legal, financial, and governance considerations, and is certainly not "nearly always a good idea." It is a specific, strategic choice made under particular circumstances, requiring extensive due diligence and alignment with the company's long-term strategic goals.
+
+While external market dynamics, competitive pressures, or shifts in the broader economic climate might influence the decision to divest, the act of divesting itself is a deliberate, internal strategic action taken by the organization. It is a proactive response to, or an anticipation of, climate patterns, rather than an inherent part of the external climate itself.
 
 ## 🎯 **Leadership**
 
@@ -82,21 +125,31 @@ employees and customers may be attached to.
 Ensure that disposal does not abandon stakeholders, such as employees, customers, or communities. Plan for fair treatment,
 severance, or transition support.
 
-## 📋 **How to Execute**
+## 📋 **How to Execute Strategic Divestment or Disposal**
 
-1. Map and identify liabilities in your value chain.
-2. Evaluate cost, risk, and strategic fit of each component.
-3. Develop a disposal plan (divestiture, shutdown, or sale).
-4. Secure leadership buy-in and align stakeholders.
-5. Execute the disposal steps with clear communication.
-6. Manage transition and monitor outcomes.
+1. **Identify Candidates:** Map your value chain. Identify components that are liabilities (obsolete, draining resources) or candidates for strategic divestment (non-core, potential for standalone growth, misaligned).
+2. **Evaluate Strategic Fit & Financial Impact:** Assess each candidate's current and future strategic importance, financial contribution (or drain), risks, and potential value if divested/spun-off. Consider market conditions for such a move.
+3. **Develop a Detailed Plan:** Formulate a specific plan for each candidate:
+    - **Divestment Type:** (e.g., spin-off, carve-out, sale to private equity, sale to a strategic buyer).
+    - **Disposal Method:** (e.g., shutdown, asset sale).
+    - Include operational, legal, financial, communication, and employee transition plans.
+4. **Secure Leadership Buy-in & Stakeholder Alignment:** Present a clear business case. Gain approval from the board and senior leadership. Develop a strategy for communicating with and managing impacts on employees, customers, investors, and other stakeholders.
+5. **Execute the Plan:** Implement the divestment or disposal. This may involve legal restructuring, asset transfers, regulatory approvals, and extensive communication.
+6. **Manage Transition & Monitor Outcomes:** Carefully manage the separation process or shutdown. For divestments, monitor the performance of the new entity and the parent company post-transaction. For disposals, ensure all obligations are met and resources are effectively reallocated.
 
 ## 📈 **Measuring Success**
 
-- Reduction in maintenance and operational costs.
-- Resources reallocated to strategic initiatives.
-- Percentage of legacy components successfully removed.
-- Improvement in organizational agility and focus.
+- **For Disposal of Liability:**
+    - Reduction in maintenance and operational costs associated with the disposed asset.
+    - Resources (financial, human, managerial attention) successfully reallocated to strategic initiatives.
+    - Percentage of targeted legacy or burdensome components successfully removed or divested.
+    - Improvement in organizational agility and streamlined focus.
+- **For Strategic Divestment (Spin-offs, Carve-outs, Sales):**
+    - Achievement of targeted financial goals (e.g., sale price, debt reduction, capital raised).
+    - Positive market reaction (e.g., share price performance of parent and/or new entity).
+    - Successful operational separation and standalone performance of the divested/new entity.
+    - Enhanced strategic clarity and focus for both the parent company and the divested entity.
+    - Long-term value creation for shareholders (e.g., increased total shareholder return from parent and spun-off entity combined, compared to pre-divestment).
 
 ## ⚠️ **Common Pitfalls and Warning Signs**
 
@@ -114,22 +167,41 @@ Removing a component too quickly may deprive the organization of essential skill
 
 ## 🧠 **Strategic Insights**
 
-### Evolution acceleration
-Removing outdated components accelerates organizational evolution by clearing bottlenecks.
+### Enhanced Strategic Focus & Re-centering
+Strategic divestments and disposals are powerful tools for clarifying an organization's strategy. By shedding non-core, underperforming, or distracting assets, leadership can redirect attention, capital, and resources toward core, high-growth areas. This re-centers the organization on its primary value proposition.
 
-### Organizational focus
-Disposal clarifies strategy, directing attention and investment toward future-facing initiatives.
+### Evolution Acceleration & Map Simplification
+Removing outdated or misaligned components (and their associated value chains from your Wardley Map) acts as a strategic pruning. This simplifies the map, reduces "strategic drag," and can significantly accelerate the organization's overall evolution by clearing bottlenecks and eliminating the inertia or resource drain of unrelated parts. A leaner map allows for more effective management and faster innovation of core capabilities.
 
-### Risk concentration
-While disposal reduces systemic drag, it can concentrate risk if overused or poorly planned.
+### Value Unlocking
+Separating a business unit (e.g., via spin-off or carve-out) can unlock significant shareholder value. The divested entity may thrive with dedicated focus and resources, while the parent company benefits from a streamlined structure and potentially a higher valuation based on its more focused core business. This can create two more valuable entities from one.
+
+### Resource Reallocation
+Freeing up capital, talent, and management bandwidth from maintaining or propping up liabilities or non-core units allows these resources to be invested in innovation, growth initiatives, or strengthening core competencies.
+
+### Risk Mitigation & Management
+Disposing of liabilities can reduce financial, operational, or reputational risks. Strategic divestments can also be used to manage risk by separating a volatile or highly regulated business from a more stable core. However, the process of divestment itself carries execution risks.
+
+### Market Perception
+Well-executed divestments can positively influence market perception, signaling strong leadership, strategic clarity, and a commitment to shareholder value. Conversely, poorly managed disposals or "fire sales" can damage reputation.
 
 ## ❓ **Key Questions to Ask**
 
-- What assets are dragging our evolution?
-- Where are we investing resources to maintain obsolete components?
-- Who will be affected by disposal and how will we support them?
-- Do we have authority and resources to execute the disposal?
-- What is the timeline and criteria for success?
+- **Identifying Candidates:**
+    - What existing assets, business units, or components are dragging our evolution, consuming disproportionate resources, or no longer align with our core strategy? (Disposal focus)
+    - Are there parts of our business that, if separated, could achieve greater focus, growth, or market valuation as independent entities? (Strategic divestment focus)
+    - Which components on our Wardley Map are creating strategic drag, are overly complex, or distract from our core purpose?
+- **Strategic Rationale:**
+    - What are the primary strategic goals for this divestment/disposal (e.g., enhance focus, reduce debt, unlock value, streamline operations)?
+    - How will this move strengthen the parent company's strategic position and/or enable the success of the divested entity?
+- **Execution & Impact:**
+    - Who will be affected by this decision (employees, customers, partners, investors), and how will we manage the transition and mitigate negative impacts?
+    - Do we have the internal capabilities, leadership commitment, and resources to execute this complex process successfully?
+    - What are the potential risks (financial, operational, legal, reputational) and how will they be managed?
+    - What is the optimal structure for the divestment (e.g., spin-off, carve-out, sale) to achieve our goals?
+- **Post-Transaction:**
+    - What are the key criteria for success for both the parent company and the divested entity (if applicable)?
+    - How will we ensure the parent company effectively reallocates resources and refocuses its strategy post-divestment?
 
 ## 🔀 **Related Strategies**
 


### PR DESCRIPTION
…rategy

- Renamed 'Disposal of Liability' to 'Strategic Divestment and Disposal of Liability'.
- Expanded definitions, rationale, and examples to include spin-offs, carve-outs, and other strategic divestment activities alongside disposal of burdensome assets.
- Added a detailed section on 'Manifestation on a Wardley Map' explaining how divestment impacts map structures and strategy.
- Introduced a new section 'Distinction from Doctrines and Climate' to clarify the strategic nature of divestment.
- Enhanced sections on 'How to Execute', 'Measuring Success', 'Strategic Insights', and 'Key Questions to Ask' to reflect the broader scope.
- Updated frontmatter (title, description, tags) and Assessment Tool component.
- Ensured changes align with CONTRIBUTING.md guidelines.