### PR TITLE
feat: Add DISABLE_FASTER_BUILD flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ npm run build
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
 
+**Note:** If you encounter issues with the faster build (e.g., on `android-arm64` environments), you can disable it by setting the `DISABLE_FASTER_BUILD` environment variable:
+
+```bash
+DISABLE_FASTER_BUILD=true npm run build
+```
+
 ### Deployment
 
 The `main` branch is deployed live with Vercel. This typically takes 1 or 2 minutes.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -12,9 +12,9 @@ const config: Config = {
 
   future: {
     experimental_faster: {
-      rspackBundler: true,
-      rspackPersistentCache: true,
-      ssgWorkerThreads: true,
+      rspackBundler: process.env.DISABLE_FASTER_BUILD !== 'true',
+      rspackPersistentCache: process.env.DISABLE_FASTER_BUILD !== 'true',
+      ssgWorkerThreads: process.env.DISABLE_FASTER_BUILD !== 'true',
     },
     v4: {
       removeLegacyPostBuildHeadAttribute: true,


### PR DESCRIPTION
This PR introduces a new environment variable, , to allow users to easily disable the experimental faster build features in Docusaurus. This is particularly useful for environments where  is not fully supported, such as Termux on  devices.