### PR TITLE
Add book pages for linked references

### DIFF
--- a/docs/books/bell-labs-life-in-the-crown-jewel.md
+++ b/docs/books/bell-labs-life-in-the-crown-jewel.md
@@ -1,0 +1,9 @@
+# Bell Labs: Life in the Crown Jewel
+
+Narain Gehani's **Bell Labs: Life in the Crown Jewel** offers an insider's account of Bell Laboratories during its most productive decades. It recounts the culture, research programmes, and management systems that supported breakthroughs such as the transistor, information theory, and satellite communications.
+
+Gehani highlights how Bell Labs balanced long-term research with product delivery, detailing funding models, talent practices, and collaboration structures. The book is a useful reference for organisations considering directed investment in advanced R&D.
+
+## Referenced in
+
+- [Directed Investment](/strategies/attacking/directed-investment)

--- a/docs/books/competition-demystified.md
+++ b/docs/books/competition-demystified.md
@@ -1,0 +1,9 @@
+# Competition Demystified
+
+**Competition Demystified** by Bruce C. Greenwald and Judd Kahn simplifies strategic analysis by focusing on competitive advantage and barriers to entry. The authors argue that most industries boil down to either localised monopolies or commodity competition, and they offer frameworks for identifying which applies to your situation.
+
+The book uses case studies to show how companies build sustainable advantages, when scale or network effects matter, and how to respond to entrants. It complements Wardley Mapping by grounding strategy decisions in structural economics.
+
+## Referenced in
+
+- [Last Man Standing](/strategies/markets/last-man-standing)

--- a/docs/books/competitive-strategy.md
+++ b/docs/books/competitive-strategy.md
@@ -1,0 +1,11 @@
+# Competitive Strategy
+
+Michael E. Porter's **Competitive Strategy: Techniques for Analyzing Industries and Competitors** (1980) introduced the Five Forces framework and generic strategies of cost leadership, differentiation, and focus. It equips leaders with analytical tools to evaluate industry structure, anticipate competitor moves, and understand how barriers to entry, supplier power, and substitutes shape profitability.
+
+Porter also explores strategic positioning, capacity expansion decisions, and how to respond to rivals across different competitive arenas. The book remains a foundational reference for crafting offensive and defensive plays in contested markets.
+
+## Referenced in
+
+- [Ambush](/strategies/competitor/ambush)
+- [Buyer-Supplier Power](/strategies/markets/buyer-supplier-power)
+- [Raising Barriers to Entry](/strategies/defensive/raising-barriers-to-entry)

--- a/docs/books/confessions-of-the-pricing-man.md
+++ b/docs/books/confessions-of-the-pricing-man.md
@@ -1,0 +1,9 @@
+# Confessions of the Pricing Man
+
+In **Confessions of the Pricing Man**, pricing expert Hermann Simon shares stories and frameworks from decades of advising companies on price strategy. He explains value-based pricing, price differentiation, and the psychology behind willingness to pay, illustrating concepts with real client engagements.
+
+Simon emphasises the organisational discipline required to implement pricing decisions, including governance, sales enablement, and measurement. The book is a practitioner’s guide to turning pricing into a growth lever rather than an afterthought.
+
+## Referenced in
+
+- [Pricing Policy](/strategies/markets/pricing-policy)

--- a/docs/books/differentiate-or-die.md
+++ b/docs/books/differentiate-or-die.md
@@ -1,0 +1,9 @@
+# Differentiate or Die
+
+**Differentiate or Die** by Jack Trout and Steve Rivkin focuses on positioning and the imperative to stand out in crowded markets. The authors outline techniques for carving a unique space in customers' minds, using examples across consumer goods, services, and B2B industries.
+
+They emphasise clarity of message, consistency, and aligning operations with the promised differentiation. The book helps strategists translate differentiation theory into practical brand and product choices.
+
+## Referenced in
+
+- [Differentiation](/strategies/markets/differentiation)

--- a/docs/books/dynamic-capabilities-and-strategic-management.md
+++ b/docs/books/dynamic-capabilities-and-strategic-management.md
@@ -1,0 +1,9 @@
+# Dynamic Capabilities and Strategic Management
+
+**Dynamic Capabilities and Strategic Management: Organizing for Innovation and Growth** by David J. Teece explores how firms sense opportunities, seize them, and reconfigure assets to stay competitive. Drawing on decades of research, Teece explains why advantage rests on organisational processes, knowledge integration, and the ability to realign resources as markets evolve.
+
+The book offers practical guidance on designing structures that foster agility—from governance models and incentive systems to partnering approaches. It is a foundational reference for leaders planning large investments and needing to balance exploration with operational discipline.
+
+## Referenced in
+
+- [Land Grab](/strategies/positional/land-grab)

--- a/docs/books/empowered.md
+++ b/docs/books/empowered.md
@@ -1,0 +1,9 @@
+# Empowered
+
+**Empowered** (2020) by Marty Cagan and Chris Jones outlines how technology organisations build empowered product teams. It emphasises outcome-focused missions, autonomous squads, and product leadership that provides vision, coaching, and guardrails rather than feature roadmaps.
+
+The authors cover hiring, career paths, discovery practices, and the partnership between product management, design, and engineering. The book serves as a field guide for leaders seeking to create experimentation-driven cultures capable of rapidly iterating on customer problems.
+
+## Referenced in
+
+- [Experimentation](/strategies/attacking/experimentation)

--- a/docs/books/fast-second.md
+++ b/docs/books/fast-second.md
@@ -1,0 +1,9 @@
+# Fast Second
+
+**Fast Second: How Smart Companies Bypass Radical Innovation to Enter and Dominate New Markets** by Constantinos C. Markides and Paul A. Geroski studies companies that wait for pioneers to prove demand before entering aggressively. It argues that second movers can scale faster by leveraging superior assets, distribution, and timing once uncertainty drops.
+
+The authors outline playbooks for spotting when to jump in, acquiring or partnering with pioneers, and designing organisational structures that support rapid follow-on execution. The book helps leaders balance patience with decisive action.
+
+## Referenced in
+
+- [Procrastination](/strategies/defensive/procrastination)

--- a/docs/books/influence-the-psychology-of-persuasion.md
+++ b/docs/books/influence-the-psychology-of-persuasion.md
@@ -1,0 +1,9 @@
+# Influence: The Psychology of Persuasion
+
+Robert B. Cialdini's **Influence: The Psychology of Persuasion** distils decades of social psychology research into six principles—reciprocity, commitment, social proof, authority, liking, and scarcity—that explain how people are persuaded. The book uses experiments and real-world stories to reveal how subtle cues shape behaviour.
+
+Cialdini also offers defensive guidance on recognising manipulative tactics and designing ethical influence programmes. For strategists, the work clarifies how narratives and framing can insert ideas into competitors or markets without overt confrontation.
+
+## Referenced in
+
+- [Insertion](/strategies/poison/insertion)

