### PR TITLE
feat: Add cautionary real-world examples to strategies

### DIFF
--- a/docs/strategies/accelerators/open-approaches/index.md
+++ b/docs/strategies/accelerators/open-approaches/index.md
@@ -57,6 +57,10 @@ Google released Android as open source, eliminating licensing fees and restricti
 
 Governments and organizations releasing open data sets, such as GPS signals, weather information, or public transport data, have enabled entire industries to emerge and thrive. For example, Transport for London (TfL) provides open APIs for real-time transit data, empowering developers to create journey planners, accessibility tools, and mobility apps. This has resulted in more innovation, ecosystem growth, and unlocked new business opportunities.
 
+### Cautionary Example: The Fragmentation of Android
+
+While Android's openness was a strategic success for Google, it also created significant challenges. The Android Open Source Project (AOSP) allowed any manufacturer to create their own version of the OS, leading to a fragmented ecosystem. This meant that apps might work on one manufacturer's phone but not another's, creating a poor experience for both users and developers. Google has tried to manage this with compatibility requirements for accessing its Play Store, but the underlying fragmentation remains a persistent issue, demonstrating that openness without strong governance can lead to chaos and a loss of strategic control.
+
 ## 🚦 **When to Use / When to Avoid**
 
 <Assessment strategyName="Open Approaches">

--- a/docs/strategies/decelerators/ipr/index.md
+++ b/docs/strategies/decelerators/ipr/index.md
@@ -59,6 +59,10 @@ Qualcomm’s extensive portfolio in 3G/4G standards forces device manufacturers 
 
 A startup patents a broad drone delivery mechanism covering general package drop-off techniques. Established logistics firms must negotiate licenses or delay their own R&D to avoid infringement.
 
+### Cautionary Example: SCO Group vs. Linux
+
+In the early 2000s, SCO Group launched a series of lawsuits against Linux users and vendors, claiming that Linux contained code that was stolen from SCO's proprietary version of Unix. The lawsuits were widely seen as an attack on the open-source community and created a great deal of fear, uncertainty, and doubt (FUD). Ultimately, SCO's claims were rejected by the courts, and the company went bankrupt. This example shows that an overly aggressive IPR strategy can backfire, leading to costly legal battles, reputational damage, and ultimately, failure.
+
 ## 🚦 **When to Use / When to Avoid**
 
 <Assessment strategyName="Patents & IPR">

--- a/docs/strategies/ecosystem/embrace-and-extend/index.md
+++ b/docs/strategies/ecosystem/embrace-and-extend/index.md
@@ -33,9 +33,13 @@ This is a high-risk strategy for companies with significant market power. The pr
 
 ## 🗺️ **Real-World Examples**
 
-### Microsoft and the Browser Wars
+### Success: Microsoft's Browser Wars
 
 The most famous (and infamous) example is Microsoft's strategy with Internet Explorer in the late 1990s. Microsoft **embraced** the open web standards of the time (HTML, CSS). They then **extended** these standards with proprietary features and tags (like `<marquee>`) that only worked in Internet Explorer. As IE's market share grew, web developers were forced to build sites that used these proprietary extensions, making them look broken in competing browsers like Netscape Navigator. This helped Microsoft **extinguish** Netscape and achieve a near-monopoly in the browser market.
+
+### Cautionary Example: The Aftermath of the Browser Wars
+
+While Microsoft's "embrace and extend" strategy was successful in winning the browser wars, it came at a high cost. The strategy led to a stagnant web, where innovation slowed for years. Developers were forced to build for a single, non-standard browser, and users were locked into a single ecosystem. This ultimately led to a massive antitrust lawsuit against Microsoft, which damaged the company's reputation and led to years of legal battles. This example shows that even a successful "embrace and extend" strategy can have significant negative consequences.
 
 ### Google's Use of Android
 

--- a/docs/strategies/positional/first-mover/index.md
+++ b/docs/strategies/positional/first-mover/index.md
@@ -48,6 +48,10 @@ Boeing was first to industrialise jet-powered commercial aircraft, establishing 
 
 An automotive company standardises electric vehicle battery modules, licensing the design to other manufacturers. By defining the architecture early, they capture manufacturing scale and ecosystem support.
 
+### Cautionary Example: Friendster
+
+Friendster was one of the first social networking sites and gained significant traction in the early 2000s. However, it was slow to innovate and failed to scale its infrastructure to meet demand. This created an opening for a "fast follower," Facebook, which learned from Friendster's mistakes, built a more stable platform, and ultimately dominated the market. This example shows that being a first mover is not enough; you must also be able to execute and adapt to maintain your lead.
+
 ## 🚦 **When to Use / When to Avoid**
 
 <Assessment strategyName="First Mover">

--- a/docs/strategies/user-perception/bundling/index.md
+++ b/docs/strategies/user-perception/bundling/index.md
@@ -32,6 +32,10 @@ Cable TV providers bundle less-popular channels with very popular ones in packag
 
 A SaaS software company needs to deprecate an old feature that some legacy customers still use. They release a new upgrade bundle: the old feature is removed, but the upgrade includes extra storage and a new AI tool at the same price. By **bundling improvements** with the removal of the old feature, they soften the blow and get customers to accept the change.
 
+### Cautionary Example: RealPlayer
+
+In the late 1990s, RealPlayer was a popular media player. However, it became infamous for bundling additional software, such as adware and browser toolbars, with its installer. Users who just wanted the media player found themselves with a host of unwanted and often malicious software. This created a strong negative perception of the brand and led many users to seek alternatives. This example shows that bundling can backfire if it is perceived as deceptive or harmful to the user.
+
 ## 🚦 **When to Use / When to Avoid**
 
 <Assessment strategyName="Bundling">


### PR DESCRIPTION
This commit adds cautionary real-world examples to a handful of strategies where a suitable one exists. This should help teach pitfalls beyond the theoretical.

The following strategies have been updated:

- `docs/strategies/accelerators/open-approaches/index.md`
- `docs/strategies/ecosystem/embrace-and-extend/index.md`
- `docs/strategies/positional/first-mover/index.md`
- `docs/strategies/user-perception/bundling/index.md`
- `docs/strategies/decelerators/ipr/index.md`