### PR TITLE
feat: Add dynamic SEO tags for better technical SEO

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -2,6 +2,7 @@ import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import storeSiteDataPlugin from './src/plugins/storeSiteData';
+import seoPlugin from './src/plugins/seoPlugin';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
@@ -216,7 +217,8 @@ const config: Config = {
   plugins: [
     require.resolve('docusaurus-lunr-search'),
     '@docusaurus/plugin-vercel-analytics',
-    storeSiteDataPlugin
+    storeSiteDataPlugin,
+    seoPlugin
   ],
 };
 

--- a/src/plugins/seoPlugin.ts
+++ b/src/plugins/seoPlugin.ts
@@ -1,0 +1,93 @@
+import fs from 'fs';
+import path from 'path';
+
+function getSeoTags({docPath, siteConfig}) {
+  const url = siteConfig.url;
+  const pageUrl = url + docPath;
+
+  if (!docPath) {
+    return [];
+  }
+
+  const docPathClean = docPath.startsWith('/') ? docPath.substring(1) : docPath;
+  let filePath = path.join('docs', docPathClean + '.md');
+
+  if(docPathClean.length === 0) {
+    filePath = path.join('docs', 'index.md');
+  } else if (!fs.existsSync(filePath)) {
+    filePath = path.join('docs', docPathClean, 'index.md');
+  }
+
+  console.log(`[getSeoTags] Processing ${filePath}`);
+
+  if (!fs.existsSync(filePath)) {
+    console.log(`[getSeoTags] File not found: ${filePath}`);
+    return [];
+  }
+
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const firstLine = content.split('\n')[0];
+  const description = firstLine.replace(/# /g, '');
+
+  return [
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'description',
+        content: description,
+      },
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'og:description',
+        content: description,
+      },
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'twitter:description',
+        content: description,
+      },
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'og:type',
+        content: 'website',
+      },
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'og:url',
+        content: pageUrl,
+      },
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'twitter:card',
+        content: 'summary_large_image',
+      },
+    },
+  ];
+}
+
+
+export default function (context, options) {
+  return {
+    name: 'seo-plugin',
+    injectHtmlTags({content, ...props}) {
+      const {routes, siteConfig} = props;
+      const currentRoute = routes.find(r => content.includes(r.path));
+      if (currentRoute) {
+        return {
+          headTags: getSeoTags({docPath: currentRoute.path, siteConfig}),
+        };
+      }
+      return {};
+    },
+  };
+}


### PR DESCRIPTION
This commit introduces a new Docusaurus plugin to dynamically generate SEO tags (meta description, Open Graph) for each page.

The plugin reads the first line of each Markdown file and uses it as the meta description. This avoids having to manually update all content files.

The following tags are now added to each page:
- `meta description`
- `og:description`
- `twitter:description`
- `og:type`
- `og:url`
- `twitter:card`

This change improves the technical SEO of the site without requiring manual content updates.