### PR TITLE
Expand books section and guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,14 @@ The `## 🧠 **Strategic Insights**` section of a strategy is where the big idea
 - Link to a strategy only if it is *very* relevant
 - Link to other terms only if it is *very* relevant: `[Foo](/terms/foo)`
 
+## Books
+
+- Books capture sources that are referenced by strategies or terms. Focus on works that are cited multiple times or provide foundational context.
+- Book pages live in `./docs/books/<book-name>.md` and the H1 should match the book title.
+- Start with 1-2 short paragraphs that cover the subtitle (if useful), the author(s), and the key ideas readers should know. Only include details you can verify.
+- Add a `## Referenced in` section that lists internal links to every strategy or term that cites the book. Keep the list updated when adding new references elsewhere on the site.
+- When editing a strategy, prefer linking to the existing book page (eg `[Platform Revolution](/books/platform-revolution)`) instead of an external retailer or review. Create or update the book page first if it does not exist.
+
 
 ## Tone, Voice and Style
 

--- a/docs/books/blue-ocean-strategy.md
+++ b/docs/books/blue-ocean-strategy.md
@@ -1,0 +1,10 @@
+# Blue Ocean Strategy
+
+**Blue Ocean Strategy: How to Create Uncontested Market Space and Make the Competition Irrelevant** (2005) by W. Chan Kim and Renée Mauborgne outlines how companies can unlock new demand by redefining market boundaries.
+
+It introduces tools such as the Value Innovation concept, the Strategy Canvas, and the Four Actions Framework to help leaders identify noncustomers, reshape offerings, and sustain differentiation without competing head-to-head.
+
+## Referenced in
+
+- [Differentiation](/strategies/markets/differentiation)
+- [Designed to Fail](/strategies/poison/designed-to-fail)

--- a/docs/books/index.md
+++ b/docs/books/index.md
@@ -1,7 +1,9 @@
-import DocCardList from '@theme/DocCardList';
-
 # Books
 
 This section contains a list of books referenced throughout the site.
 
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
 <DocCardList />