--- a/docs/books/judo-strategy.md
+++ b/docs/books/judo-strategy.md
@@ -1,0 +1,9 @@
+# Judo Strategy
+
+In **Judo Strategy**, David B. Yoffie and Mary Kwak analyse how smaller companies can exploit the strength and momentum of incumbents. Using martial arts metaphors and business cases (such as Netscape vs. Microsoft), they describe tactics for rapid movement, leverage, and balance that let challengers turn a giant's size into a liability.
+
+The book covers moves like building alliances, shaping standards, and attacking under-served niches before incumbents can react. It is a tactical manual for entrants attempting to undermine barriers without direct confrontation.
+
+## Referenced in
+
+- [Undermining Barriers to Entry](/strategies/attacking/undermining-barriers-to-entry)

--- a/docs/books/leading-change.md
+++ b/docs/books/leading-change.md
@@ -1,0 +1,9 @@
+# Leading Change
+
+In **Leading Change**, John P. Kotter presents an eight-step model for delivering successful organisational transformations. The book emphasises establishing urgency, forming guiding coalitions, crafting vision, communicating for buy-in, empowering action, generating wins, consolidating gains, and anchoring new approaches in culture.
+
+Kotter draws on corporate case studies to show why change programmes stall when leaders skip steps or under-invest in communication. It remains a core reference for executives tackling inertia and building momentum for large-scale change initiatives.
+
+## Referenced in
+
+- [Managing Inertia](/strategies/defensive/managing-inertia)

--- a/docs/books/made-by-customers.md
+++ b/docs/books/made-by-customers.md
@@ -1,0 +1,9 @@
+# Made by Customers
+
+In **Made by Customers: The New Revolution in Creating and Marketing Products**, Stefan Thomke and Eric von Hippel explore how companies harness user innovation. The authors show how customer toolkits, lead-user programmes, and feedback loops let organisations co-design offerings that better meet emerging needs.
+
+The book highlights examples from manufacturing, software, and consumer goods to illustrate how democratised innovation reshapes R&D and marketing processes. It is a helpful reference for teams building co-creation initiatives or community-led product development.
+
+## Referenced in
+
+- [Co-Creation](/strategies/ecosystem/co-creation)

--- a/docs/books/mergers-and-acquisitions-for-dummies.md
+++ b/docs/books/mergers-and-acquisitions-for-dummies.md
@@ -1,0 +1,9 @@
+# Mergers & Acquisitions For Dummies
+
+Bill Snow's **Mergers & Acquisitions For Dummies** is a practical guide to planning, valuing, and closing M&A deals. It explains the roles of advisors, due diligence workflows, financing structures, and negotiation tactics from both buy-side and sell-side perspectives.
+
+The book provides checklists and plain-language explanations that help executives understand deal timelines, integration risks, and regulatory considerations. It is a useful primer for teams evaluating threat acquisitions or other defensive transactions.
+
+## Referenced in
+
+- [Threat Acquisition](/strategies/defensive/threat-acquisition)

--- a/docs/books/modern-monopolies.md
+++ b/docs/books/modern-monopolies.md
@@ -1,0 +1,9 @@
+# Modern Monopolies
+
+In **Modern Monopolies**, Alex Moazed and Nicholas L. Johnson examine how platform businesses create and capture value. They explain the economics of multi-sided markets, network effects, and data-driven feedback loops that allow platform companies to outpace traditional linear businesses.
+
+The authors provide case studies from technology, retail, and transportation, outlining strategies for launching platforms, governing ecosystems, and monetising participation. The book is a field guide for leaders building or competing with platform monopolies.
+
+## Referenced in
+
+- [Two-Factor Markets](/strategies/ecosystem/two-factor-markets)

--- a/docs/books/monetizing-innovation.md
+++ b/docs/books/monetizing-innovation.md
@@ -1,0 +1,9 @@
+# Monetizing Innovation
+
+**Monetizing Innovation** by Madhavan Ramanujam and Georg Tacke focuses on integrating pricing into product innovation. The authors describe how to test willingness to pay early, design offers around monetisation models, and avoid common traps like feature bloat or underpricing breakthroughs.
+
+They provide case studies and interviews showing how companies align product management, marketing, and finance around pricing hypotheses. The book delivers practical tools for building pricing experiments into the product development lifecycle.
+
+## Referenced in
+
+- [Pricing Policy](/strategies/markets/pricing-policy)

--- a/docs/books/obviously-awesome.md
+++ b/docs/books/obviously-awesome.md
@@ -1,0 +1,9 @@
+# Obviously Awesome
+
+April Dunford's **Obviously Awesome** provides a step-by-step positioning process for technology products. It guides teams through identifying competitive alternatives, isolating unique attributes, mapping true value, and defining customer segments that care most about that value.
+
+Dunford includes worksheets and real examples that show how to craft messaging, choose market categories, and align go-to-market execution. The book is a practical resource for teams working on differentiation and product storytelling.
+
+## Referenced in
+
+- [Differentiation](/strategies/markets/differentiation)

--- a/docs/books/platforms-markets-and-innovation.md
+++ b/docs/books/platforms-markets-and-innovation.md
@@ -1,0 +1,10 @@
+# Platforms, Markets and Innovation
+
+**Platforms, Markets and Innovation** (2009) edited by Annabelle Gawer examines how platform leaders orchestrate ecosystems of complementors. The collection analyses case studies such as Intel, Microsoft, and mobile telecoms to explain how modular architectures, governance choices, and standards battles shape competitive outcomes.
+
+The book highlights strategic levers platform owners use to encourage innovation—ranging from openness policies to API design, pricing, and developer incentives. It provides practical insight into how platform firms balance control with participation and how rivals can challenge an incumbent platform.
+
+## Referenced in
+
+- [First Mover](/strategies/positional/first-mover)
+- [Land Grab](/strategies/positional/land-grab)

--- a/docs/books/priceless-the-myth-of-fair-value.md
+++ b/docs/books/priceless-the-myth-of-fair-value.md
@@ -1,0 +1,9 @@
+# Priceless: The Myth of Fair Value
+
+William Poundstone's **Priceless: The Myth of Fair Value (and How to Take Advantage of It)** explores behavioural pricing and why perceptions of fairness shape buying decisions. Drawing on experiments in psychology and behavioural economics, it demonstrates anchoring, decoy pricing, and other techniques that influence willingness to pay.
+
+The book helps strategists understand how framing, context, and small design choices affect price acceptance. It is particularly useful for teams aligning pricing policy with user perception dynamics.
+
+## Referenced in
+
+- [Pricing Policy](/strategies/markets/pricing-policy)

