### PR TITLE
Fix: Reorder strategy sections per CONTRIBUTING.md

### DIFF
--- a/docs/strategies/competitor/misdirection/index.md
+++ b/docs/strategies/competitor/misdirection/index.md
@@ -30,6 +30,14 @@ Misdirection is valuable because it allows a company to:
 
 Misdirection works by exploiting the fact that competitors monitor each other closely. By carefully controlling the signals you send (public statements, investment hints, product announcements), you can influence what your rivals *think* you are doing. This can cause them to move in ways that leave them vulnerable or give you an advantage. It requires a deep understanding of what information your competitors monitor and how they interpret it.
 
+## 🗺️ **Real-World Examples**
+
+-   **Pre-Announcements and Vaporware:** Announcing a product that is not yet ready (vaporware) can deter competitors or influence customer expectations. IBM's announcement of the System/360 Model 91 after a competitor's launch caused a drop in the competitor's sales, even though IBM's product was not available for two years. Microsoft has also been accused of using early announcements to hinder competitors.
+
+-   **False Investment Signals:** Companies may signal heavy investment in a technology or market that is not their true focus, hoping competitors will follow and waste resources. The misdirecting company can then focus on its real innovation while rivals chase a false lead.
+
+-   **Public Statements & Strategic Messaging:** Leaders can use public statements and marketing to misdirect. For example, a CEO might downplay interest in a market to lull competitors into complacency, then later enter that market. Apple kept its iPhone plans secret, so competitors were not fully prepared for its debut. Startups might emphasize a less important feature to keep competitors from noticing their real asset.
+
 ## 🚦 **When to Use / When to Avoid**
 
 <Assessment strategyName="Misdirection">
@@ -59,14 +67,6 @@ Misdirection is most useful when you have a significant move planned that could 
 ### Avoid when
 
 Misdirection should be used sparingly because overuse or discovery can damage a company's credibility. Competitors may begin to distrust all communications, which can be harmful when genuine communication is needed. Misdirection can also mislead external stakeholders like investors or customers, causing confusion or distrust.
-
-## 🗺️ **Real-World Examples**
-
--   **Pre-Announcements and Vaporware:** Announcing a product that is not yet ready (vaporware) can deter competitors or influence customer expectations. IBM's announcement of the System/360 Model 91 after a competitor's launch caused a drop in the competitor's sales, even though IBM's product was not available for two years. Microsoft has also been accused of using early announcements to hinder competitors.
-
--   **False Investment Signals:** Companies may signal heavy investment in a technology or market that is not their true focus, hoping competitors will follow and waste resources. The misdirecting company can then focus on its real innovation while rivals chase a false lead.
-
--   **Public Statements & Strategic Messaging:** Leaders can use public statements and marketing to misdirect. For example, a CEO might downplay interest in a market to lull competitors into complacency, then later enter that market. Apple kept its iPhone plans secret, so competitors were not fully prepared for its debut. Startups might emphasize a less important feature to keep competitors from noticing their real asset.
 
 ## 🎯 **Leadership**
 

--- a/docs/strategies/competitor/reinforcing-competitor-inertia/index.md
+++ b/docs/strategies/competitor/reinforcing-competitor-inertia/index.md
@@ -29,6 +29,12 @@ This strategy is valuable because it turns a competitor's strength (past success
 
 The core idea is to introduce changes that the competitor is likely to resist. This could involve new technologies, business models, or market approaches. By consistently applying pressure and highlighting the competitor's inaction, you can reinforce their inertia and widen the gap between your organization and theirs. This strategy requires keen observation, a deep understanding of the competitor's weaknesses, and the ability to anticipate their reactions.
 