+```

--- a/docs/books/platform-revolution.md
+++ b/docs/books/platform-revolution.md
@@ -1,0 +1,12 @@
+# Platform Revolution
+
+**Platform Revolution: How Networked Markets Are Transforming the Economy—and How to Make Them Work for You** (2016) by Geoffrey G. Parker, Marshall W. Van Alstyne, and Sangeet Paul Choudary explores how platform businesses orchestrate interactions between producers and consumers.
+
+The book explains key concepts such as network effects, governance rules, and pricing strategies that help platforms ignite and scale. It provides practical frameworks for launching, growing, and monetizing platform ecosystems across industries.
+
+## Referenced in
+
+- [Harvesting](/strategies/markets/harvesting)
+- [Two-Factor Markets](/strategies/ecosystem/two-factor-markets)
+- [Market Enablement](/strategies/accelerators/market-enablement)
+- [Value Chain Disaggregation and Re-aggregation](/strategies/dealing-with-toxicity/value-chain-disaggregation-and-re-aggregation)

--- a/docs/books/the-art-of-war.md
+++ b/docs/books/the-art-of-war.md
@@ -2,7 +2,7 @@
 
 **The Art of War** is an ancient Chinese military treatise attributed to Sun Tzu.
 
-It is a classic text on strategy, with timeless insights on the importance of surprise and deception.
+Composed around the 5th century BCE, its 13 chapters cover planning, leadership, intelligence, deception, and the use of terrain. The principles have been applied beyond warfare to business competition, negotiations, and organisational strategy, emphasising the value of preparation and adaptability.
 
 ## Referenced in
 

--- a/docs/books/the-business-of-platforms.md
+++ b/docs/books/the-business-of-platforms.md
@@ -1,0 +1,10 @@
+# The Business of Platforms
+
+**The Business of Platforms: Strategy in the Age of Digital Competition, Innovation, and Power** (2019) by Michael A. Cusumano, Annabelle Gawer, and David B. Yoffie examines how platform companies compete, collaborate, and evolve.
+
+It contrasts transaction, innovation, and hybrid platforms, highlighting governance choices, ecosystem risks, and regulatory considerations that determine whether platforms achieve durable advantage or stall.
+
+## Referenced in
+
+- [Harvesting](/strategies/markets/harvesting)
+- [Platform Envelopment](/strategies/ecosystem/platform-envelopment)

--- a/docs/books/the-innovators-dilemma.md
+++ b/docs/books/the-innovators-dilemma.md
@@ -2,7 +2,7 @@
 
 **The Innovator's Dilemma: When New Technologies Cause Great Firms to Fail** is a book by Clayton M. Christensen.
 
-It provides the theoretical framework for understanding how disruptive challengers can attack and defeat established incumbents.
+It introduced the theory of disruptive innovation, explaining how technologies that start out as simpler, cheaper, or lower-performing alternatives can upend industry leaders. Christensen distinguishes sustaining innovations from disruptive ones and advocates for creating autonomous teams to explore disruptive opportunities before competitors do.
 
 ## Referenced in
 

--- a/docs/strategies/accelerators/market-enablement/index.md
+++ b/docs/strategies/accelerators/market-enablement/index.md
@@ -246,4 +246,4 @@ The degree of "openness" (e.g., open standards, open source, open data) is a cri
 ## 📚 **Further Reading & References**
 
 - *"The Innovator's Dilemma"* by Clayton M. Christensen - While not directly about market enablement, this book provides deep insights into how markets evolve and how incumbents can be disrupted, which is relevant context for why and how one might enable new markets.
-- *["Platform Revolution: How Networked Markets Are Transforming the Economy—and How to Make Them Work for You"](https://www.amazon.co.uk/Platform-Revolution-Networked-Transforming-Economy/dp/0393249131)* by Geoffrey G. Parker, Marshall W. Van Alstyne, and Sangeet Paul Choudary - Explores the dynamics of platform business models, many of which rely on enabling an ecosystem of producers and consumers.
+- **[Platform Revolution](/books/platform-revolution)** by Geoffrey G. Parker, Marshall W. Van Alstyne, and Sangeet Paul Choudary - Explores the dynamics of platform business models, many of which rely on enabling an ecosystem of producers and consumers.

--- a/docs/strategies/dealing-with-toxicity/value-chain-disaggregation-and-re-aggregation/index.md
+++ b/docs/strategies/dealing-with-toxicity/value-chain-disaggregation-and-re-aggregation/index.md
@@ -226,7 +226,7 @@ This strategy can fundamentally alter the competitive landscape. It can lower ba
 
 - *"Unbundling the Corporation"* by John Hagel and Marc Singer (Harvard Business Review, 1999) - A foundational article on the concept of disaggregating corporate functions.
 - *"The Wide Lens: A New Strategy for Innovation"* by Ron Adner - Discusses innovation ecosystems and the importance of managing dependencies beyond your own organization, relevant to re-aggregation.
-- *"Platform Revolution: How Networked Markets Are Transforming the Economy—and How to Make Them Work for You"* by Geoffrey G. Parker, Marshall W. Van Alstyne, and Sangeet Paul Choudary - Explores the rise of platform business models, often an outcome of value chain re-aggregation.
+- **[Platform Revolution](/books/platform-revolution)** by Geoffrey G. Parker, Marshall W. Van Alstyne, and Sangeet Paul Choudary - Explores the rise of platform business models, often an outcome of value chain re-aggregation.
 - Various industry reports on Telco Disaggregation, Open Banking (FinTech), and the changing Media landscape provide practical examples.
 
 ---

--- a/docs/strategies/ecosystem/platform-envelopment/index.md
+++ b/docs/strategies/ecosystem/platform-envelopment/index.md
@@ -205,7 +205,7 @@ Platforms often start open to attract users and developers, then selectively clo
 ## 📚 **Further Reading & References**
 
 * **[Platform Competition: Envelopment Strategies](https://www.jstor.org/stable/41261793)** by Thomas R. Eisenmann, Geoffrey Parker, and Marshall W. Van Alstyne - A foundational academic paper on platform envelopment. (Note: Access may require subscription or purchase).
-* **[The Business of Platforms: Strategy in the Age of Digital Competition, Innovation, and Power](https://www.hbs.edu/faculty/Pages/item.aspx?num=56021)** by Michael A. Cusumano, Annabelle Gawer, and David B. Yoffie - Discusses platform strategies, including envelopment.
+* **[The Business of Platforms](/books/the-business-of-platforms)** by Michael A. Cusumano, Annabelle Gawer, and David B. Yoffie - Discusses platform strategies, including envelopment.
 * **[WeChat's World](https://www.economist.com/business/2016/08/06/wechats-world)** by The Economist - An article describing the breadth of WeChat's platform and its envelopment of various services.
 * **[Aggregators and Platforms: A Strategic Analysis](https://stratechery.com/2015/aggregation-theory/)** by Ben Thompson (Stratechery) - While not solely about envelopment, discusses platform power and dynamics relevant to this strategy.
 

--- a/docs/strategies/ecosystem/two-factor-markets/index.md
+++ b/docs/strategies/ecosystem/two-factor-markets/index.md
@@ -163,6 +163,6 @@ In a two-sided market, your product is not just a piece of software; it is the e
 
 ## 📚 **Further Reading & References**
 
-- **[Platform Revolution](https://www.goodreads.com/book/show/26899832-platform-revolution)** by Geoffrey G. Parker, Marshall W. Van Alstyne, and Sangeet Paul Choudary. The definitive guide to platform business models.
+- **[Platform Revolution](/books/platform-revolution)** by Geoffrey G. Parker, Marshall W. Van Alstyne, and Sangeet Paul Choudary. The definitive guide to platform business models.
 - **[The Cold Start Problem](https://www.goodreads.com/book/show/56223994-the-cold-start-problem)** by Andrew Chen. A deep dive into how to launch and scale network effects.
 - **[Modern Monopolies](https://www.goodreads.com/book/show/26245217-modern-monopolies)** by Alex Moazed and Nicholas L. Johnson. An analysis of the platform business model and its impact on the economy.

--- a/docs/strategies/markets/differentiation/index.md
+++ b/docs/strategies/markets/differentiation/index.md
@@ -158,6 +158,6 @@ Differentiation is useless if customers don't know about it or don't understand 
 
 ## 📚 **Further Reading & References**
 
-- **[Blue Ocean Strategy](https://www.goodreads.com/book/show/4892.Blue_Ocean_Strategy)** by W. Chan Kim and Renée Mauborgne. A classic book on creating uncontested market space.
+- **[Blue Ocean Strategy](/books/blue-ocean-strategy)** by W. Chan Kim and Renée Mauborgne. A classic book on creating uncontested market space.
 - **[Differentiate or Die](https://www.goodreads.com/book/show/13339.Differentiate_or_Die)** by Jack Trout and Steve Rivkin. A practical guide to the principles of differentiation.
 - **[Obviously Awesome](https://www.goodreads.com/book/show/44232216-obviously-awesome)** by April Dunford. A book focused on positioning, which is the art of communicating differentiation.

--- a/docs/strategies/markets/harvesting/index.md
+++ b/docs/strategies/markets/harvesting/index.md
@@ -164,5 +164,5 @@ At its best, harvesting is a symbiotic relationship. The ecosystem provides inno
 
 ## 📚 **Further Reading & References**
 
-- **[Platform Revolution](https://www.goodreads.com/book/show/26899832-platform-revolution)** by Geoffrey G. Parker, Marshall W. Van Alstyne, and Sangeet Paul Choudary. A comprehensive guide to platform business models.
-- **[The Business of Platforms](https://www.goodreads.com/book/show/43688225-the-business-of-platforms)** by Michael A. Cusumano, Annabelle Gawer, and David B. Yoffie. Explores the strategies of platform companies.
+- **[Platform Revolution](/books/platform-revolution)** by Geoffrey G. Parker, Marshall W. Van Alstyne, and Sangeet Paul Choudary. A comprehensive guide to platform business models.
+- **[The Business of Platforms](/books/the-business-of-platforms)** by Michael A. Cusumano, Annabelle Gawer, and David B. Yoffie. Explores the strategies of platform companies.

--- a/docs/strategies/poison/designed-to-fail/index.md
+++ b/docs/strategies/poison/designed-to-fail/index.md
@@ -181,4 +181,4 @@ These initiatives are not meant to last. Their purpose is to occupy space, creat
 
 - [HD DVD vs Blu-ray (Wikipedia)](https://en.wikipedia.org/wiki/HD_DVD) — a case of market fragmentation leading to failure.
 - [Betamax vs VHS (Wikipedia)](https://en.wikipedia.org/wiki/Betamax) — example of proprietary format wars.
-- *Blue Ocean Strategy* (W. Chan Kim & Renée Mauborgne) — insights into creating and defending market spaces.
+- **[Blue Ocean Strategy](/books/blue-ocean-strategy)** by W. Chan Kim and Renée Mauborgne — insights into creating and defending market spaces.

--- a/docs/terms/index.md
+++ b/docs/terms/index.md
@@ -1,3 +1,9 @@
 # Terms
 
 This section contains a list of terms referenced throughout the site.
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```


### PR DESCRIPTION
## Summary
- add book pages for Platform Revolution, The Business of Platforms, and Blue Ocean Strategy while enriching existing entries
- point strategy references to the new book pages and restore the DocCardList-driven index pages
- extend contributing guidelines with expectations for maintaining the growing books catalogue

## Testing
- npm run lint:md:fix
- python -m pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68c89b75c26c832ba403aee09dfa0f3d