--- a/docs/books/seeing-like-a-state.md
+++ b/docs/books/seeing-like-a-state.md
@@ -1,0 +1,9 @@
+# Seeing Like a State
+
+James C. Scott's **Seeing Like a State** critiques high-modernist planning and the tendency of large institutions to impose simplified schemes on complex societies. Through historical case studies, Scott shows how top-down standardisation can erase local knowledge and provoke resistance.
+
+The book highlights the importance of legibility, incentives, and the messy reality of implementation. Its insights help strategists understand how dominant organisations co-opt local practices or why centralised initiatives often clash with grassroots dynamics.
+
+## Referenced in
+
+- [Co-opting](/strategies/ecosystem/co-opting)

--- a/docs/books/strategic-management-of-technological-innovation.md
+++ b/docs/books/strategic-management-of-technological-innovation.md
@@ -1,0 +1,10 @@
+# Strategic Management of Technological Innovation
+
+Melissa A. Schilling's **Strategic Management of Technological Innovation** provides a comprehensive framework for managing innovation portfolios. The text explores technology S-curves, dominant design emergence, innovation diffusion, and the organisational structures required to shepherd ideas from research through commercialisation.
+
+Schilling blends academic research with corporate case studies, showing how firms evaluate timing, invest in complementary assets, and orchestrate partnerships. It is a practical reference for leaders deciding when to pioneer, how to scale, and how to build capabilities that keep innovation pipelines healthy.
+
+## Referenced in
+
+- [First Mover](/strategies/positional/first-mover)
+- [Land Grab](/strategies/positional/land-grab)

--- a/docs/books/the-art-of-deception.md
+++ b/docs/books/the-art-of-deception.md
@@ -1,0 +1,9 @@
+# The Art of Deception
+
+**The Art of Deception** by Kevin D. Mitnick and William L. Simon chronicles social engineering attacks and the psychology behind them. Through case studies, it explains how attackers exploit trust, authority, and urgency to persuade people into revealing secrets or granting access to systems.
+
+The authors provide defensive practices—policy design, awareness training, verification procedures—that reduce exposure to manipulation. The book is essential context for strategies that rely on planting narratives or exploiting human factors as part of competitive play.
+
+## Referenced in
+
+- [Insertion](/strategies/poison/insertion)

--- a/docs/books/the-business-of-america-is-lobbying.md
+++ b/docs/books/the-business-of-america-is-lobbying.md
@@ -1,0 +1,9 @@
+# The Business of America is Lobbying
+
+Lee Drutman's **The Business of America is Lobbying** analyses how corporate lobbying became a permanent part of the U.S. political system. It traces the growth of influence campaigns, the economics of lobbying firms, and why companies build in-house public affairs capabilities.
+
+Drutman explains how lobbying strategies shape regulation, framing it as a long-term investment rather than episodic activity. The book provides data-driven insight for strategists assessing when regulatory plays can reinforce competitive positions.
+
+## Referenced in
+
+- [Defensive Regulation](/strategies/defensive/defensive-regulation)

--- a/docs/books/the-cold-start-problem.md
+++ b/docs/books/the-cold-start-problem.md
@@ -1,0 +1,9 @@
+# The Cold Start Problem
+
+Andrew Chen's **The Cold Start Problem** explains how to launch and scale network-effect businesses. Drawing on experiences from Uber and other tech companies, Chen describes the atomic networks that ignite growth, the roles of acquisition loops, engagement loops, and economics loops, and the tactics required to move from niche communities to mass-market platforms.
+
+The book offers practical playbooks for solving early liquidity challenges, designing onboarding that kick-starts interactions, and defending networks as they mature. It is essential reading for teams orchestrating two-sided markets.
+
+## Referenced in
+
+- [Two-Factor Markets](/strategies/ecosystem/two-factor-markets)

--- a/docs/books/the-direct-to-consumer-playbook.md
+++ b/docs/books/the-direct-to-consumer-playbook.md
@@ -1,0 +1,9 @@
+# The Direct-to-Consumer Playbook
+
+Mike Stevens' **The Direct-to-Consumer Playbook** distils lessons from building and advising DTC brands. It covers positioning, digital acquisition, subscription economics, and the operational foundations needed to serve customers directly without intermediaries.
+
+The book emphasises understanding unit economics, building community, and orchestrating fulfilment and customer service to support recurring relationships. It is a practical manual for leaders planning to bypass traditional channels and own the end-to-end customer experience.
+
+## Referenced in
+
+- [Channel Conflict and Disintermediation](/strategies/ecosystem/channel-conflict-and-disintermediation)

--- a/docs/books/the-everything-store.md
+++ b/docs/books/the-everything-store.md
@@ -1,0 +1,9 @@
+# The Everything Store
+
+Brad Stone's **The Everything Store: Jeff Bezos and the Age of Amazon** chronicles Amazon's rise from online bookstore to diversified platform. It details strategic choices around logistics, marketplace expansion, AWS, and the culture of relentless customer focus and frugality that underpinned growth.
+
+Stone provides insight into how Amazon manages supplier relationships, negotiates with partners, and leverages scale to influence entire ecosystems. The book is valuable for understanding buyer-supplier power dynamics and platform strategy execution.
+
+## Referenced in
+
+- [Buyer-Supplier Power](/strategies/markets/buyer-supplier-power)

--- a/docs/books/the-future-of-competition.md
+++ b/docs/books/the-future-of-competition.md
@@ -1,0 +1,9 @@
+# The Future of Competition
+
+C.K. Prahalad and Venkat Ramaswamy's **The Future of Competition: Co-Creating Unique Value with Customers** argues that value creation is shifting from firm-centric offerings to collaborative experiences. The authors illustrate how companies invite customers into design, production, and delivery, using dialogue, access, risk-benefits, and transparency as the DART model for co-creation.
+
+The book provides cases from industries such as automotive, consumer goods, and technology to show how co-creation reshapes business models and relationships. It offers a strategic blueprint for organisations that want to unlock value by partnering deeply with users.
+
+## Referenced in
+
+- [Co-Creation](/strategies/ecosystem/co-creation)

--- a/docs/books/the-goal.md
+++ b/docs/books/the-goal.md
@@ -1,0 +1,9 @@
+# The Goal
+
+**The Goal** by Eliyahu M. Goldratt and Jeff Cox is a business novel that introduces the Theory of Constraints. Through the story of a manufacturing plant manager, it explains how to identify bottlenecks, optimise flow, and align metrics with overall system throughput rather than local efficiencies.
+
+The book popularised concepts such as the five focusing steps and drum-buffer-rope scheduling. Its storytelling format makes complex operational ideas accessible, providing leaders with a vocabulary for diagnosing constraints and prioritising improvement work.
+
+## Referenced in
+
+- [Exploiting Constraint](/strategies/decelerators/exploiting-constraint)

--- a/docs/books/the-power-of-pull.md
+++ b/docs/books/the-power-of-pull.md
@@ -1,0 +1,9 @@
+# The Power of Pull
+
+In **The Power of Pull**, John Hagel III, John Seely Brown, and Lang Davison argue that advantage comes from attracting resources, talent, and ideas when needed rather than owning them outright. They describe how digital networks enable organisations to sense opportunities, mobilise ecosystems, and accelerate learning through open flows of knowledge.
+
+The book offers frameworks for cultivating edge initiatives, shaping serendipity, and designing platforms that draw participants into shared problem solving. It is especially relevant for leaders seeking to reposition the centre of gravity of an industry or build communities around their platforms.
+
+## Referenced in
+
+- [Centre of Gravity](/strategies/attacking/centre-of-gravity)