+## 🗺️ **Real-World Examples**
+
+-   **Kodak and Digital Photography:** Kodak long dominated film photography and was very slow to embrace digital cameras (fearing cannibalization of its film business). Competitors like Sony and Canon exploited this inertia by aggressively advancing digital camera technology and capturing the consumer market. Kodak's leadership, wedded to film, responded by doubling down on film's profitability and only timidly engaging with digital. They effectively reinforced Kodak's inertia by continuing to innovate in digital, which made Kodak cling even more desperately to its fading film sales. Kodak's fear of change ("protect the film business at all costs") was reinforced by the market shift; it kept them stuck until it was too late. In 2012, Kodak filed for bankruptcy, having been unable to overcome its own inertia. Competitors had forced the issue by pushing the new technology that Kodak resisted.
+-   **Blockbuster vs. Netflix:** Blockbuster had huge inertia with its physical video rental stores and the lucrative late-fees model. When Netflix introduced subscription DVD-by-mail (and later streaming), Blockbuster initially responded by emphasizing their stores and downplaying the mail/online trend. Netflix's move forced Blockbuster to confront a model that undercut late fees, but Blockbuster's inertia was strong; they relied on late fees which brought in $800M in revenue in 2000. Even when Blockbuster tried a no-late-fee campaign, it was half-hearted and they stuck to their retail presence. By pushing the subscription model, Netflix reinforced Blockbuster's commitment to its old revenue streams (Blockbuster executives infamously laughed off an offer to buy Netflix in 2000, not adapting in time). That inertia gave Netflix years to grow unopposed in the new model, and Blockbuster's eventual attempts to catch up were too late.
+-   **Smartphone Industry Keyboard vs. Touchscreen:** Research In Motion (BlackBerry) was extremely successful with its physical-keyboard smartphones and had internal inertia believing that business customers needed physical keys. When Apple introduced the iPhone with a full touchscreen, BlackBerry initially responded by sticking to its keyboard-centric designs (even as consumers and then enterprises started shifting preferences). Apple's move to touch interfaces, and later Android following, forced BlackBerry into an inertial trap: they hesitated to make a truly competitive touchscreen device for too long, worried about alienating their existing user base and undermining their secure email niche. By the time they did (the BlackBerry Storm and others), Apple and Android had taken over. In this case, Apple didn't intend to reinforce BlackBerry's inertia per se, but Apple's strategy had that effect; it leveraged BlackBerry's inability to pivot quickly away from their legacy strength, thus sealing BlackBerry's decline.
+
 ## 🚦 **When to Use / When to Avoid**
 
 <Assessment strategyName="Reinforcing Competitor Inertia">
@@ -65,12 +71,6 @@ This strategy is most effective when a competitor exhibits clear resistance to c
 -   The competitor is agile and adaptable
 -   The market is stable and not undergoing significant change
 -   Your organization is also vulnerable to the same inertia
-
-## 🗺️ **Real-World Examples**
-
--   **Kodak and Digital Photography:** Kodak long dominated film photography and was very slow to embrace digital cameras (fearing cannibalization of its film business). Competitors like Sony and Canon exploited this inertia by aggressively advancing digital camera technology and capturing the consumer market. Kodak's leadership, wedded to film, responded by doubling down on film's profitability and only timidly engaging with digital. They effectively reinforced Kodak's inertia by continuing to innovate in digital, which made Kodak cling even more desperately to its fading film sales. Kodak's fear of change ("protect the film business at all costs") was reinforced by the market shift; it kept them stuck until it was too late. In 2012, Kodak filed for bankruptcy, having been unable to overcome its own inertia. Competitors had forced the issue by pushing the new technology that Kodak resisted.
--   **Blockbuster vs. Netflix:** Blockbuster had huge inertia with its physical video rental stores and the lucrative late-fees model. When Netflix introduced subscription DVD-by-mail (and later streaming), Blockbuster initially responded by emphasizing their stores and downplaying the mail/online trend. Netflix's move forced Blockbuster to confront a model that undercut late fees, but Blockbuster's inertia was strong; they relied on late fees which brought in $800M in revenue in 2000. Even when Blockbuster tried a no-late-fee campaign, it was half-hearted and they stuck to their retail presence. By pushing the subscription model, Netflix reinforced Blockbuster's commitment to its old revenue streams (Blockbuster executives infamously laughed off an offer to buy Netflix in 2000, not adapting in time). That inertia gave Netflix years to grow unopposed in the new model, and Blockbuster's eventual attempts to catch up were too late.
--   **Smartphone Industry Keyboard vs. Touchscreen:** Research In Motion (BlackBerry) was extremely successful with its physical-keyboard smartphones and had internal inertia believing that business customers needed physical keys. When Apple introduced the iPhone with a full touchscreen, BlackBerry initially responded by sticking to its keyboard-centric designs (even as consumers and then enterprises started shifting preferences). Apple's move to touch interfaces, and later Android following, forced BlackBerry into an inertial trap: they hesitated to make a truly competitive touchscreen device for too long, worried about alienating their existing user base and undermining their secure email niche. By the time they did (the BlackBerry Storm and others), Apple and Android had taken over. In this case, Apple didn't intend to reinforce BlackBerry's inertia per se, but Apple's strategy had that effect; it leveraged BlackBerry's inability to pivot quickly away from their legacy strength, thus sealing BlackBerry's decline.
 
 ## 🎯 **Leadership**
 
