### PR TITLE
Fix: Correct H2 heading order in strategy documents

### DIFF
--- a/docs/strategies/competitor/fragmentation/index.md
+++ b/docs/strategies/competitor/fragmentation/index.md
@@ -83,6 +83,10 @@ Leading a fragmentation strategy requires strategic thinking and a deep understa
 
 -   Addressing ethical and reputational considerations, as fragmentation can be perceived as aggressive.
 
+## 📋 **How to Execute**
+
+*(Placeholder for content)*
+
 ## 📈 **Measuring Success**
 
 -   Market share changes: Track the competitor's loss of market share and the gain of market share by new entrants or competitors.

--- a/docs/strategies/dealing-with-toxicity/disposal-of-liability/index.md
+++ b/docs/strategies/dealing-with-toxicity/disposal-of-liability/index.md
@@ -33,7 +33,7 @@ Applying this strategy involves a careful assessment of your organization's port
 
 For detailed, actionable steps, refer to the [**How to Execute Strategic Divestment or Disposal**](#-how-to-execute-strategic-divestment-or-disposal) section.
 
-## 🗺️ **Manifestation on a Wardley Map**
+### Manifestation on a Wardley Map
 Strategic Divestment represents a profound "moving of pieces" as it literally removes or reconfigures entire segments of an organization's Wardley Map.
 
 - **Creation of New Maps:** A spun-off entity, for example, effectively creates a new, independent Wardley Map for its operations.
@@ -45,7 +45,7 @@ Strategic Divestment represents a profound "moving of pieces" as it literally re
 
 This makes Strategic Divestment a powerful gameplay for achieving clarity and accelerating progress on a map that has become overly complex or diversified.
 
-## 🏷️ **Real-World Examples**
+## 🗺️ **Real-World Examples**
 
 ### IBM’s PC Division Sale to Lenovo (2005)
 IBM sold its commoditized PC division to Lenovo to shed a low-margin business and focus on services and software, enabling it
@@ -104,11 +104,6 @@ A telecom operator divests or decommissions its legacy copper infrastructure, wh
 - The separated entity would not be viable on its own, or the divestment would critically weaken the parent company's remaining operations or market position.
 - Market conditions are unfavorable for achieving a fair value for the divested asset or entity.
 
-## ⚠️ **Distinction from Doctrines and Climate**
-Strategic Divestment (including disposal of liability) is a highly complex, high-impact decision, not a routine or universally applicable best practice (i.e., not a doctrine). It involves intricate legal, financial, and governance considerations, and is certainly not "nearly always a good idea." It is a specific, strategic choice made under particular circumstances, requiring extensive due diligence and alignment with the company's long-term strategic goals.
-
-While external market dynamics, competitive pressures, or shifts in the broader economic climate might influence the decision to divest, the act of divesting itself is a deliberate, internal strategic action taken by the organization. It is a proactive response to, or an anticipation of, climate patterns, rather than an inherent part of the external climate itself.
-
 ## 🎯 **Leadership**
 
 ### Core challenge
@@ -125,7 +120,7 @@ employees and customers may be attached to.
 Ensure that disposal does not abandon stakeholders, such as employees, customers, or communities. Plan for fair treatment,
 severance, or transition support.
 
-## 📋 **How to Execute Strategic Divestment or Disposal**
+## 📋 **How to Execute**
 
 1. **Identify Candidates:** Map your value chain. Identify components that are liabilities (obsolete, draining resources) or candidates for strategic divestment (non-core, potential for standalone growth, misaligned).
 2. **Evaluate Strategic Fit & Financial Impact:** Assess each candidate's current and future strategic importance, financial contribution (or drain), risks, and potential value if divested/spun-off. Consider market conditions for such a move.
@@ -166,6 +161,11 @@ Ignoring contractual obligations or regulatory requirements can result in fines 
 Removing a component too quickly may deprive the organization of essential skills or knowledge.
 
 ## 🧠 **Strategic Insights**
+
+### Distinction from Doctrines and Climate
+Strategic Divestment (including disposal of liability) is a highly complex, high-impact decision, not a routine or universally applicable best practice (i.e., not a doctrine). It involves intricate legal, financial, and governance considerations, and is certainly not "nearly always a good idea." It is a specific, strategic choice made under particular circumstances, requiring extensive due diligence and alignment with the company's long-term strategic goals.
+
+While external market dynamics, competitive pressures, or shifts in the broader economic climate might influence the decision to divest, the act of divesting itself is a deliberate, internal strategic action taken by the organization. It is a proactive response to, or an anticipation of, climate patterns, rather than an inherent part of the external climate itself.
 
 ### Enhanced Strategic Focus & Re-centering
 Strategic divestments and disposals are powerful tools for clarifying an organization's strategy. By shedding non-core, underperforming, or distracting assets, leadership can redirect attention, capital, and resources toward core, high-growth areas. This re-centers the organization on its primary value proposition.
@@ -211,11 +211,6 @@ disposal isn’t feasible.
 - [Refactoring](/strategies/dealing-with-toxicity/refactoring) - Internally transform or repurpose components as an
 alternative to disposal.
 
-## 📚 **Further Reading & References**
-
-- HBR: [“Pruning the Corporate Portfolio”](https://hbr.org/2017/12/case-study-should-a-hotel-giant-eliminate-some-brands-and-refocus) - Guidance on divestment timing and execution.
-- [General Electric rids itself of financial unit in $26.5bn deal as it hones focus](https://www.theguardian.com/business/2015/apr/10/general-electric-sell-financial-unit-26-billion-deal) - GE’s divestiture of GE Capital (2015) - Case study of reducing complexity by divesting a non-core business.
-
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: What was once an asset can become a liability as the market and technology landscape changes.
@@ -223,3 +218,8 @@ alternative to disposal.
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Holding onto a liability due to past success can be detrimental; disposal is necessary.
 - [Creative Destruction](/climatic-patterns/creative-destruction) – rel: Disposing of a liability can be a form of creative destruction, allowing resources to be reallocated to more promising areas.
 - [Capital flows to new areas of value](/climatic-patterns/capital-flows-to-new-areas-of-value) – rel: Freeing up capital by disposing of liabilities allows investment in new value-creating opportunities.
+
+## 📚 **Further Reading & References**
+
+- HBR: [“Pruning the Corporate Portfolio”](https://hbr.org/2017/12/case-study-should-a-hotel-giant-eliminate-some-brands-and-refocus) - Guidance on divestment timing and execution.
+- [General Electric rids itself of financial unit in $26.5bn deal as it hones focus](https://www.theguardian.com/business/2015/apr/10/general-electric-sell-financial-unit-26-billion-deal) - GE’s divestiture of GE Capital (2015) - Case study of reducing complexity by divesting a non-core business.

--- a/docs/strategies/dealing-with-toxicity/pig-in-a-poke/index.md
+++ b/docs/strategies/dealing-with-toxicity/pig-in-a-poke/index.md
@@ -131,11 +131,6 @@ Executing a "Pig in a Poke" directly can inflict significant, long-lasting reput
 - [Sweat & Dump](/strategies/dealing-with-toxicity/sweat-and-dump) – Outsource asset operation to third parties before exiting.
 - [Refactoring](/strategies/dealing-with-toxicity/refactoring) – Internally transform or repurpose assets as an alternative.
 
-## 📚 **Further Reading & References**
-
-- [Pump and Dump](https://en.wikipedia.org/wiki/Pump_and_dump) – Overview of the practice in financial markets.
-- Case Study: Cuban’s [Broadcast.com Sale](https://en.wikipedia.org/wiki/Broadcast.com) – Timing an exit at peak hype for maximum gain.
-
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: A component that was once valuable can become less so, tempting a seller to offload it deceptively.
@@ -143,3 +138,8 @@ Executing a "Pig in a Poke" directly can inflict significant, long-lasting reput
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Buyers might be blinded by the past reputation of an asset, failing to see its current toxicity.
 - [Most competitors have poor situational awareness](/climatic-patterns/most-competitors-have-poor-situational-awareness) – rel: The seller exploits the buyer's lack of awareness or due diligence.
 - [Future value is inversely proportional to the certainty we have over it](/climatic-patterns/future-value-is-inversely-proportional-to-the-certainty-we-have-over-it) – rel: The seller creates a false sense of certainty about future value.
+
+## 📚 **Further Reading & References**
+
+- [Pump and Dump](https://en.wikipedia.org/wiki/Pump_and_dump) – Overview of the practice in financial markets.
+- Case Study: Cuban’s [Broadcast.com Sale](https://en.wikipedia.org/wiki/Broadcast.com) – Timing an exit at peak hype for maximum gain.

--- a/docs/strategies/dealing-with-toxicity/refactoring/index.md
+++ b/docs/strategies/dealing-with-toxicity/refactoring/index.md
@@ -18,6 +18,20 @@ Purpose: *reduce losses and integrate leftover value* into the organization in a
 
 Key principles: identify components (people, tech, processes) that can be useful elsewhere. For example, maybe the product is dead but the underlying database could support another service, or the team can be moved to a different project with slight retraining. By refactoring, you gradually wind down the old structure while not wasting everything.
 
+## 🗺️ **Real-World Examples**
+
+### Software/Tech
+
+Many companies "refactor" their legacy IT. E.g., taking an old mainframe application and breaking it into microservices or migrating functions to modern systems one piece at a time (some parts might be turned into APIs for new apps). In doing so, they preserve critical logic or data (value) but eliminate the monolithic, hard-to-maintain structure. IBM's example with moving combustion engine production offshore (per forum) was partly a physical refactoring, shifting location and focusing that unit solely on being a cost-efficient piece until shut down.
+
+### Industrial
+
+A car manufacturer phasing out combustion engines might refactor its production: move older engine production lines to a lower-cost factory (like VW moving them to Poland) and repurpose some facilities to build electric components. They aren't scrapping everything: they reassign factories or workers to new tasks where possible (e.g., train engine designers to work on electric drive trains). Ultimately, when combustion ends, they have minimized domestic impact and squeezed remaining value from those engines in a cheaper setting. They have a mix of sweat (in cheaper plant) and integration (transition workforce to new tech).
+
+### Hypothetical
+
+A publishing company has a huge staff for print magazine layout, a diminishing need. Instead of mass layoffs, it refactors: it retrains a chunk of them in digital content layout and transfers them to the web team (useful skill reuse), it automates some layout tasks with software, and for the purely excess roles, it offers either internal transfers (some designers might move to marketing department) or packages out. The physical space freed by a smaller print team is converted into a multimedia studio for new digital content. This way, the company gradually morphs the legacy print operation into a leaner, partly repurposed unit that complements the digital side, rather than a sudden chop.
+
 ## 🚦 **When to Use / When to Avoid**
 
 <Assessment strategyName="Refactoring">
@@ -49,20 +63,6 @@ The legacy asset has **subcomponents of value** that you can clearly redeploy. O
 ### Avoid when
 
 The toxic asset is hemorrhaging so badly that incremental changes won't stop the bleeding -- sometimes you need a quick cut (disposal) rather than gentle refactor. Also avoid if the effort to refactor is too high or distracts too much from core (sometimes dismantling internally can consume a lot of management attention -- if that's the case, might be better to do sweat & dump or pig in poke). If no part of the old is really salvageable or compatible with new directions, refactoring may just delay the inevitable.
-
-## 🗺️ **Real-World Examples**
-
-### Software/Tech
-
-Many companies "refactor" their legacy IT. E.g., taking an old mainframe application and breaking it into microservices or migrating functions to modern systems one piece at a time (some parts might be turned into APIs for new apps). In doing so, they preserve critical logic or data (value) but eliminate the monolithic, hard-to-maintain structure. IBM's example with moving combustion engine production offshore (per forum) was partly a physical refactoring, shifting location and focusing that unit solely on being a cost-efficient piece until shut down.
-
-### Industrial
-
-A car manufacturer phasing out combustion engines might refactor its production: move older engine production lines to a lower-cost factory (like VW moving them to Poland) and repurpose some facilities to build electric components. They aren't scrapping everything: they reassign factories or workers to new tasks where possible (e.g., train engine designers to work on electric drive trains). Ultimately, when combustion ends, they have minimized domestic impact and squeezed remaining value from those engines in a cheaper setting. They have a mix of sweat (in cheaper plant) and integration (transition workforce to new tech).
-
-### Hypothetical
-
-A publishing company has a huge staff for print magazine layout, a diminishing need. Instead of mass layoffs, it refactors: it retrains a chunk of them in digital content layout and transfers them to the web team (useful skill reuse), it automates some layout tasks with software, and for the purely excess roles, it offers either internal transfers (some designers might move to marketing department) or packages out. The physical space freed by a smaller print team is converted into a multimedia studio for new digital content. This way, the company gradually morphs the legacy print operation into a leaner, partly repurposed unit that complements the digital side, rather than a sudden chop.
 
 ## 🎯 **Leadership**
 
@@ -134,11 +134,6 @@ The primary leadership challenge is **managing the transition sensitively and de
 - [**Sweat & Dump**](/strategies/dealing-with-toxicity/sweat-and-dump) - An alternative to refactoring where the asset is pushed hard for short-term gain before disposal, often externally.
 - [**Value Chain Disaggregation and Re-aggregation**](/strategies/dealing-with-toxicity/value-chain-disaggregation-and-re-aggregation) - While refactoring is about internal reorganization of a legacy asset, VCDAR is a broader strategic play involving breaking down and recombining entire value chains, often to create new market offerings or business models. Refactoring might be a small part of a larger VCDAR initiative if legacy components are repurposed into a new value chain structure.
 - [Pig in a Poke](/strategies/dealing-with-toxicity/pig-in-a-poke) - Packaging toxic components within refactored entities so hidden liabilities surface only after acceptance or deployment.
-## 📚 **Further Reading & References**
-
-- Agile/DevOps analogies - Many tech companies apply refactoring to processes: e.g., breaking a legacy business process into agile teams. Business literature on **business process re-engineering** touches similar ideas (though BPR often aimed at improvement, here aim is also removal).
-- *"Dual Transformation" (Anthony, Johnson)* - a strategy book that talks about running a legacy business (Transformation B) while building new (Transformation A), and how to transfer capabilities from B to A. It's essentially how to refactor an organization during disruption, moving old capabilities to new growth, similar to refactoring concept described here.
-
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: Legacy systems inevitably reach a point where they need refactoring or disposal due to evolution.
@@ -146,3 +141,8 @@ The primary leadership challenge is **managing the transition sensitively and de
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Inertia towards successful legacy systems can delay necessary refactoring.
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Refactoring can improve efficiency by removing outdated components, freeing resources for innovation.
 - [Higher order systems create new sources of worth](/climatic-patterns/higher-order-systems-create-new-sources-of-worth) – rel: Refactoring can involve integrating salvaged components into new, higher-order systems.
+
+## 📚 **Further Reading & References**
+
+- Agile/DevOps analogies - Many tech companies apply refactoring to processes: e.g., breaking a legacy business process into agile teams. Business literature on **business process re-engineering** touches similar ideas (though BPR often aimed at improvement, here aim is also removal).
+- *"Dual Transformation" (Anthony, Johnson)* - a strategy book that talks about running a legacy business (Transformation B) while building new (Transformation A), and how to transfer capabilities from B to A. It's essentially how to refactor an organization during disruption, moving old capabilities to new growth, similar to refactoring concept described here.

--- a/docs/strategies/dealing-with-toxicity/sweat-and-dump/index.md
+++ b/docs/strategies/dealing-with-toxicity/sweat-and-dump/index.md
@@ -147,10 +147,6 @@ While operational burdens and capex are offloaded, significant reputational risk
 
 - [designed-to-fail](/strategies/poison/designed-to-fail) - intentionally structuring spin-offs or transformations to fail, enabling clean separation and transfer of liabilities.
 - [Last Man Standing](/strategies/markets/last-man-standing) - offloading assets to specialist providers in a competitive market, letting survivors absorb residual risks and costs.
-## 📚 **Further Reading & References**
-
-- Case Study: [Nortel](https://en.wikipedia.org/wiki/Timeline_of_Nortel) Support Spin-offs – Real-world legacy IT sweat & dump scenario.
-
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: Legacy systems become candidates for Sweat & Dump as they reach the end of their lifecycle.
@@ -158,3 +154,7 @@ While operational burdens and capex are offloaded, significant reputational risk
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Inertia can prevent organizations from divesting toxic assets, making Sweat & Dump a necessary strategy.
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Offloading a legacy system allows the organization to focus resources on innovation.
 - [Capital flows to new areas of value](/climatic-patterns/capital-flows-to-new-areas-of-value) – rel: Sweat & Dump frees up capital from legacy systems to be invested in new, higher-value areas.
+
+## 📚 **Further Reading & References**
+
+- Case Study: [Nortel](https://en.wikipedia.org/wiki/Timeline_of_Nortel) Support Spin-offs – Real-world legacy IT sweat & dump scenario.

--- a/docs/strategies/ecosystem/alliances/index.md
+++ b/docs/strategies/ecosystem/alliances/index.md
@@ -37,6 +37,20 @@ Key principles for effective alliances:
 
 Alliances are particularly effective as ecosystem plays, allowing collective action in environments of high uncertainty or where first-mover advantage matters.
 
+## 🗺️ **Real-World Examples**
+
+### Star Alliance (airlines)
+
+Dozens of airlines allied to extend reach through code-sharing and integrated frequent flyer benefits. This enabled a global network under a single brand, driving the evolution of air travel connectivity.
+
+### AllSeen Alliance (IoT)
+
+Qualcomm, Microsoft, LG and others formed an alliance to promote AllJoyn as an open standard for device interoperability. Similar efforts include the Zigbee Alliance.
+
+### Hypothetical EV Alliance
+
+Several mid-sized electric vehicle startups create a joint venture for charging infrastructure. This allows them to rival Tesla’s Supercharger network and accelerate EV adoption.
+
 ## 🚦 **When to Use / When to Avoid**
 
 <Assessment strategyName="Alliances">
@@ -73,20 +87,6 @@ Alliances are particularly effective as ecosystem plays, allowing collective act
 - potential for anti-trust issues or perceptions of collusion
 - alliance could slow you down unnecessarily
 - you have a dominant position and don't need others
-
-## 🗺️ **Real-World Examples**
-
-### Star Alliance (airlines)
-
-Dozens of airlines allied to extend reach through code-sharing and integrated frequent flyer benefits. This enabled a global network under a single brand, driving the evolution of air travel connectivity.
-
-### AllSeen Alliance (IoT)
-
-Qualcomm, Microsoft, LG and others formed an alliance to promote AllJoyn as an open standard for device interoperability. Similar efforts include the Zigbee Alliance.
-
-### Hypothetical EV Alliance
-
-Several mid-sized electric vehicle startups create a joint venture for charging infrastructure. This allows them to rival Tesla’s Supercharger network and accelerate EV adoption.
 
 ## 🎯 **Leadership**
 

--- a/docs/strategies/markets/buyer-supplier-power/index.md
+++ b/docs/strategies/markets/buyer-supplier-power/index.md
@@ -146,11 +146,6 @@ Every value chain is also a power chain. Understanding this allows you to see th
 
 - [Channel Conflict and Disintermediation](/strategies/ecosystem/channel-conflict-and-disintermediation) - reallocating buyer-supplier relationships by bypassing intermediaries to capture margin and control channels.
 - [Pricing Policy](/strategies/markets/pricing-policy) - adjusting pricing structures to influence supplier margins and buyer incentives, shifting power dynamics.
-## 📚 **Further Reading & References**
-
-*   **[Competitive Strategy](https://www.goodreads.com/book/show/236901.Competitive_Strategy)** by Michael E. Porter. The classic text that introduced the "Five Forces" framework, which is central to understanding buyer-supplier power.
-*   **[The Everything Store: Jeff Bezos and the Age of Amazon](https://www.goodreads.com/book/show/17660462-the-everything-store)** by Brad Stone. Provides many examples of how Amazon has masterfully managed buyer-supplier power.
-
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: The balance of power between buyers and suppliers shifts as markets and components evolve.
@@ -158,3 +153,8 @@ Every value chain is also a power chain. Understanding this allows you to see th
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – rel: Increased efficiency in a part of the value chain can alter power dynamics, e.g., by making suppliers more interchangeable.
 - [Higher order systems create new sources of worth](/climatic-patterns/higher-order-systems-create-new-sources-of-worth) – rel: New higher-order systems can create new chokepoints and shift power, like platform ecosystems.
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: Competitors' moves to consolidate power or form alliances will impact the buyer-supplier landscape.
+
+## 📚 **Further Reading & References**
+
+*   **[Competitive Strategy](https://www.goodreads.com/book/show/236901.Competitive_Strategy)** by Michael E. Porter. The classic text that introduced the "Five Forces" framework, which is central to understanding buyer-supplier power.
+*   **[The Everything Store: Jeff Bezos and the Age of Amazon](https://www.goodreads.com/book/show/17660462-the-everything-store)** by Brad Stone. Provides many examples of how Amazon has masterfully managed buyer-supplier power.

--- a/docs/strategies/markets/harvesting/index.md
+++ b/docs/strategies/markets/harvesting/index.md
@@ -146,11 +146,6 @@ At its best, harvesting is a symbiotic relationship. The ecosystem provides inno
 *   **[Threat Acquisition](/strategies/defensive/threat-acquisition)**: Harvesting can sometimes be a defensive move to acquire a company that is becoming a threat.
 
 - [Market Enablement](/strategies/accelerators/market-enablement) - preparing and priming the ecosystem so that harvested services and innovations are rapidly adopted and scaled.
-## 📚 **Further Reading & References**
-
-*   **[Platform Revolution](https://www.goodreads.com/book/show/26899832-platform-revolution)** by Geoffrey G. Parker, Marshall W. Van Alstyne, and Sangeet Paul Choudary. A comprehensive guide to platform business models.
-*   **[The Business of Platforms](https://www.goodreads.com/book/show/43688225-the-business-of-platforms)** by Michael A. Cusumano, Annabelle Gawer, and David B. Yoffie. Explores the strategies of platform companies.
-
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: The ecosystem around a platform evolves, creating new opportunities for harvesting.
@@ -158,3 +153,8 @@ At its best, harvesting is a symbiotic relationship. The ecosystem provides inno
 - [Higher order systems create new sources of worth](/climatic-patterns/higher-order-systems-create-new-sources-of-worth) – rel: Successful harvested features often become part of a higher-order system (the platform), increasing its overall value.
 - [No choice on evolution](/climatic-patterns/no-choice-on-evolution) – rel: Platforms must evolve by incorporating successful ecosystem innovations (harvesting) to stay relevant.
 - [Capital flows to new areas of value](/climatic-patterns/capital-flows-to-new-areas-of-value) – rel: Harvesting directs the platform owner's capital (build or buy) towards validated areas of value.
+
+## 📚 **Further Reading & References**
+
+*   **[Platform Revolution](https://www.goodreads.com/book/show/26899832-platform-revolution)** by Geoffrey G. Parker, Marshall W. Van Alstyne, and Sangeet Paul Choudary. A comprehensive guide to platform business models.
+*   **[The Business of Platforms](https://www.goodreads.com/book/show/43688225-the-business-of-platforms)** by Michael A. Cusumano, Annabelle Gawer, and David B. Yoffie. Explores the strategies of platform companies.

--- a/docs/strategies/markets/signal-distortion/index.md
+++ b/docs/strategies/markets/signal-distortion/index.md
@@ -144,11 +144,6 @@ Signal Distortion is a powerful reminder that in many markets, the perception of
 *   **[Fear, Uncertainty, and Doubt (FUD)](/terms/fear-uncertainty-and-doubt)**: A specific tactic of signal distortion focused on creating negative perceptions about a competitor.
 
 - [Fool's Mate](/strategies/attacking/fools-mate) - baiting competitors into missteps with deliberate misinformation, setting up a rapid counterstrike.
-## 📚 **Further Reading & References**
-
-*   **[Trust Me, I'm Lying: Confessions of a Media Manipulator](https://www.goodreads.com/book/show/13542853-trust-me-i-m-lying)** by Ryan Holiday. A stark look at how media can be manipulated.
-*   **[The Art of War](https://www.goodreads.com/book/show/10534.The_Art_of_War)** by Sun Tzu. The ancient text is full of wisdom on deception and misdirection.
-
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Most competitors have poor situational awareness](/climatic-patterns/most-competitors-have-poor-situational-awareness) – rel: This strategy exploits the poor situational awareness of competitors by feeding them misleading signals.
@@ -156,3 +151,8 @@ Signal Distortion is a powerful reminder that in many markets, the perception of
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Competitors relying on past successful signals may be easily misled by distorted new signals.
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: The goal of signal distortion is to influence competitors' actions to your advantage.
 - [The less evolved something is the more uncertain it becomes](/climatic-patterns/the-less-evolved-something-is-then-the-more-uncertain-it-becomes) – rel: Uncertainty in early-stage markets makes them more susceptible to signal distortion.
+
+## 📚 **Further Reading & References**
+
+*   **[Trust Me, I'm Lying: Confessions of a Media Manipulator](https://www.goodreads.com/book/show/13542853-trust-me-i-m-lying)** by Ryan Holiday. A stark look at how media can be manipulated.
+*   **[The Art of War](https://www.goodreads.com/book/show/10534.The_Art_of_War)** by Sun Tzu. The ancient text is full of wisdom on deception and misdirection.

--- a/docs/strategies/markets/standards-game/index.md
+++ b/docs/strategies/markets/standards-game/index.md
@@ -159,12 +159,6 @@ Competitors may attempt embrace-and-extend tactics or create alternative allianc
 - [Alliances](/strategies/ecosystem/alliances) - forming coalitions of organisations to coordinate and promote standardisation efforts.
 - [Playing Both Sides](/strategies/attacking/playing-both-sides) - engaging multiple standard bodies or camps in parallel to influence outcomes and retain flexibility.
 - [Buyer-Supplier Power](/strategies/markets/buyer-supplier-power) - leveraging control of standard implementation to influence supplier terms and buyer commitments.
-## 📚 **Further Reading & References**
-
-- [USB Implementers Forum](https://www.usb.org/) – Example of industry coordination driving a ubiquitous standard.
-- [GSM Association](https://www.gsma.com/) – Case study of regulators and industry collaborating on a global mobile standard.
-- [RFC 2026 – The Internet Standards Process](https://www.rfc-editor.org/rfc/rfc2026) – Insight into how open standards bodies govern technical specifications.
-
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: Standards emerge as components evolve towards commodity; playing the standards game is a way to influence this evolution.
@@ -172,3 +166,9 @@ Competitors may attempt embrace-and-extend tactics or create alternative allianc
 - [Shifts from product to utility show punctuated equilibrium](/climatic-patterns/shifts-from-product-to-utility-tend-to-demonstrate-a-punctuated-equilibrium) – rel: The establishment of a standard can be a punctuation point in the shift of a component to a utility.
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: Competitors will fight to establish their own standards or resist yours.
 - [No one size fits all](/climatic-patterns/no-one-size-fits-all) – rel: While a standard aims for uniformity, its application might still vary, or competing standards may serve different niches.
+
+## 📚 **Further Reading & References**
+
+- [USB Implementers Forum](https://www.usb.org/) – Example of industry coordination driving a ubiquitous standard.
+- [GSM Association](https://www.gsma.com/) – Case study of regulators and industry collaborating on a global mobile standard.
+- [RFC 2026 – The Internet Standards Process](https://www.rfc-editor.org/rfc/rfc2026) – Insight into how open standards bodies govern technical specifications.

--- a/docs/strategies/poison/designed-to-fail/index.md
+++ b/docs/strategies/poison/designed-to-fail/index.md
@@ -162,12 +162,6 @@ These initiatives are not meant to last. Their purpose is to occupy space, creat
 - [Licensing](/strategies/poison/licensing) — controlling ecosystems through legal terms.
 
 - [Standards Game](/strategies/markets/standards-game) - introducing deliberately flawed specifications to fragment competitor ecosystems and clear the path for your own standard.
-## 📚 **Further Reading & References**
-
-- [HD DVD vs Blu-ray (Wikipedia)](https://en.wikipedia.org/wiki/HD_DVD) — a case of market fragmentation leading to failure.
-- [Betamax vs VHS (Wikipedia)](https://en.wikipedia.org/wiki/Betamax) — example of proprietary format wars.
-- *Blue Ocean Strategy* (W. Chan Kim & Renée Mauborgne) — insights into creating and defending market spaces.
-
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: This strategy aims to disrupt the natural evolution of a nascent market.
@@ -175,3 +169,9 @@ These initiatives are not meant to last. Their purpose is to occupy space, creat
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: This is a direct attempt to influence and derail competitors' actions.
 - [Most competitors have poor situational awareness](/climatic-patterns/most-competitors-have-poor-situational-awareness) – rel: Exploits competitors' inability to discern a deliberately flawed initiative from a genuine one.
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: A company might use this to protect a successful but aging core business from a disruptive new market.
+
+## 📚 **Further Reading & References**
+
+- [HD DVD vs Blu-ray (Wikipedia)](https://en.wikipedia.org/wiki/HD_DVD) — a case of market fragmentation leading to failure.
+- [Betamax vs VHS (Wikipedia)](https://en.wikipedia.org/wiki/Betamax) — example of proprietary format wars.
+- *Blue Ocean Strategy* (W. Chan Kim & Renée Mauborgne) — insights into creating and defending market spaces.

--- a/docs/strategies/poison/insertion/index.md
+++ b/docs/strategies/poison/insertion/index.md
@@ -172,11 +172,6 @@ Insertion is rarely a standalone play. Its effectiveness is often amplified when
 - [Press Release Process](/strategies/attacking/press-release-process) — public signals to manipulate perception.
 - [Designed to Fail](/strategies/poison/designed-to-fail) — pre-seeding flawed initiatives.
 
-## 📚 **Further Reading & References**
-
-- Cialdini, R. — [*Influence: The Psychology of Persuasion*](https://www.amazon.co.uk/Influence-Psychology-Robert-Cialdini-PhD/dp/006124189X) — foundational concepts of behavioral influence.
-- Mitnick, K. — [*The Art of Deception*](https://www.amazon.co.uk/Art-Deception-Controlling-Element-Security/dp/076454280X) — case studies on social engineering and covert operations.
-
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: The methods of insertion and the vulnerabilities of competitors evolve over time.
@@ -184,3 +179,8 @@ Insertion is rarely a standalone play. Its effectiveness is often amplified when
 - [Most competitors have poor situational awareness](/climatic-patterns/most-competitors-have-poor-situational-awareness) – rel: This strategy exploits the target's lack of awareness about being influenced.
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: Competitors relying on past successful decision-making frameworks can be vulnerable to inserted narratives that fit those frameworks.
 - [The less evolved something is the more uncertain it becomes](/climatic-patterns/the-less-evolved-something-is-then-the-more-uncertain-it-becomes) – rel: Uncertainty in a competitor's strategy or market understanding provides fertile ground for insertion.
+
+## 📚 **Further Reading & References**
+
+- Cialdini, R. — [*Influence: The Psychology of Persuasion*](https://www.amazon.co.uk/Influence-Psychology-Robert-Cialdini-PhD/dp/006124189X) — foundational concepts of behavioral influence.
+- Mitnick, K. — [*The Art of Deception*](https://www.amazon.co.uk/Art-Deception-Controlling-Element-Security/dp/076454280X) — case studies on social engineering and covert operations.

--- a/docs/strategies/poison/licensing/index.md
+++ b/docs/strategies/poison/licensing/index.md
@@ -169,11 +169,6 @@ In complex ecosystems where multiple patented technologies are required to creat
 - [Exploiting Network Effects](/strategies/accelerators/exploiting-network-effects) — using network lock-in.
 - [Limitation of Competition](/strategies/defensive/limitation-of-competition) — structural barriers to entry.
 
-## 📚 **Further Reading & References**
-
-- [GPLv3 License](https://www.gnu.org/licenses/gpl-3.0.html) — example of strong copyleft.
-- [Multi-licensing](https://en.wikipedia.org/wiki/Multi-licensing) — overview of dual and multi-licensing strategies.
-
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: Licensing terms must adapt as technologies evolve and commoditize.
@@ -181,3 +176,8 @@ In complex ecosystems where multiple patented technologies are required to creat
 - [Higher order systems create new sources of worth](/climatic-patterns/higher-order-systems-create-new-sources-of-worth) – rel: Licensing can control access to components needed to build higher-order systems, thus capturing value.
 - [Competitors' actions will change the game](/climatic-patterns/competitors-actions-will-change-the-game) – rel: Competitors may challenge licenses or create alternatives, forcing changes in licensing strategy.
 - [Past success breeds inertia](/climatic-patterns/past-success-breeds-inertia) – rel: A company successful with a particular licensing model might be slow to adapt it as the market changes.
+
+## 📚 **Further Reading & References**
+
+- [GPLv3 License](https://www.gnu.org/licenses/gpl-3.0.html) — example of strong copyleft.
+- [Multi-licensing](https://en.wikipedia.org/wiki/Multi-licensing) — overview of dual and multi-licensing strategies.

--- a/docs/strategies/positional/weak-signal-horizon/index.md
+++ b/docs/strategies/positional/weak-signal-horizon/index.md
@@ -148,12 +148,6 @@ Effective sensing requires an organisational culture that values and acts on ear
 - [Procrastination](/strategies/defensive/procrastination) - holding action until weak signals coalesce, reducing the risk of premature commitments to false positives.
 - [Experimentation](/strategies/attacking/experimentation) - conducting targeted probes to validate weak signals and refine strategic direction.
 - [Directed Investment](/strategies/attacking/directed-investment) - allocating resources to areas highlighted by validated signals to establish a competitive edge.
-## 📚 **Further Reading & References**
-
-- Wardley, S. – [*Anticipation*](https://blog.gardeviance.org/2016/12/anticipation.html) – foundational concepts on sensing and foresight.
-- Kahneman, D. – [*Thinking, Fast and Slow*](https://www.amazon.co.uk/Thinking-Fast-Slow-Daniel-Kahneman/dp/0141033576#:~:text=Book%20details&text=Nobel%20Prize%20winner%20Daniel%20Kahneman,%2C%20and%20slow%2C%20rational%20thinking.) – for insights on bias and signal interpretation.
-- [*Horizon Scanning*](https://en.wikipedia.org/wiki/Horizon_scanning), Wikipedia - methodologies in foresight practice.
-
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: Weak signals often indicate the early stages of a component's evolution or a shift in its trajectory.
@@ -161,3 +155,9 @@ Effective sensing requires an organisational culture that values and acts on ear
 - [The less evolved something is the more uncertain it becomes](/climatic-patterns/the-less-evolved-something-is-then-the-more-uncertain-it-becomes) – rel: Weak signals are inherently uncertain but crucial for navigating early, unevolved spaces.
 - [Economy has cycles](/climatic-patterns/economy-has-cycles) – rel: Recognizing cyclical patterns can help identify weak signals related to market peaks, troughs, and transitions.
 - [Not everything is random](/climatic-patterns/not-everything-is-random) – rel: The core belief of weak signal detection is that underlying patterns, not randomness, drive market changes.
+
+## 📚 **Further Reading & References**
+
+- Wardley, S. – [*Anticipation*](https://blog.gardeviance.org/2016/12/anticipation.html) – foundational concepts on sensing and foresight.
+- Kahneman, D. – [*Thinking, Fast and Slow*](https://www.amazon.co.uk/Thinking-Fast-Slow-Daniel-Kahneman/dp/0141033576#:~:text=Book%20details&text=Nobel%20Prize%20winner%20Daniel%20Kahneman,%2C%20and%20slow%2C%20rational%20thinking.) – for insights on bias and signal interpretation.
+- [*Horizon Scanning*](https://en.wikipedia.org/wiki/Horizon_scanning), Wikipedia - methodologies in foresight practice.

--- a/docs/strategies/user-perception/artificial-competition/index.md
+++ b/docs/strategies/user-perception/artificial-competition/index.md
@@ -35,6 +35,12 @@ Used effectively, artificial competition offers multiple layers of strategic ben
 
 This is about **shaping the environment in which decisions are made**. Skilled leaders use this strategy to create optionality, reduce volatility, and consolidate advantage
 
+## 🗺️ **Real-World Examples**
+
+### MediaMarkt and Saturn
+
+The consumer electronics retailers **MediaMarkt and Saturn** in Europe are perceived as fierce competitors. However, both belong to the *same holding company*. This strategy consolidates market share within the holding company while blocking out other entrants.
+
 ## 🚦 **When to Use / When to Avoid**
 
 <Assessment strategyName="Artifical Competition">
@@ -69,12 +75,6 @@ This is about **shaping the environment in which decisions are made**. Skilled l
 - Maintaining two entities is prohibitively costly or complex.
 - Transparency in your industry makes affiliations easy to uncover, risking trust erosion.
 
-
-## 🗺️ **Real-World Examples**
-
-### MediaMarkt and Saturn
-
-The consumer electronics retailers **MediaMarkt and Saturn** in Europe are perceived as fierce competitors. However, both belong to the *same holding company*. This strategy consolidates market share within the holding company while blocking out other entrants.
 
 ## 🎯 **Leadership**
 

--- a/docs/strategies/user-perception/brand-and-marketing/index.md
+++ b/docs/strategies/user-perception/brand-and-marketing/index.md
@@ -40,6 +40,16 @@ In markets saturated with similar offerings, a compelling brand narrative provid
 
 Effective application begins with a deep, empathetic understanding of the target customer segment – their motivations, pain points, values, and identity. This insight is the foundation for crafting authentic brand messages and narratives that genuinely resonate, creating a meaningful connection and sense of relevance. Implementation involves strategically positioning the brand within the market landscape, sometimes requiring sophisticated tactics like dual branding to effectively engage diverse niches without compromising the main brand's integrity. Consistent execution of this brand strategy across all customer touchpoints is vital for building and reinforcing the desired perception.
 
+## 🗺️ **Real-World Examples**
+
+### BlackBerry's "It's not a toy" Campaign
+
+BlackBerry positioned its phones as professional tools, implicitly labeling iPhones as frivolous. This branding aimed to keep corporate users loyal by appealing to their professional identity.
+
+### Orange's "NJU Mobile" Sub-Brand
+
+Orange launched "NJU Mobile" to target youth while maintaining its main brand's integrity. This dual branding strategy allowed it to cover all bases.
+
 ## 🚦 **When to Use / When to Avoid**
 
 <Assessment strategyName="Brand and Marketing">
@@ -73,16 +83,6 @@ Effective application begins with a deep, empathetic understanding of the target
 - The market is highly rational and price-driven.
 - The product has quality issues that marketing cannot fix.
 - Innovation is needed more than branding.
-
-## 🗺️ **Real-World Examples**
-
-### BlackBerry's "It's not a toy" Campaign
-
-BlackBerry positioned its phones as professional tools, implicitly labeling iPhones as frivolous. This branding aimed to keep corporate users loyal by appealing to their professional identity.
-
-### Orange's "NJU Mobile" Sub-Brand
-
-Orange launched "NJU Mobile" to target youth while maintaining its main brand's integrity. This dual branding strategy allowed it to cover all bases.
 
 ## 🎯 **Leadership**
 


### PR DESCRIPTION
Reordered H2 sections in 16 strategy documents to ensure they match the order defined in `REQUIRED_STRATEGY_HEADINGS` in `tests/test_content_quality.py`.

This resolves failures in the `test_strategy_headings_in_order` test. Non-standard H2 headings were also addressed by merging their content into appropriate standard sections or correcting heading text as needed to pass the tests.