--- a/docs/books/the-strategy-and-tactics-of-pricing.md
+++ b/docs/books/the-strategy-and-tactics-of-pricing.md
@@ -1,0 +1,9 @@
+# The Strategy and Tactics of Pricing
+
+**The Strategy and Tactics of Pricing** by Thomas T. Nagle, John Hogan, and Joseph Zale offers a structured approach to building and executing pricing strategies. It covers economic foundations, value-based pricing, segmentation, and the organisational processes required to align sales and product teams around price realisation.
+
+The book emphasises practical tools such as price waterfalls, willingness-to-pay analysis, and packaging design. It is widely used by pricing leaders who need to craft bundles, manage discounting discipline, and translate positioning into profitable offers.
+
+## Referenced in
+
+- [Bundling](/strategies/user-perception/bundling)

--- a/docs/books/thinking-fast-and-slow.md
+++ b/docs/books/thinking-fast-and-slow.md
@@ -1,0 +1,9 @@
+# Thinking, Fast and Slow
+
+**Thinking, Fast and Slow** (2011) by Daniel Kahneman synthesises behavioural economics research on how people make judgements under uncertainty. It introduces the dual-system model—fast, intuitive "System 1" thinking and slower, analytical "System 2" reasoning—and shows how cognitive shortcuts shape perception, probability assessments, and risk appetite.
+
+Kahneman outlines biases such as anchoring, availability, and loss aversion, explaining why even experts misread weak signals or overweight recent information. The book offers guidance on structuring decisions, stress-testing assumptions, and building processes that counteract mental shortcuts when stakes are high.
+
+## Referenced in
+
+- [Weak Signal (Horizon)](/strategies/positional/weak-signal-horizon)

--- a/docs/books/thinking-in-bets.md
+++ b/docs/books/thinking-in-bets.md
@@ -1,0 +1,9 @@
+# Thinking in Bets
+
+In **Thinking in Bets**, former professional poker player Annie Duke explains how to make better decisions under uncertainty. She introduces concepts such as resulting, probabilistic thinking, and decision accountability groups to help leaders separate decision quality from outcomes.
+
+The book provides techniques for constructing scenarios, updating beliefs as new information arrives, and communicating uncertainty without paralysing teams. It is relevant for strategic plays that require timing and judgement in ambiguous environments.
+
+## Referenced in
+
+- [Ambush](/strategies/competitor/ambush)

--- a/docs/books/trust-me-im-lying.md
+++ b/docs/books/trust-me-im-lying.md
@@ -1,0 +1,9 @@
+# Trust Me, I'm Lying
+
+In **Trust Me, I'm Lying: Confessions of a Media Manipulator**, Ryan Holiday reveals how modern media incentives can be gamed. Drawing on his experience running marketing stunts, he explains how to seed stories in blogs, manufacture outrage, and exploit the viral news cycle.
+
+Holiday also warns about the societal costs of these tactics, showing how misinformation cascades through loosely fact-checked networks. The book is a cautionary manual for anyone considering or countering signal distortion campaigns.
+
+## Referenced in
+
+- [Signal Distortion](/strategies/markets/signal-distortion)

--- a/docs/books/unlocking-the-customer-value-chain.md
+++ b/docs/books/unlocking-the-customer-value-chain.md
@@ -1,0 +1,9 @@
+# Unlocking the Customer Value Chain
+
+**Unlocking the Customer Value Chain** by Thales S. Teixeira with Greg Piechota explains how disruptive companies decouple stages of the customer journey to win share. Drawing on academic research and case studies (including Amazon, Warby Parker, and Airbnb), it shows how startups exploit friction points in incumbent value chains and then re-bundle services on their own platforms.
+
+The book provides a framework for mapping customer activities, spotting where value can be captured, and sequencing moves from entry to full platform plays. It is especially useful for strategists evaluating disintermediation or direct-to-consumer shifts.
+
+## Referenced in
+
+- [Channel Conflict and Disintermediation](/strategies/ecosystem/channel-conflict-and-disintermediation)

--- a/docs/books/who-says-elephants-cant-dance.md
+++ b/docs/books/who-says-elephants-cant-dance.md
@@ -1,0 +1,9 @@
+# Who Says Elephants Can't Dance?
+
+**Who Says Elephants Can't Dance?** is Louis V. Gerstner Jr.'s memoir of leading IBM's turnaround in the 1990s. He recounts how the company shifted from a hardware-centric culture to a services-led organisation, describing decisions on cost restructuring, cultural change, and market focus.
+
+Gerstner highlights the importance of confronting reality, aligning incentives, and sustaining momentum amid deep-seated inertia. The narrative offers practical lessons for leaders tasked with reshaping large, legacy enterprises.
+
+## Referenced in
+
+- [Managing Inertia](/strategies/defensive/managing-inertia)

--- a/docs/books/working-backwards.md
+++ b/docs/books/working-backwards.md
@@ -1,0 +1,9 @@
+# Working Backwards
+
+**Working Backwards** by Colin Bryar and Bill Carr documents Amazon's leadership principles and product development mechanisms. It details practices like the PR/FAQ process, single-threaded leadership, and metrics-driven operational excellence that enable teams to start with customer outcomes and iterate toward launch.
+
+The book combines anecdotes from Amazon's growth with guidance on how to adopt the mechanisms in other organisations. It stresses writing-driven decision making, rigorous input metrics, and mechanisms for scaling experimentation while preserving customer obsession.
+
+## Referenced in
+
+- [Press Release Process](/strategies/attacking/press-release-process)

