### PR TITLE
Add Markdown linting GitHub Action and update existing actions

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,15 @@
+name: Markdown Lint
+
+on:
+  push:
+    branches: ['**']
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install markdownlint-cli
+        run: npm install -g markdownlint-cli
+      - name: Run markdownlint
+        run: markdownlint '**/*.md' --ignore node_modules

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,8 +3,6 @@ name: Pytest
 on:
   push:
     branches: ['**']
-  pull_request:
-    branches: ['**']
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,6 @@ name: Node.js CI
 on:
   push:
     branches: ['**']
-  pull_request:
-    branches: ['**']
 
 jobs:
   test:


### PR DESCRIPTION
- Added a new GitHub Action to lint Markdown files on every push.
- Updated existing Pytest and Node.js CI actions to run only on push, not on pull requests, to avoid duplicate runs.