@@ -134,15 +134,15 @@ Reinforcing someone else's inertia often requires that the new paradigm you push
 -   [**Tech Drops**](/strategies/competitor/tech-drops): Can be used to capitalize on a competitor's inertia by launching a sudden, unexpected attack when they are least prepared.
 
 - [misdirection](/strategies/competitor/misdirection) - employing deceptive signals or decoys to deepen a competitor's complacency and reinforce their resistance to change.
-## 📚 **Further Reading & References**
-
--   Clayton Christensen, *The Innovator's Dilemma*
-- [The Rise and Fall of Kodak: How an Industry Giant Missed the Digital Revolution - Unlimited Graphic Design Service](https://penji.co/the-rise-and-fall-of-kodak/) (Kodak's focus on traditional film, despite the rise of digital, demonstrates reinforcing their own inertia.)
-- [Lessons from the Rise of Netflix and the Fall of Blockbuster | Cato Institute](https://www.cato.org/commentary/lessons-rise-netflix-fall-blockbuster) (Blockbuster's continued focus on physical stores, while Netflix innovated, is another example.)
-
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) - rel: this pattern is the foundation that this strategy seeks to exploit.
 - [Inertia can kill an organisation](/climatic-patterns/inertia-can-kill-an-organisation) - rel: this strategy accelerates the negative consequences of a competitor's inertia.
 - [Everything evolves](/climatic-patterns/everything-evolves) - rel: understanding that change is constant is key to recognizing when a competitor is failing to adapt, creating an opportunity for this strategy.
 - [Competitors actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) - rel: this strategy is a proactive way to change the game by leveraging a competitor's inertia.
+
+## 📚 **Further Reading & References**
+
+-   Clayton Christensen, *The Innovator's Dilemma*
+- [The Rise and Fall of Kodak: How an Industry Giant Missed the Digital Revolution - Unlimited Graphic Design Service](https://penji.co/the-rise-and-fall-of-kodak/) (Kodak's focus on traditional film, despite the rise of digital, demonstrates reinforcing their own inertia.)
+- [Lessons from the Rise of Netflix and the Fall of Blockbuster | Cato Institute](https://www.cato.org/commentary/lessons-rise-netflix-fall-blockbuster) (Blockbuster's continued focus on physical stores, while Netflix innovated, is another example.)

--- a/docs/strategies/competitor/restriction-of-movement/index.md
+++ b/docs/strategies/competitor/restriction-of-movement/index.md
@@ -25,6 +25,14 @@ This strategy doesn't necessarily eliminate a competitor but restricts their gro
 
 By strategically controlling key aspects of the market, a business can limit a competitor's ability to grow or adapt. This can involve securing exclusive deals, establishing dominant standards, or creating patent thickets. The effect is to limit the competitor's options, forcing them into a constrained position.
 
+## 🗺️ **Real-World Examples**
+
+-   **Facebook "Circling" Snapchat:** Facebook copied Snapchat's core features across its apps after failing to acquire Snapchat. Instagram Stories, WhatsApp Status, and Facebook Stories effectively encircled Snapchat's niche. This limited Snapchat's growth by restricting its room to maneuver.
+
+-   **Exclusive Deals and Ecosystem Control:** Apple's App Store policies restrict competitors on its platform by prohibiting alternative app stores and certain third-party functionalities. Microsoft's exclusive licensing deals with PC manufacturers in the 1990s limited rival operating systems' distribution.
+
+-   **Patent Fencing:** Companies create "patent thickets" by patenting a broad array of technologies, not just core inventions. This restricts competitors' innovation paths, as seen in the smartphone patent wars.
+
 ## 🚦 **When to Use / When to Avoid**
 
 <Assessment strategyName="Restriction of Movement">
@@ -55,14 +63,6 @@ Leadership should use this strategy when they want to holistically control the c
 ### Avoid when
 
 Leaders should be cautious of harming industry relationships or attracting regulatory scrutiny.
-
-## 🗺️ **Real-World Examples**
-
--   **Facebook "Circling" Snapchat:** Facebook copied Snapchat's core features across its apps after failing to acquire Snapchat. Instagram Stories, WhatsApp Status, and Facebook Stories effectively encircled Snapchat's niche. This limited Snapchat's growth by restricting its room to maneuver.
-
--   **Exclusive Deals and Ecosystem Control:** Apple's App Store policies restrict competitors on its platform by prohibiting alternative app stores and certain third-party functionalities. Microsoft's exclusive licensing deals with PC manufacturers in the 1990s limited rival operating systems' distribution.
-
--   **Patent Fencing:** Companies create "patent thickets" by patenting a broad array of technologies, not just core inventions. This restricts competitors' innovation paths, as seen in the smartphone patent wars.
 
 ## 🎯 **Leadership**
 

--- a/docs/strategies/competitor/sapping/index.md
+++ b/docs/strategies/competitor/sapping/index.md
@@ -2,13 +2,11 @@
 tags: [sapping, competitor, multi-front, attrition, endurance, resource drain, distraction]
 ---
 
-**Attacking a competitor on multiple fronts simultaneously to weaken their capacity to respond**.
+**Attacking a competitor on multiple fronts simultaneously to weaken their capacity to respond.**
 
 > *"Opening up multiple fronts on a competitor to weaken their ability to react."*
 >
 > - Simon Wardley
-
-Sapping, inspired by military tactics, involves launching simultaneous attacks across various fronts (product, price, marketing, geography) to stretch a competitor's resources and attention. The core idea is that a competitor capable of defending against a single attack will struggle against a barrage of concurrent challenges. By forcing a rival to divide their focus and resources, their overall effectiveness is degraded. Sapping is a strategy of attrition and distraction, aiming to drain the competitor's energy and induce mistakes or neglect.
 
 ## 🤔 **Explanation**
 
@@ -23,6 +21,14 @@ Sapping works by exploiting the limitations of a competitor's resources and atte
 ### When is sapping most effective?
 
 Sapping is most effective when the attacker has superior resources or agility compared to the competitor. It is often used by larger or more diversified companies against narrower ones. The goal is to create a situation where the competitor cannot cope with the volume of challenges.
+
+## 🗺️ **Real-World Examples**
+
+-   **Microsoft in the 1990s (Multi-Front Attack):** Microsoft competed on many fronts in the mid-1990s, including browsers (vs. Netscape), programming platforms (Java vs. Windows APIs), personal devices (vs. Sony/Palm), and enterprise software (vs. IBM/Novell). Microsoft's resources allowed it to link its attacks, such as Windows + Office integration against Netscape and Lotus/WordPerfect. An antitrust finding noted Microsoft's campaign against "middleware threats" like Netscape and Java, which "raised its rivals' costs, and ultimately, effectively eliminated Netscape as a platform threat" while weakening Sun's Java momentum. By opening simultaneous battles (browser, middleware, applications), Microsoft sapped competitors' abilities to mount a unified response.
+
+-   **Facebook vs. Emerging Social Apps:** Facebook's attack on Snapchat involved multiple fronts, including copying Stories (feature front), leveraging its global reach (geographic front), and using its ad targeting power (business front). This sapping strategy strained Snap, a smaller company, leading to impacts on Snapchat's growth and market cap. Facebook's multi-faceted approach targeted Snap from various angles.
+
+-   **Amazon vs. Retail Competitors:** Amazon often uses multi-front competition. Against traditional retailers like Target and Walmart in the mid-2000s, Amazon attacked through online sales in various product categories (general merchandise front), Amazon Prime with fast shipping (logistics/membership front), undercutting prices (pricing front), expanding into digital goods (new technology front), and entering cloud computing. Retailers faced challenges needing to invest in e-commerce tech, lower prices, improve supply chains, and consider new business lines simultaneously. This sapping strategy impacted many retailers, with survivors like Walmart also becoming multifaceted.
 
 ## 🚦 **When to Use / When to Avoid**
 
@@ -54,14 +60,6 @@ Use sapping when you have superior resources or agility and can fight on many fr
 ### Avoid When
 
 Avoid sapping if you lack the resources or agility to sustain a multi-front attack. It is also risky if the competitor has the capacity to counter-attack effectively or if the costs of the strategy outweigh the potential gains.
-
-## 🗺️ **Real-World Examples**
-
--   **Microsoft in the 1990s (Multi-Front Attack):** Microsoft competed on many fronts in the mid-1990s, including browsers (vs. Netscape), programming platforms (Java vs. Windows APIs), personal devices (vs. Sony/Palm), and enterprise software (vs. IBM/Novell). Microsoft's resources allowed it to link its attacks, such as Windows + Office integration against Netscape and Lotus/WordPerfect. An antitrust finding noted Microsoft's campaign against "middleware threats" like Netscape and Java, which "raised its rivals' costs, and ultimately, effectively eliminated Netscape as a platform threat" while weakening Sun's Java momentum. By opening simultaneous battles (browser, middleware, applications), Microsoft sapped competitors' abilities to mount a unified response.
-
--   **Facebook vs. Emerging Social Apps:** Facebook's attack on Snapchat involved multiple fronts, including copying Stories (feature front), leveraging its global reach (geographic front), and using its ad targeting power (business front). This sapping strategy strained Snap, a smaller company, leading to impacts on Snapchat's growth and market cap. Facebook's multi-faceted approach targeted Snap from various angles.
-
--   **Amazon vs. Retail Competitors:** Amazon often uses multi-front competition. Against traditional retailers like Target and Walmart in the mid-2000s, Amazon attacked through online sales in various product categories (general merchandise front), Amazon Prime with fast shipping (logistics/membership front), undercutting prices (pricing front), expanding into digital goods (new technology front), and entering cloud computing. Retailers faced challenges needing to invest in e-commerce tech, lower prices, improve supply chains, and consider new business lines simultaneously. This sapping strategy impacted many retailers, with survivors like Walmart also becoming multifaceted.
 
 ## 🎯 **Leadership**
 
@@ -140,10 +138,6 @@ Sapping should lead to the competitor's collapse in one area or their retreat fr
 -   [**Circling and Probing**](/strategies/competitor/circling-and-probing): Circling and probing can be used to identify weaknesses in a competitor before launching a sapping attack.
 
 - [Ambush](/strategies/competitor/ambush) - coordinating stealth erosion tactics with surprise strikes to overwhelm competitors on multiple fronts.
-## 📚 **Further Reading & References**
-
--   Clayton Christensen - "The Innovator's Dilemma" (for examples of multi-front competition and disruption).
-
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: The competitor's strengths and weaknesses will change over time, creating new sapping opportunities.
@@ -151,3 +145,7 @@ Sapping should lead to the competitor's collapse in one area or their retreat fr
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: A competitor's past success can make them slow to react to sapping efforts.
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Identifying and exploiting a competitor's inefficiencies is a key aspect of sapping.
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: Sapping is a direct action to change the game by weakening a competitor.
+
+## 📚 **Further Reading & References**
+
+-   Clayton Christensen - "The Innovator's Dilemma" (for examples of multi-front competition and disruption).

--- a/docs/strategies/competitor/talent-raid/index.md
+++ b/docs/strategies/competitor/talent-raid/index.md
@@ -4,13 +4,11 @@ description: Removing or absorbing key talent from a rival organisation.
 tags: [talent-raid, competitor, talent, human resources, acquisition, poaching, expertise, weakening rivals]
 ---
 
-**Removing or absorbing key talent from a rival organization**.
+**Removing or absorbing key talent from a rival organization.**
 
 > *"Removing core talent from a competitor either directly or indirectly."*
 >
 > - Simon Wardley
-
-A Talent Raid is a competitive strategy focused on removing or absorbing key talent from a rival organisation. By taking away a competitor's critical human resources — their experts, leaders, engineers or creative minds — you simultaneously strengthen your own company and weaken theirs. This can be done directly by hiring employees away or indirectly by enticing them through acquisitions or partnerships. Talent is often the lifeblood of tech and creative industries; a well‑timed raid can disrupt projects, slow innovation or deprive a competitor of strategic direction. In essence, a talent raid treats top employees as a scarce competitive asset and seeks to control that asset.
 
 ## 🤔 **Explanation**
 
@@ -30,6 +28,12 @@ A talent raid is valuable because it directly impacts a competitor's ability to 
 ### How?
 
 Talent Raid can be executed directly by hiring away a competitor's employees or indirectly through acquisitions or partnerships that bring talent in-house. It involves identifying key talent or teams within a competitor's organization, assessing their value, and then enticing them to join your organization. This often requires offering better compensation, career opportunities, or a more appealing work environment.
+
+## 🗺️ **Real-World Examples**
+
+* **Apple and Tesla:** Apple and Tesla have notoriously traded talent, each looking to bolster their teams for electric cars and related technologies. In 2015, Tesla's CEO Elon Musk quipped that Apple was the "Tesla Graveyard" -- "If you don't make it at Tesla, you go work at Apple", in response to Apple hiring many ex-Tesla engineers. By 2018, Apple had poached at least 46 employees from Tesla in a single year, including key engineers for its secretive car project. This talent raid by Apple aimed to boost its own automotive initiative while undermining Tesla's. Losing dozens of experienced staff (some of whom had deep knowledge of Tesla's battery, software, and Autopilot systems) could slow Tesla's development and force them into a continuous recruitment and training mode. Conversely, Tesla has also raided Apple for talent in areas like user interface and chip design, hiring over 150 former Apple employees at one point. These raids indicate both companies see each other's talent as prime targets in the competition for electric and autonomous vehicle leadership.
+* **Google's Acqui-hiring:** Google has a history of "acqui-hiring" -- acquiring startups primarily to get their engineers and designers. For example, Google acquired a small team working on a mobile email app (SlideMail) not just for the product, but to bring the talented developers in-house (indirectly removing talent that could have been employed by competitors). Another case: when Google bought DeepMind in 2014, it wasn't just acquiring technology, but also scooping up some of the world's leading AI researchers, thereby denying that talent to competitors like Facebook or Microsoft. This is an indirect talent raid via acquisition, which gave Google a leap in AI capability and left others to either try to poach from Google or find talent elsewhere.
+* **Finance and Big Law Talent Moves:** In sectors like investment banking or law firms, it's common for a firm to lure star performers (a rainmaking banker or a celebrated trial lawyer) from a competitor with huge compensation packages. The reasoning is the same: that individual brings over clients or deals and leaves the former employer weakened (perhaps clients follow the person, or the competitor loses a unique skill set). For instance, when a top trading team or portfolio manager exits a hedge fund to join another, it's effectively a talent raid that can shake the original firm (investors might withdraw funds in that manager's absence).
 
 ## 🚦 **When to Use / When to Avoid**
 
@@ -63,12 +67,6 @@ Talent Raid is most effective when key talent or teams within a competitor's org
 * The poached talent may not fit or perform well in the new environment.
 * The cost of acquiring the talent outweighs the potential benefits.
 * A blatant raid can sour relationships when you still need to cooperate with that competitor in other areas.
-
-## 🗺️ **Real-World Examples**
-
-* **Apple and Tesla:** Apple and Tesla have notoriously traded talent, each looking to bolster their teams for electric cars and related technologies. In 2015, Tesla's CEO Elon Musk quipped that Apple was the "Tesla Graveyard" -- "If you don't make it at Tesla, you go work at Apple", in response to Apple hiring many ex-Tesla engineers. By 2018, Apple had poached at least 46 employees from Tesla in a single year, including key engineers for its secretive car project. This talent raid by Apple aimed to boost its own automotive initiative while undermining Tesla's. Losing dozens of experienced staff (some of whom had deep knowledge of Tesla's battery, software, and Autopilot systems) could slow Tesla's development and force them into a continuous recruitment and training mode. Conversely, Tesla has also raided Apple for talent in areas like user interface and chip design, hiring over 150 former Apple employees at one point. These raids indicate both companies see each other's talent as prime targets in the competition for electric and autonomous vehicle leadership.
-* **Google's Acqui-hiring:** Google has a history of "acqui-hiring" -- acquiring startups primarily to get their engineers and designers. For example, Google acquired a small team working on a mobile email app (SlideMail) not just for the product, but to bring the talented developers in-house (indirectly removing talent that could have been employed by competitors). Another case: when Google bought DeepMind in 2014, it wasn't just acquiring technology, but also scooping up some of the world's leading AI researchers, thereby denying that talent to competitors like Facebook or Microsoft. This is an indirect talent raid via acquisition, which gave Google a leap in AI capability and left others to either try to poach from Google or find talent elsewhere.
-* **Finance and Big Law Talent Moves:** In sectors like investment banking or law firms, it's common for a firm to lure star performers (a rainmaking banker or a celebrated trial lawyer) from a competitor with huge compensation packages. The reasoning is the same: that individual brings over clients or deals and leaves the former employer weakened (perhaps clients follow the person, or the competitor loses a unique skill set). For instance, when a top trading team or portfolio manager exits a hedge fund to join another, it's effectively a talent raid that can shake the original firm (investors might withdraw funds in that manager's absence).
 
 ## 🎯 **Leadership**
 

--- a/docs/strategies/competitor/tech-drops/index.md
+++ b/docs/strategies/competitor/tech-drops/index.md
@@ -24,6 +24,16 @@ Tech Drops allows an organization to proactively define the future trajectory of
 
 The strategy hinges on visionary innovation, rigorous development in secrecy, and flawless execution. A novel technological concept is typically incubated away from public view (e.g., in a dedicated R&D lab or "skunkworks" project) to ensure the element of surprise. Simultaneously, the organization prepares for mass adoption by ensuring scalability of infrastructure, marketing, and support services. The launch is a high-impact, coordinated event designed to maximize market awareness and demonstrate the clear superiority or novelty of the innovation. The goal is to make the new technology appear as a sudden breakthrough, fundamentally changing what customers expect from products or services in that category.
 
+## 🗺️ **Real-World Examples**
+
+### Apple's iPhone Launch (2007)
+
+The introduction of the iPhone is a masterclass in the Tech Drops strategy. While competitors like Nokia, BlackBerry, and Microsoft were focused on incremental improvements to physical keyboards and enterprise features, Apple secretly developed a device that combined a multi-touch screen, a full-featured web browser, and an iPod into a single product. The launch caught the entire industry by surprise, instantly making existing "smartphones" feel obsolete and forcing every competitor to abandon their roadmaps and start over.
+
+### AWS Lambda Launch (2014)
+
+At its re:Invent conference, AWS frequently uses Tech Drops tactics. The launch of AWS Lambda in 2014 is a prime example. While the industry was focused on virtual machines and containers, AWS introduced "serverless" computing, a completely new paradigm for building applications. This move created a new market category out of thin air, established AWS as the leader, and forced competitors like Google and Microsoft to spend years developing their own competing offerings (Google Cloud Functions and Azure Functions).
+
 ## 🚦 **When to Use / When to Avoid**
 
 <Assessment strategyName="Tech Drops">
@@ -41,16 +51,6 @@ The strategy hinges on visionary innovation, rigorous development in secrecy, an
     <li>The innovation is significant and defensible, not just an incremental feature.</li>
   </Readiness>
 </Assessment>
-
-## 🗺️ **Real-World Examples**
-
-### Apple's iPhone Launch (2007)
-
-The introduction of the iPhone is a masterclass in the Tech Drops strategy. While competitors like Nokia, BlackBerry, and Microsoft were focused on incremental improvements to physical keyboards and enterprise features, Apple secretly developed a device that combined a multi-touch screen, a full-featured web browser, and an iPod into a single product. The launch caught the entire industry by surprise, instantly making existing "smartphones" feel obsolete and forcing every competitor to abandon their roadmaps and start over.
-
-### AWS Lambda Launch (2014)
-
-At its re:Invent conference, AWS frequently uses Tech Drops tactics. The launch of AWS Lambda in 2014 is a prime example. While the industry was focused on virtual machines and containers, AWS introduced "serverless" computing, a completely new paradigm for building applications. This move created a new market category out of thin air, established AWS as the leader, and forced competitors like Google and Microsoft to spend years developing their own competing offerings (Google Cloud Functions and Azure Functions).
 
 ## 🎯 **Leadership**
 


### PR DESCRIPTION
Reordered sections in several competitor strategy documents to align with the standard format outlined in CONTRIBUTING.md.

Files affected:
- docs/strategies/competitor/misdirection/index.md
- docs/strategies/competitor/reinforcing-competitor-inertia/index.md
- docs/strategies/competitor/restriction-of-movement/index.md
- docs/strategies/competitor/sapping/index.md
- docs/strategies/competitor/talent-raid/index.md
- docs/strategies/competitor/tech-drops/index.md

Also made minor adjustments to the initial single-sentence descriptions in some files for conciseness, where they were overly long.