### PR TITLE
Fix: Add explanations to related strategy links

### DIFF
--- a/docs/strategies/accelerators/open-approaches/index.md
+++ b/docs/strategies/accelerators/open-approaches/index.md
@@ -168,7 +168,7 @@ For example, if your competitor is slower-moving or dependent on licensing, open
 - [Licensing](/strategies/poison/licensing) - choosing license terms to encourage adoption and contributions while maintaining control over derivative uses.
 - [Harvesting](/strategies/markets/harvesting) - extracting strategic value or revenue after an open ecosystem has matured and scaled.
 - [Standards Game](/strategies/markets/standards-game) - using openness to seed protocols or formats that become de facto standards, locking in an ecosystem.
-- [Value Chain Disaggregation and Re-aggregation](/strategies/dealing-with-toxicity/value-chain-disaggregation-and-re-aggregation)
+- [Value Chain Disaggregation and Re-aggregation](/strategies/dealing-with-toxicity/value-chain-disaggregation-and-re-aggregation) - Open approaches can facilitate the disaggregation of value chains by promoting interoperability and standard interfaces between components, and enable new forms of re-aggregation by fostering collaborative ecosystems.
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – trigger: industrialisation of a component often leads to opening it up.

--- a/docs/strategies/dealing-with-toxicity/disposal-of-liability/index.md
+++ b/docs/strategies/dealing-with-toxicity/disposal-of-liability/index.md
@@ -210,8 +210,7 @@ disposal isn’t feasible.
 - [Pig in a Poke](/strategies/dealing-with-toxicity/pig-in-a-poke) - Misrepresent toxic assets as valuable to offload them.
 - [Refactoring](/strategies/dealing-with-toxicity/refactoring) - Internally transform or repurpose components as an
 alternative to disposal.
-
-- [Value Chain Disaggregation and Re-aggregation](/strategies/dealing-with-toxicity/value-chain-disaggregation-and-re-aggregation)
+- [Value Chain Disaggregation and Re-aggregation](/strategies/dealing-with-toxicity/value-chain-disaggregation-and-re-aggregation) - Disaggregating a value chain can help identify and isolate liabilities, making them easier to dispose of. The remaining components can then be re-aggregated into a healthier value chain.
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Everything evolves](/climatic-patterns/everything-evolves) – rel: What was once an asset can become a liability as the market and technology landscape changes.

--- a/docs/strategies/defensive/raising-barriers-to-entry/index.md
+++ b/docs/strategies/defensive/raising-barriers-to-entry/index.md
@@ -141,7 +141,7 @@ Raising the barriers to entry shifts the basis of competition. It's no longer ab
 - [Lobbying](/strategies/user-perception/lobbying) - advocating for policy changes that institutionalise barriers and discourage new entrants.
 - [Bundling](/strategies/user-perception/bundling) - packaging offerings together to force entrants to match comprehensive solutions, raising thresholds for entry.
 - [Buyer-Supplier Power](/strategies/markets/buyer-supplier-power) - leveraging control over supply chains or customer relationships to impose onerous terms on newcomers.
-- [Platform Envelopment](/strategies/ecosystem/platform-envelopment)
+- [Platform Envelopment](/strategies/ecosystem/platform-envelopment) - A platform can raise barriers to entry by enveloping (integrating or absorbing) adjacent services or functionalities, forcing potential new entrants to compete with a much broader and more integrated offering.
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Inertia can kill an organisation](/climatic-patterns/inertia-can-kill-an-organisation) – trigger: barriers entrench incumbents and slow adaptation.

--- a/docs/strategies/ecosystem/embrace-and-extend/index.md
+++ b/docs/strategies/ecosystem/embrace-and-extend/index.md
@@ -145,7 +145,7 @@ A strong, vibrant open-source community around a standard is one of the best def
 - [Co-opting](/strategies/ecosystem/co-opting) - absorbing compatible implementations into your ecosystem before introducing proprietary extensions.
 - [restriction-of-movement](/strategies/competitor/restriction-of-movement) - enforcing extensions to constrain competitors’ ability to adopt or move between standards.
 - [fragmentation](/strategies/competitor/fragmentation) - splintering the ecosystem by introducing incompatible variants that divide community implementations.
-- [Platform Envelopment](/strategies/ecosystem/platform-envelopment)
+- [Platform Envelopment](/strategies/ecosystem/platform-envelopment) - "Embrace and Extend" can be a method to achieve platform envelopment, by first adopting a standard to integrate a service, then extending it with proprietary features to lock users into the platform's ecosystem.
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Creative Destruction](/climatic-patterns/creative-destruction) – trigger: extending a standard can undermine incumbent approaches.

--- a/docs/strategies/ecosystem/innovate-leverage-commoditize/index.md
+++ b/docs/strategies/ecosystem/innovate-leverage-commoditize/index.md
@@ -159,8 +159,8 @@ This strategy is based on the insight that today's innovations are tomorrow's co
 - [Co-creation](/strategies/ecosystem/co-creation) - partnering with users and ecosystem members to generate prototypes and validate innovations for leveraging.
 - [Sweat & Dump](/strategies/dealing-with-toxicity/sweat-and-dump) - offloading non-core assets to specialists, freeing resources for focused innovation and leverage.
 - [Playing Both Sides](/strategies/attacking/playing-both-sides) - leveraging relationships on multiple market fronts to gather insights and maximise strategic leverage.
