### PR TITLE
Add privacy policy

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -186,6 +186,10 @@ const config: Config = {
           title: 'More',
           items: [
             {
+              label: 'Privacy Policy',
+              to: '/privacy-policy',
+            },
+            {
               label: 'GitHub',
               href: 'https://github.com/dave1010/wardley-leadership-strategies',
             },

--- a/src/pages/privacy-policy.md
+++ b/src/pages/privacy-policy.md
@@ -1,0 +1,56 @@
+---
+title: Privacy Policy
+---
+
+# Privacy Policy
+
+_Last updated: 15 September 2025_
+
+Wardley Leadership Strategies is an informational site maintained by Dave Hulbert. It explains how to apply Wardley Mapping gameplays and related doctrine. The site does not offer user accounts, newsletters, or interactive services; visitors simply browse published guidance.
+
+## Information we collect
+
+### Site analytics
+
+We use privacy-focused [Vercel Analytics](https://vercel.com/docs/analytics) through our Docusaurus configuration to understand how people use the site. The service records page views, referrers, approximate geolocation, device and browser details, and truncated IP addresses so that we can count unique visits and detect unusual traffic. The data is aggregated inside Vercel's infrastructure, and no cookies or cross-site tracking identifiers are set.
+
+### Hosting logs
+
+The site is hosted on Vercel. Like most hosting providers, Vercel automatically keeps short-lived request logs that include your IP address, browser user agent, the pages you requested, and basic diagnostic details. These logs help keep the service reliable and secure (for example by diagnosing outages or abuse).
+
+### Third-party assets
+
+Pages load typefaces from Google Fonts. When your browser requests these files, Google receives your IP address and user agent to deliver the font files. Google may also log standard request metadata for operational purposes. No other third-party embeds or trackers run on the site.
+
+We do not collect contact information, payment details, or any other personal information directly.
+
+## How we use the information
+
+The information described above is used to:
+
+- monitor how many people are using the site and which pages are most helpful;
+- ensure the site stays fast, reliable, and secure; and
+- diagnose, investigate, or prevent abuse of the service.
+
+We process this data on the basis of our legitimate interest in operating and improving the site.
+
+## Sharing and storage
+
+Analytics data and server logs are stored within Vercel's systems. Aggregated reporting may be shared internally to guide content improvements, but raw data is not sold or shared with advertisers. Font files are delivered directly by Google, which receives standard web request metadata when fonts are loaded.
+
+## Retention
+
+Vercel Analytics keeps aggregated metrics so that we can view historical traffic trends. Vercel's infrastructure also retains request logs for a limited period aligned with their standard platform practices. We do not keep independent copies of these logs.
+
+## Cookies and tracking technologies
+
+The site does not set cookies or use device fingerprinting for tracking. Vercel Analytics operates without cookies, and Google Fonts only serves static assets.
+
+## Your choices
+
+Because we do not collect information directly, there is no account to delete or profile to update. You can control the data shared with us by using privacy tools such as VPNs or tracker-blocking browser extensions. If you disable external font loading in your browser, system fonts will be used instead.
+
+## Contact
+
+If you have questions about this policy or want to exercise privacy rights, contact Dave Hulbert using the details published at [dave.engineer](https://dave.engineer) or open an issue in the [GitHub repository](https://github.com/dave1010/wardley-leadership-strategies).
+


### PR DESCRIPTION
## Summary
- add a standalone privacy policy page that documents analytics, hosting logs, and third-party assets
- link the privacy policy from the site footer for easy discovery

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c895228268832b8068d66ba6fb7329