--- a/docs/strategies/attacking/centre-of-gravity/index.md
+++ b/docs/strategies/attacking/centre-of-gravity/index.md
@@ -190,5 +190,5 @@ This kind of cultural or visionary gravity is harder to replicate or fight. It�
 ## 📚 **Further Reading & References**
 
 - [Clusters and the New Economics of Competition (Michael Porter, HBR)](https://hbr.org/1998/11/clusters-and-the-new-economics-of-competition) – The foundational theory of economic clusters and competitive advantage.
-- [The Power of Pull (John Hagel et al.)](https://www.amazon.co.uk/Power-Pull-John-Hagel/dp/0465019358) – Explores how pull strategies shape talent and innovation ecosystems.
+- [The Power of Pull (John Hagel et al.)](/books/the-power-of-pull) – Explores how pull strategies shape talent and innovation ecosystems.
 - [Critical Mass](/terms/critical-mass) – The tipping point at which a center of gravity becomes self-sustaining.

--- a/docs/strategies/attacking/directed-investment/index.md
+++ b/docs/strategies/attacking/directed-investment/index.md
@@ -191,4 +191,4 @@ Directed investment can shift the centre of gravity in a value chain, attracting
 - [The Innovator's Dilemma (Christensen)](https://en.wikipedia.org/wiki/The_Innovator%27s_Dilemma) – Explores why established organisations struggle with disruptive innovation and the need for separate, focused investments.
 - [Corporate Venturing: Managing the Innovation Family](https://www.strategy-business.com/article/03408) – On structuring and managing internal ventures.
 - [Google DeepMind: The Story Behind the World's Leading AI Startup](https://www.techadvisor.com/article/738778/google-deepmind-the-story-behind-the-worlds-leading-ai-startup.html) – Case study of Google's directed investment in AI.
-- [Bell Labs: Life in the Crown Jewel](https://books.google.co.uk/books/about/Bell_Labs.html?id=3vpSAAAAMAAJ&redir_esc=y) by Narain Gehani, Silicon Press, 2002 – The story of AT&T's legendary R&D investment.
+- [Bell Labs: Life in the Crown Jewel](/books/bell-labs-life-in-the-crown-jewel) by Narain Gehani, Silicon Press, 2002 – The story of AT&T's legendary R&D investment.

--- a/docs/strategies/attacking/experimentation/index.md
+++ b/docs/strategies/attacking/experimentation/index.md
@@ -195,6 +195,6 @@ Experiments often reveal new dependencies or bottlenecks early, letting you shap
 
 - Simon Wardley – *"Use of specialists groups, hackdays and other mechanisms of experimentation."*
 - [Empowered Product Teams](https://www.svpg.com/empowered-product-teams/) – Article by Marty Cagan on enabling autonomy.
-- [Empowered](https://www.amazon.com/gp/product/1119387507) – Book expanding on how to build empowered teams.
+- [Empowered](/books/empowered) – Book expanding on how to build empowered teams.
 - [Google's 20% Time](https://www.wired.com/2013/08/20-percent-time-will-never-die/) – How giving employees space to experiment led to products like Gmail.
 - [Skunk Works](https://www.lockheedmartin.com/en-us/who-we-are/business-areas/aeronautics/skunkworks.html) – Official history and lessons from Lockheed's experimental team.

--- a/docs/strategies/attacking/press-release-process/index.md
+++ b/docs/strategies/attacking/press-release-process/index.md
@@ -209,4 +209,4 @@ A press release that reads as weak or incoherent is a fast signal of strategic u
 
 ## 📚 **Further Reading & References**
 
-- [Working Backwards](https://www.amazon.com/Working-Backwards-Insights-Stories-Secrets/dp/1250267595) - Details Amazon's methodology.
+- [Working Backwards](/books/working-backwards) - Details Amazon's methodology.

--- a/docs/strategies/attacking/undermining-barriers-to-entry/index.md
+++ b/docs/strategies/attacking/undermining-barriers-to-entry/index.md
@@ -148,4 +148,4 @@ Open-sourcing a key technology is one of the most powerful ways to undermine a b
 ## 📚 **Further Reading & References**
 
 - **[The Innovator's Dilemma](/books/the-innovators-dilemma)** by Clayton M. Christensen. Provides the theoretical framework for understanding how disruptive challengers can attack and defeat established incumbents.
-- **[Judo Strategy](https://www.goodreads.com/book/show/236922.Judo_Strategy)** by David B. Yoffie and Mary Kwak. A book focused on how smaller players can use an incumbent's weight and strength against them.
+- **[Judo Strategy](/books/judo-strategy)** by David B. Yoffie and Mary Kwak. A book focused on how smaller players can use an incumbent's weight and strength against them.

--- a/docs/strategies/competitor/ambush/index.md
+++ b/docs/strategies/competitor/ambush/index.md
@@ -202,5 +202,5 @@ An Ambush is an overtly aggressive move, and it can easily lead to an all-out wa
 ## 📚 **Further Reading & References**
 
 * [The Art of War](/books/the-art-of-war) by Sun Tzu - Provides timeless wisdom on surprise, timing, and knowing your enemy, all crucial for Ambush strategies.
-* [Competitive Strategy: Techniques for Analyzing Industries and Competitors](https://www.goodreads.com/book/show/309100.Competitive_Strategy) by Michael E. Porter - Offers frameworks for understanding competitor behavior and industry dynamics, useful for identifying Ambush opportunities.
-* [Thinking in Bets: Making Smarter Decisions When You Don't Have All the Facts](https://www.goodreads.com/book/show/35911677-thinking-in-bets) by Annie Duke - While not directly about Ambush, it offers insights into decision-making under uncertainty, relevant for timing an Ambush.
+* [Competitive Strategy: Techniques for Analyzing Industries and Competitors](/books/competitive-strategy) by Michael E. Porter - Offers frameworks for understanding competitor behavior and industry dynamics, useful for identifying Ambush opportunities.
+* [Thinking in Bets: Making Smarter Decisions When You Don't Have All the Facts](/books/thinking-in-bets) by Annie Duke - While not directly about Ambush, it offers insights into decision-making under uncertainty, relevant for timing an Ambush.

--- a/docs/strategies/decelerators/exploiting-constraint/index.md
+++ b/docs/strategies/decelerators/exploiting-constraint/index.md
@@ -210,4 +210,4 @@ When the constraint eases, you want the market to remember that you were the par
 - [Standard Oil](https://en.wikipedia.org/wiki/Standard_Oil) – Overview of how the company used price wars, transport control, and vertical integration to squeeze rivals bound by existing constraints.
 - [How the global chip shortage unfolded](https://www.reuters.com/technology/autos-transportation/how-pandemic-led-chip-shortage-2021-09-23/) – Reuters explainer linking demand spikes, limited fabrication capacity, and strategic supply agreements.
 - [UK slot allocation guidance](https://www.caa.co.uk/commercial-industry/airports/airport-capacity-slots/uk-slot-allocation/) – Civil Aviation Authority material describing how scarce airport slots are governed and traded.
-- [The Goal](https://www.penguinrandomhouse.com/books/64619/the-goal-by-eli-goldratt-and-jeff-cox/) – Eliyahu Goldratt’s foundational work on the Theory of Constraints, useful for understanding how bottlenecks shape operations and strategy.
+- [The Goal](/books/the-goal) – Eliyahu Goldratt’s foundational work on the Theory of Constraints, useful for understanding how bottlenecks shape operations and strategy.

--- a/docs/strategies/defensive/defensive-regulation/index.md
+++ b/docs/strategies/defensive/defensive-regulation/index.md
@@ -154,5 +154,5 @@ Defensive Regulation is a strategy that is primarily available to large, powerfu
 
 ## 📚 **Further Reading & References**
 
-- **[The Business of America is Lobbying](https://books.google.co.uk/books/about/The_Business_of_America_is_Lobbying.html?id=f8qqBgAAQBAJ&redir_esc=y)** by Lee Drutman, Oxford University Press, 2015. An overview of the role of lobbying in the American economy.
+- **[The Business of America is Lobbying](/books/the-business-of-america-is-lobbying)** by Lee Drutman, Oxford University Press, 2015. An overview of the role of lobbying in the American economy.
 - **[Rent-Seeking](https://www.investopedia.com/terms/r/rentseeking.asp)**, Investopedia. A good definition of the economic concept that underpins this strategy.

--- a/docs/strategies/defensive/managing-inertia/index.md
+++ b/docs/strategies/defensive/managing-inertia/index.md
@@ -150,6 +150,6 @@ To overcome inertia, you often need to change the organizational structure to al
 
 ## 📚 **Further Reading & References**
 
-- **[Leading Change](https://www.goodreads.com/book/show/10548.Leading_Change)** by John P. Kotter. The classic, foundational text on managing organizational change.
+- **[Leading Change](/books/leading-change)** by John P. Kotter. The classic, foundational text on managing organizational change.
 - **[The Innovator's Dilemma](/books/the-innovators-dilemma)** by Clayton M. Christensen. Explains why successful companies often fail to adapt to disruptive change.
-- **[Who Says Elephants Can't Dance?](https://www.goodreads.com/book/show/13337.Who_Says_Elephants_Can_t_Dance_)** by Louis V. Gerstner Jr. A firsthand account of managing the massive inertia at IBM to turn the company around.
+- **[Who Says Elephants Can't Dance?](/books/who-says-elephants-cant-dance)** by Louis V. Gerstner Jr. A firsthand account of managing the massive inertia at IBM to turn the company around.

--- a/docs/strategies/defensive/procrastination/index.md
+++ b/docs/strategies/defensive/procrastination/index.md
@@ -169,4 +169,4 @@ For large organizations, strategic procrastination can be part of a broader port
 ## 📚 **Further Reading & References**
 
 - **[The Innovator's Dilemma](/books/the-innovators-dilemma)** by Clayton M. Christensen. Provides a deep understanding of why incumbent companies often procrastinate on disruptive innovations.
-- **[Fast Second: How Smart Companies Bypass Radical Innovation to Enter and Dominate New Markets](https://www.goodreads.com/book/show/13338.Fast_Second)** by Constantinos C. Markides and Paul A. Geroski. A book dedicated to the strategy of being a fast follower.
+- **[Fast Second: How Smart Companies Bypass Radical Innovation to Enter and Dominate New Markets](/books/fast-second)** by Constantinos C. Markides and Paul A. Geroski. A book dedicated to the strategy of being a fast follower.

--- a/docs/strategies/defensive/raising-barriers-to-entry/index.md
+++ b/docs/strategies/defensive/raising-barriers-to-entry/index.md
@@ -161,4 +161,4 @@ This strategy fundamentally changes competition from a battle of individual prod
 ## 📚 **Further Reading & References**
 
 - **[The Innovator's Dilemma](/books/the-innovators-dilemma)** by Clayton M. Christensen. Discusses how incumbents can be disrupted by new entrants with simpler, more focused products, which is the threat that this strategy is designed to counter.
-- **[Competitive Strategy](https://www.goodreads.com/book/show/236901.Competitive_Strategy)** by Michael E. Porter. The classic text on competitive strategy, which includes a detailed analysis of barriers to entry.
+- **[Competitive Strategy](/books/competitive-strategy)** by Michael E. Porter. The classic text on competitive strategy, which includes a detailed analysis of barriers to entry.

--- a/docs/strategies/defensive/threat-acquisition/index.md
+++ b/docs/strategies/defensive/threat-acquisition/index.md
@@ -159,4 +159,4 @@ While threat acquisitions can be expensive, the cost of inaction can be even hig
 
 - [Wardley Maps](https://medium.com/wardleymaps) by Simon Wardley.
 - [The Innovator's Dilemma](/books/the-innovators-dilemma) by Clayton M. Christensen.
-- [Mergers & Acquisitions For Dummies](https://www.goodreads.com/book/show/137523.Mergers_Acquisitions_For_Dummies) by Bill Snow.
+- [Mergers & Acquisitions For Dummies](/books/mergers-and-acquisitions-for-dummies) by Bill Snow.

--- a/docs/strategies/ecosystem/channel-conflict-and-disintermediation/index.md
+++ b/docs/strategies/ecosystem/channel-conflict-and-disintermediation/index.md
@@ -157,5 +157,5 @@ Channel conflict is not just about cutting costs; it's about forcing change. It 
 
 ## 📚 **Further Reading & References**
 
-- **[The Direct-to-Consumer Playbook](https://books.google.co.uk/books/about/The_Direct_to_Consumer_Playbook.html?id=THibzgEACAAJ&redir_esc=y)** by Mike Stevens. A guide to building a DTC business.
-- **[Unlocking the Customer Value Chain: How Decoupling Drives Consumer Disruption](https://books.google.co.uk/books/about/Unlocking_the_Customer_Value_Chain.html?id=xSdcDwAAQBAJ&redir_esc=y)** by Thales S. Teixeira, Greg Piechota, Crown, 19 Feb 2019. An HBR article that explores the dynamics of disintermediation.
+- **[The Direct-to-Consumer Playbook](/books/the-direct-to-consumer-playbook)** by Mike Stevens. A guide to building a DTC business.
+- **[Unlocking the Customer Value Chain: How Decoupling Drives Consumer Disruption](/books/unlocking-the-customer-value-chain)** by Thales S. Teixeira and Greg Piechota. Analysis of how decoupling shifts value and drives disintermediation.

--- a/docs/strategies/ecosystem/co-creation/index.md
+++ b/docs/strategies/ecosystem/co-creation/index.md
@@ -157,5 +157,5 @@ The core insight of co-creation is that value is not created by the company and 
 
 ## 📚 **Further Reading & References**
 
-- **[The Future of Competition: Co-Creating Unique Value with Customers](https://www.goodreads.com/book/show/189993.The_Future_of_Competition)** by C.K. Prahalad and Venkat Ramaswamy. The book that popularized the concept of co-creation.
-- **[Made by Customers: The New Revolution in Creating and Marketing Products](https://www.goodreads.com/book/show/6487933-made-by-customers)** by Stefan Thomke and Eric von Hippel. Explores the power of user-led innovation.
+- **[The Future of Competition: Co-Creating Unique Value with Customers](/books/the-future-of-competition)** by C.K. Prahalad and Venkat Ramaswamy. The book that popularized the concept of co-creation.
+- **[Made by Customers: The New Revolution in Creating and Marketing Products](/books/made-by-customers)** by Stefan Thomke and Eric von Hippel. Explores the power of user-led innovation.

--- a/docs/strategies/ecosystem/co-opting/index.md
+++ b/docs/strategies/ecosystem/co-opting/index.md
@@ -150,4 +150,4 @@ This strategy is often used to neutralize a competitor's main weapon. By removin
 ## 📚 **Further Reading & References**
 
 - **[How Instagram's new Stories feature is a Snapchat clone](https://www.theverge.com/2016/8/2/12353186/instagram-stories-snapchat-clone)** by Casey Newton, The Verge. A contemporary analysis of the most famous modern example of co-opting.
-- **[Seeing Like a State](https://www.goodreads.com/book/show/2345.Seeing_Like_a_State)** by James C. Scott. While not a business book, it provides deep insights into how large, centralized systems (like big companies) co-opt and absorb local, organic practices.
+- **[Seeing Like a State](/books/seeing-like-a-state)** by James C. Scott. While not a business book, it provides deep insights into how large, centralized systems (like big companies) co-opt and absorb local, organic practices.

--- a/docs/strategies/ecosystem/two-factor-markets/index.md
+++ b/docs/strategies/ecosystem/two-factor-markets/index.md
@@ -164,5 +164,5 @@ In a two-sided market, your product is not just a piece of software; it is the e
 ## 📚 **Further Reading & References**
 
 - **[Platform Revolution](/books/platform-revolution)** by Geoffrey G. Parker, Marshall W. Van Alstyne, and Sangeet Paul Choudary. The definitive guide to platform business models.
-- **[The Cold Start Problem](https://www.goodreads.com/book/show/56223994-the-cold-start-problem)** by Andrew Chen. A deep dive into how to launch and scale network effects.
-- **[Modern Monopolies](https://www.goodreads.com/book/show/26245217-modern-monopolies)** by Alex Moazed and Nicholas L. Johnson. An analysis of the platform business model and its impact on the economy.
+- **[The Cold Start Problem](/books/the-cold-start-problem)** by Andrew Chen. A deep dive into how to launch and scale network effects.
+- **[Modern Monopolies](/books/modern-monopolies)** by Alex Moazed and Nicholas L. Johnson. An analysis of the platform business model and its impact on the economy.

--- a/docs/strategies/markets/buyer-supplier-power/index.md
+++ b/docs/strategies/markets/buyer-supplier-power/index.md
@@ -163,5 +163,5 @@ Every value chain is also a power chain. Understanding this allows you to see th
 
 ## 📚 **Further Reading & References**
 
-- **[Competitive Strategy](https://www.goodreads.com/book/show/236901.Competitive_Strategy)** by Michael E. Porter. The classic text that introduced the "Five Forces" framework, which is central to understanding buyer-supplier power.
-- **[The Everything Store: Jeff Bezos and the Age of Amazon](https://www.goodreads.com/book/show/17660462-the-everything-store)** by Brad Stone. Provides many examples of how Amazon has masterfully managed buyer-supplier power.
+- **[Competitive Strategy](/books/competitive-strategy)** by Michael E. Porter. The classic text that introduced the "Five Forces" framework, which is central to understanding buyer-supplier power.
+- **[The Everything Store: Jeff Bezos and the Age of Amazon](/books/the-everything-store)** by Brad Stone. Provides many examples of how Amazon has masterfully managed buyer-supplier power.

--- a/docs/strategies/markets/differentiation/index.md
+++ b/docs/strategies/markets/differentiation/index.md
@@ -159,5 +159,5 @@ Differentiation is useless if customers don't know about it or don't understand 
 ## 📚 **Further Reading & References**
 
 - **[Blue Ocean Strategy](/books/blue-ocean-strategy)** by W. Chan Kim and Renée Mauborgne. A classic book on creating uncontested market space.
-- **[Differentiate or Die](https://www.goodreads.com/book/show/13339.Differentiate_or_Die)** by Jack Trout and Steve Rivkin. A practical guide to the principles of differentiation.
-- **[Obviously Awesome](https://www.goodreads.com/book/show/44232216-obviously-awesome)** by April Dunford. A book focused on positioning, which is the art of communicating differentiation.
+- **[Differentiate or Die](/books/differentiate-or-die)** by Jack Trout and Steve Rivkin. A practical guide to the principles of differentiation.
+- **[Obviously Awesome](/books/obviously-awesome)** by April Dunford. A book focused on positioning, which is the art of communicating differentiation.

--- a/docs/strategies/markets/last-man-standing/index.md
+++ b/docs/strategies/markets/last-man-standing/index.md
@@ -156,4 +156,4 @@ This strategy is a powerful example of Joseph Schumpeter's concept of "creative 
 ## 📚 **Further Reading & References**
 
 * **[Amazon and the last man standing](https://blog.gardeviance.org/2015/08/amazon-and-last-man-standing.html)** by Simon Wardley. A foundational post on this strategy.
-* **[Competition Demystified](https://www.goodreads.com/book/show/236923.Competition_Demystified)** by Bruce Greenwald and Judd Kahn. Provides a framework for analyzing competitive advantages, which is crucial for this strategy.
+* **[Competition Demystified](/books/competition-demystified)** by Bruce Greenwald and Judd Kahn. Provides a framework for analyzing competitive advantages, which is crucial for this strategy.

--- a/docs/strategies/markets/pricing-policy/index.md
+++ b/docs/strategies/markets/pricing-policy/index.md
@@ -157,6 +157,6 @@ Pricing is the primary mechanism for capturing value. However, a pricing policy 
 
 ## 📚 **Further Reading & References**
 
-- **[Confessions of the Pricing Man](https://www.goodreads.com/book/show/25999222-confessions-of-the-pricing-man)** by Hermann Simon. A deep dive into the art and science of pricing.
-- **[Monetizing Innovation](https://www.goodreads.com/book/show/28788259-monetizing-innovation)** by Madhavan Ramanujam and Georg Tacke. A practical guide to building a pricing strategy around innovation.
-- **[Priceless: The Myth of Fair Value](https://www.goodreads.com/book/show/6903732-priceless)** by William Poundstone. An exploration of the psychology of pricing.
+- **[Confessions of the Pricing Man](/books/confessions-of-the-pricing-man)** by Hermann Simon. A deep dive into the art and science of pricing.
+- **[Monetizing Innovation](/books/monetizing-innovation)** by Madhavan Ramanujam and Georg Tacke. A practical guide to building a pricing strategy around innovation.
+- **[Priceless: The Myth of Fair Value](/books/priceless-the-myth-of-fair-value)** by William Poundstone. An exploration of the psychology of pricing.

--- a/docs/strategies/markets/signal-distortion/index.md
+++ b/docs/strategies/markets/signal-distortion/index.md
@@ -162,5 +162,5 @@ Signal Distortion is a powerful reminder that in many markets, the perception of
 
 ## 📚 **Further Reading & References**
 
-- **[Trust Me, I'm Lying: Confessions of a Media Manipulator](https://www.goodreads.com/book/show/13542853-trust-me-i-m-lying)** by Ryan Holiday. A stark look at how media can be manipulated.
+- **[Trust Me, I'm Lying: Confessions of a Media Manipulator](/books/trust-me-im-lying)** by Ryan Holiday. A stark look at how media can be manipulated.
 - **[The Art of War](/books/the-art-of-war)** by Sun Tzu. The ancient text is full of wisdom on deception and misdirection.

--- a/docs/strategies/poison/insertion/index.md
+++ b/docs/strategies/poison/insertion/index.md
@@ -182,5 +182,5 @@ Insertion is rarely a standalone play. Its effectiveness is often amplified when
 
 ## 📚 **Further Reading & References**
 
-- Cialdini, R. — [*Influence: The Psychology of Persuasion*](https://www.amazon.co.uk/Influence-Psychology-Robert-Cialdini-PhD/dp/006124189X) — foundational concepts of behavioral influence.
-- Mitnick, K. — [*The Art of Deception*](https://www.amazon.co.uk/Art-Deception-Controlling-Element-Security/dp/076454280X) — case studies on social engineering and covert operations.
+- Cialdini, R. — [*Influence: The Psychology of Persuasion*](/books/influence-the-psychology-of-persuasion) — foundational concepts of behavioral influence.
+- Mitnick, K. — [*The Art of Deception*](/books/the-art-of-deception) — case studies on social engineering and covert operations.

--- a/docs/strategies/positional/first-mover/index.md
+++ b/docs/strategies/positional/first-mover/index.md
@@ -160,8 +160,8 @@ Heavy upfront investment requires clear signals and strong governance to avoid w
 
 ## 📚 **Further Reading & References**
 
-- Gawer, A. – [*Platforms, Markets and Innovation*](https://www.amazon.co.uk/Platforms-Markets-Innovation-Annabelle-Gawer/dp/1848447892) – analysis of platform leadership and standards.
-- Schilling, M. – [*Strategic Management of Technological Innovation*](https://www.amazon.co.uk/Strategic-Management-Technological-Innovation-Schilling/dp/0071326448) – insights on timing and scaling innovations.
+- Gawer, A. – [*Platforms, Markets and Innovation*](/books/platforms-markets-and-innovation) – analysis of platform leadership and standards.
+- Schilling, M. – [*Strategic Management of Technological Innovation*](/books/strategic-management-of-technological-innovation) – insights on timing and scaling innovations.
 - [On Pioneers, Settlers, Town Planners and Theft.](https://blog.gardeviance.org/2015/03/on-pioneers-settlers-town-planners-and.html) - Simon Wardley
 - [Is it better to be a first mover or a fast follower?](https://www.bdo.co.uk/en-gb/insights/industries/technology-media-and-life-sciences/plugdin-insights-is-it-better-to-be-a-first-mover-or-a-fast-follower)
 - [Fast Followers and First Movers: Innovation in Organizations](https://blog.siemens.com/2022/12/fast-followers-and-first-movers-innovation-in-organizations/)

--- a/docs/strategies/positional/land-grab/index.md
+++ b/docs/strategies/positional/land-grab/index.md
@@ -155,7 +155,7 @@ Maintain agility by planning divestment or spin-off strategies for positions tha
 
 ## 📚 **Further Reading & References**
 
-- Gawer, A. – [*Platforms, Markets and Innovation*](https://www.amazon.co.uk/Platforms-Markets-Innovation-Annabelle-Gawer/dp/1848447892) – analysis of platform leadership and standards.
-- Schilling, M. – [*Strategic Management of Technological Innovation*](https://www.amazon.co.uk/Strategic-Management-Technological-Innovation-Schilling/dp/0071326448) – insights on timing and scaling innovations.
+- Gawer, A. – [*Platforms, Markets and Innovation*](/books/platforms-markets-and-innovation) – analysis of platform leadership and standards.
+- Schilling, M. – [*Strategic Management of Technological Innovation*](/books/strategic-management-of-technological-innovation) – insights on timing and scaling innovations.
 - [On Pioneers, Settlers, Town Planners and Theft.](https://blog.gardeviance.org/2015/03/on-pioneers-settlers-town-planners-and.html) - Simon Wardley
-- Teece, D. – [*Dynamic Capabilities and Strategic Management*](https://www.amazon.co.uk/Dynamic-Capabilities-Strategic-Management-Organizing/dp/0199691908) – on resource commitment and agility.
+- Teece, D. – [*Dynamic Capabilities and Strategic Management*](/books/dynamic-capabilities-and-strategic-management) – on resource commitment and agility.

--- a/docs/strategies/positional/weak-signal-horizon/index.md
+++ b/docs/strategies/positional/weak-signal-horizon/index.md
@@ -161,5 +161,5 @@ Effective sensing requires an organisational culture that values and acts on ear
 ## 📚 **Further Reading & References**
 
 - Wardley, S. – [*Anticipation*](https://blog.gardeviance.org/2016/12/anticipation.html) – foundational concepts on sensing and foresight.
-- Kahneman, D. – [*Thinking, Fast and Slow*](https://www.amazon.co.uk/Thinking-Fast-Slow-Daniel-Kahneman/dp/0141033576#:~:text=Book%20details&text=Nobel%20Prize%20winner%20Daniel%20Kahneman,%2C%20and%20slow%2C%20rational%20thinking.) – for insights on bias and signal interpretation.
+- Kahneman, D. – [*Thinking, Fast and Slow*](/books/thinking-fast-and-slow) – for insights on bias and signal interpretation.
 - [*Horizon Scanning*](https://en.wikipedia.org/wiki/Horizon_scanning), Wikipedia - methodologies in foresight practice.

--- a/docs/strategies/user-perception/bundling/index.md
+++ b/docs/strategies/user-perception/bundling/index.md
@@ -145,4 +145,4 @@ From a value chain perspective, bundling can represent a form of vertical integr
 
 - [U.S. v. Microsoft (1998) – DOJ Antitrust Case Documents](https://www.justice.gov/atr/us-v-microsoft-courts-findings-fact) – Describes how bundling Internet Explorer with Windows gave Microsoft a strategic edge and the legal ramifications.
 - [Bundling and Tying: Antitrust Analysis](https://www.ftc.gov/advice-guidance/competition-guidance/guide-antitrust-laws/single-firm-conduct/tying-sale-two-products) – Federal Trade Commission guidance on bundling and tying practices.
-- [The Strategy and Tactics of Pricing](https://www.amazon.co.uk/Double-Your-Price-Strategy-Tactics/dp/1292426349) – Book covering pricing strategies, including bundling.
+- [The Strategy and Tactics of Pricing](/books/the-strategy-and-tactics-of-pricing) – Book covering pricing strategies, including bundling.


### PR DESCRIPTION
## Summary
- add dedicated book pages for every work referenced by strategies and include contextual summaries
- update strategy further-reading links to point at the new book pages instead of external retailers
- record cross-links on book pages so each title lists the strategies that cite it

## Testing
- npm run lint:md:fix
- python -m pytest tests


------
https://chatgpt.com/codex/tasks/task_e_68c9c0720098832b88eb12a5976bf63e