-- [Value Chain Disaggregation and Re-aggregation](/strategies/dealing-with-toxicity/value-chain-disaggregation-and-re-aggregation)
-- [Platform Envelopment](/strategies/ecosystem/platform-envelopment)
+- [Value Chain Disaggregation and Re-aggregation](/strategies/dealing-with-toxicity/value-chain-disaggregation-and-re-aggregation) - The ILC cycle can drive disaggregation as new platform capabilities emerge, and re-aggregation as ecosystem players adapt to newly commoditized components.
+- [Platform Envelopment](/strategies/ecosystem/platform-envelopment) - The "Commoditize" phase of ILC is a form of platform envelopment, where successful ecosystem functionalities are integrated into the core platform.
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Components can co-evolve](/climatic-patterns/components-can-co-evolve) – trigger: nurturing an ecosystem accelerates mutual improvement.

--- a/docs/strategies/ecosystem/platform-envelopment/index.md
+++ b/docs/strategies/ecosystem/platform-envelopment/index.md
@@ -179,8 +179,7 @@ Platforms often start open to attract users and developers, then selectively clo
 *   **[Innovate-Leverage-Commoditize (ILC)](/strategies/ecosystem/innovate-leverage-commoditize)** - Platforms often leverage their existing user base and data (Leverage) to move into new areas (Innovate) which they then seek to make standard offerings (Commoditize).
 *   **[Raising Barriers to Entry](/strategies/defensive/raising-barriers-to-entry)** - Successful envelopment can create significant barriers for new entrants or existing competitors.
 *   **[Embrace and Extend](/strategies/ecosystem/embrace-and-extend)** - Similar in that it involves co-opting external functionalities, but envelopment is often more about direct competition or absorption into the platform's core.
-
-- [Value Chain Disaggregation and Re-aggregation](/strategies/dealing-with-toxicity/value-chain-disaggregation-and-re-aggregation)
+- [Value Chain Disaggregation and Re-aggregation](/strategies/dealing-with-toxicity/value-chain-disaggregation-and-re-aggregation) - Platform envelopment is a form of re-aggregating capabilities into the platform's value chain, often absorbing functionalities that were previously disaggregated or provided by others.
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – trigger: As core platform components become more efficient and commoditized, resources are freed up to innovate and expand into adjacent areas.

--- a/docs/strategies/ecosystem/tower-and-moat/index.md
+++ b/docs/strategies/ecosystem/tower-and-moat/index.md
@@ -136,9 +136,8 @@ A Tower and Moat strategy is the ultimate positional play. It's not about having
 *   **[Two-Sided Markets](/strategies/ecosystem/two-factor-markets)**: A two-sided market can be a powerful way to build the network effects needed for a strong Moat.
 *   **[Embrace and Extend](/strategies/ecosystem/embrace-and-extend)**: A related strategy, but typically focused on co-opting an existing standard rather than building a new Tower.
 *   **[Raising Barriers to Entry](/strategies/defensive/raising-barriers-to-entry)**: The Moat is a powerful set of barriers to entry.
-
 - [Buyer-Supplier Power](/strategies/markets/buyer-supplier-power) - leveraging influence over supply chains and customer relationships to deepen the moat and raise switching costs.
-- [Platform Envelopment](/strategies/ecosystem/platform-envelopment)
+- [Platform Envelopment](/strategies/ecosystem/platform-envelopment) - Enveloping adjacent services or functionalities into the core platform is a key method for building the "Moat" around the "Tower," by commoditizing potential differentiators.
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Shifts from product to utility show punctuated equilibrium](/climatic-patterns/shifts-from-product-to-utility-tend-to-demonstrate-a-punctuated-equilibrium) – trigger: rapid transitions create opportunities to build the tower.

--- a/docs/strategies/user-perception/bundling/index.md
+++ b/docs/strategies/user-perception/bundling/index.md
@@ -130,8 +130,7 @@ From a value chain perspective, bundling can represent a form of vertical integr
 - [Confusion of Choice](/strategies/user-perception/confusion-of-choice) – Bundling can be combined with complex packages to make alternatives hard to compare.
 - [Raising Barriers to Entry](/strategies/defensive/raising-barriers-to-entry) – Bundling many features raises customer expectations and can deter new entrants.
 - [Land Grab](/strategies/positional/land-grab) – Bundling can quickly expand user base for a new service by piggybacking on an existing one.
-
-- [Platform Envelopment](/strategies/ecosystem/platform-envelopment)
+- [Platform Envelopment](/strategies/ecosystem/platform-envelopment) – Bundling is a common tactic used in platform envelopment to integrate new functionalities or services into an existing platform, often to expand its scope and user base.
 ## ⛅ **Relevant Climatic Patterns**
 
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation) – trigger: combining commoditised components creates new offers.


### PR DESCRIPTION
Adds missing explanations to links in the 'Related Strategies' sections of several strategy documents, as required by content quality tests and CONTRIBUTING.md.

This resolves the failing `test_related_strategy_links_are_explained` pytest.