### PR TITLE
Add strategy navigator with generated strategy index

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -111,6 +111,10 @@ const config: Config = {
           to: '/strategies',
         },
         {
+          label: 'Strategy Navigator',
+          to: '/strategy-navigator',
+        },
+        {
           label: 'Doctrines',
           to: '/doctrines',
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
         "babel-jest": "^30.0.2",
+        "gray-matter": "^4.0.3",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^30.0.3",
         "jest-environment-jsdom": "^30.0.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "jest": "^30.0.3",
     "jest-environment-jsdom": "^30.0.2",
     "markdownlint-cli": "^0.45.0",
+    "gray-matter": "^4.0.3",
     "typescript": "~5.8.3"
   },
   "browserslist": {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,7 +10,7 @@ Run `pytest` from the repository root to check for content issues such as:
 - unexplained related links
 - required headings in strategy documents
 
-Only one helper script remains:
+Helper scripts:
 
 ## `add_related_links.py`
 Automatically inserts missing links into the **Related Strategies** sections
@@ -24,3 +24,11 @@ python3 scripts/add_related_links.py > added.csv
 
 **Note:** This script modifies the markdown files. Review changes with `git diff`
 before committing.
+
+## `build-strategy-index.mjs`
+Parses every strategy file and generates `src/data/strategyIndex.ts`, which powers
+the Strategy Navigator page. Run it whenever strategy content changes:
+
+```bash
+node scripts/build-strategy-index.mjs
+```

--- a/scripts/build-strategy-index.mjs
+++ b/scripts/build-strategy-index.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * Generates a rich strategy index from the MDX files under docs/strategies.
+ *
+ * The output is written to src/data/strategyIndex.ts and includes the
+ * front-matter metadata alongside the MapSignals and Readiness statements used
+ * by the assessment component on each strategy page.
+ */
+
+import {promises as fs} from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+
+const __dirname = path.resolve();
+const docsDir = path.join(__dirname, 'docs', 'strategies');
+const outputFile = path.join(__dirname, 'src', 'data', 'strategyIndex.ts');
+
+const HEADER = `// AUTO-GENERATED FILE - DO NOT EDIT DIRECTLY.
+// Run \`node scripts/build-strategy-index.mjs\` to regenerate.
+
+export type StrategyMetadata = {
+  id: string;
+  title: string;
+  description: string;
+  tags: string[];
+  permalink: string;
+  category: string;
+  mapSignals: string[];
+  readiness: string[];
+};
+
+const strategies: StrategyMetadata[] = `;
+
+const FOOTER = `;
+
+export default strategies;
+`;
+
+function cleanHtml(text) {
+  return text
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function extractList(content, tagName) {
+  const regex = new RegExp(String.raw`<${tagName}[^>]*>([\s\S]*?)</${tagName}>`, 'i');
+  const match = content.match(regex);
+  if (!match) {
+    return [];
+  }
+
+  const inner = match[1];
+  const items = [];
+
+  const liRegex = /<li[^>]*>([\s\S]*?)<\/li>/gi;
+  let liMatch;
+  while ((liMatch = liRegex.exec(inner)) !== null) {
+    const cleaned = cleanHtml(liMatch[1]);
+    if (cleaned) {
+      items.push(cleaned);
+    }
+  }
+
+  if (items.length === 0) {
+    const bulletRegex = /^\s*[-*+]\s+(.*)$/gim;
+    let bulletMatch;
+    while ((bulletMatch = bulletRegex.exec(inner)) !== null) {
+      const cleaned = cleanHtml(bulletMatch[1]);
+      if (cleaned) {
+        items.push(cleaned);
+      }
+    }
+  }
+
+  const seen = new Set();
+  return items.filter((item) => {
+    if (seen.has(item)) {
+      return false;
+    }
+    seen.add(item);
+    return true;
+  });
+}
+
+function normalisePermalink(relativePath) {
+  const withoutIndex = relativePath.replace(/index\.md$/i, '');
+  return `/${withoutIndex.replace(/\\/g, '/').replace(/\/+/g, '/')}`;
+}
+
+async function collectStrategyFiles(dir) {
+  const entries = await fs.readdir(dir, {withFileTypes: true});
+  const results = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...(await collectStrategyFiles(fullPath)));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.toLowerCase() === 'index.md') {
+      const relative = path.relative(path.join(__dirname, 'docs'), fullPath).replace(/\\/g, '/');
+      const segments = relative.split('/');
+      // strategies/<category>/<strategy>/index.md -> segments length >= 4
+      if (segments.length >= 4 && segments[0] === 'strategies') {
+        results.push(fullPath);
+      }
+    }
+  }
+
+  return results;
+}
+
+async function buildIndex() {
+  const files = await collectStrategyFiles(docsDir);
+  const strategies = [];
+
+  for (const filePath of files) {
+    const fileContent = await fs.readFile(filePath, 'utf8');
+    const {data, content} = matter(fileContent);
+
+    const relative = path.relative(path.join(__dirname, 'docs'), filePath).replace(/\\/g, '/');
+    const segments = relative.split('/');
+    const category = segments[1] ?? 'uncategorised';
+    const slugSegments = segments.slice(0, -1);
+    const permalink = normalisePermalink(slugSegments.join('/') + '/');
+    const id = segments.slice(1, -1).join('/');
+
+    const strategy = {
+      id,
+      title: data.title ?? slugSegments.at(-1) ?? 'Unknown strategy',
+      description: data.description ?? '',
+      tags: Array.isArray(data.tags) ? data.tags : [],
+      permalink,
+      category,
+      mapSignals: extractList(content, 'MapSignals'),
+      readiness: extractList(content, 'Readiness'),
+    };
+
+    strategies.push(strategy);
+  }
+
+  strategies.sort((a, b) => a.title.localeCompare(b.title));
+
+  const output = `${HEADER}${JSON.stringify(strategies, null, 2)}${FOOTER}`;
+  await fs.mkdir(path.dirname(outputFile), {recursive: true});
+  await fs.writeFile(outputFile, output);
+  console.log(`Generated ${strategies.length} strategies to ${path.relative(__dirname, outputFile)}`);
+}
+
+buildIndex().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/data/strategyIndex.ts
+++ b/src/data/strategyIndex.ts
@@ -1,0 +1,1997 @@
+// AUTO-GENERATED FILE - DO NOT EDIT DIRECTLY.
+// Run `node scripts/build-strategy-index.mjs` to regenerate.
+
+export type StrategyMetadata = {
+  id: string;
+  title: string;
+  description: string;
+  tags: string[];
+  permalink: string;
+  category: string;
+  mapSignals: string[];
+  readiness: string[];
+};
+
+const strategies: StrategyMetadata[] = [
+  {
+    "id": "ecosystem/alliances",
+    "title": "Alliances",
+    "description": "Formal partnerships or consortia formed to pursue shared goals.",
+    "tags": [
+      "alliances",
+      "ecosystem",
+      "partnerships",
+      "consortia",
+      "collaboration",
+      "standards",
+      "collective action",
+      "cooperation"
+    ],
+    "permalink": "/strategies/ecosystem/alliances/",
+    "category": "ecosystem",
+    "mapSignals": [
+      "The competitive environment includes dominant players or high barriers that are difficult to tackle alone.",
+      "Your mapping reveals complementary players with shared interests or aligned user needs across the value chain.",
+      "There is a need to shape emerging standards, platforms, or interoperability in a volatile or nascent market.",
+      "Value creation is distributed across multiple entities, making collective action more effective than individual moves.",
+      "Your current capabilities show clear gaps that could be filled through strategic partnerships rather than internal investment.",
+      "Regulatory, geographic, or technical diversity makes a unified approach more compelling to customers or stakeholders."
+    ],
+    "readiness": [
+      "We can articulate mutual benefits and a clear value proposition to prospective alliance members.",
+      "We have the governance experience to structure and manage cross-organizational collaboration at scale.",
+      "We are prepared to share decision-making and control where necessary to achieve broader outcomes.",
+      "We have the cultural maturity and leadership bandwidth to build trust across organizational boundaries.",
+      "We maintain ecosystem awareness, understanding adjacent players’ capabilities, incentives, and historical relationships.",
+      "We are ready to compromise on speed or autonomy in exchange for market shaping or shared infrastructure benefits.",
+      "We have risk mitigation plans if the alliance dissolves or partner incentives shift over time."
+    ]
+  },
+  {
+    "id": "competitor/ambush",
+    "title": "Ambush",
+    "description": "Reactively undermining a specific competitor's progress or negating their advantage with a surprise strategic maneuver.",
+    "tags": [
+      "competitor",
+      "surprise",
+      "reactive",
+      "undermining",
+      "market-play",
+      "disruption",
+      "counter-attack"
+    ],
+    "permalink": "/strategies/competitor/ambush/",
+    "category": "competitor",
+    "mapSignals": [
+      "A specific competitor is about to launch a product that threatens our position.",
+      "A competitor has recently announced a significant investment in an area where we can quickly counter.",
+      "We observe a competitor achieving a milestone that makes them vulnerable to a specific counter-move (e.g., reliance on a single supplier we could acquire).",
+      "A competitor's new offering has a clear weakness we can exploit immediately.",
+      "The market landscape shows a competitor gaining significant traction that we need to arrest."
+    ],
+    "readiness": [
+      "We have excellent competitor intelligence capabilities.",
+      "We can act decisively and quickly once a trigger is identified.",
+      "We have existing assets or capabilities that can be rapidly repurposed or redeployed.",
+      "Our organization can maintain secrecy around the planned Ambush.",
+      "We are prepared for potential retaliatory actions from the ambushed competitor.",
+      "Leadership is willing to make bold, potentially aggressive moves."
+    ]
+  },
+  {
+    "id": "user-perception/artificial-competition",
+    "title": "Artificial Competition",
+    "description": "Creating the illusion of competition by establishing or funding a secondary entity that competes with your own offerings.",
+    "tags": [
+      "artificial-competition",
+      "user-perception",
+      "illusion of choice",
+      "market control",
+      "branding",
+      "monopoly avoidance"
+    ],
+    "permalink": "/strategies/user-perception/artificial-competition/",
+    "category": "user-perception",
+    "mapSignals": [
+      "We dominate a market or segment where regulatory or public scrutiny over monopoly risk is increasing.",
+      "There is a lack of credible competitors in our space, leaving us exposed or unchallenged.",
+      "Our mapping reveals untapped adjacent segments or personas we could reach via a differentiated brand.",
+      "We see value in testing alternative positioning or pricing strategies without altering the core brand.",
+      "Regulatory dynamics or public trust factors suggest visible competition would improve legitimacy.",
+      "Customer sentiment data suggests skepticism about choice or market concentration."
+    ],
+    "readiness": [
+      "We can establish or acquire a secondary entity with sufficiently distinct branding and operational separation.",
+      "We have internal governance structures capable of maintaining plausible independence while aligning high-level strategy.",
+      "We are able to operate dual brands without creating internal conflict, inefficiencies, or cannibalisation.",
+      "We can manage the legal, operational, and reputational risks if the relationship is revealed.",
+      "We have clear goals for the strategy, including success criteria and an exit or integration plan.",
+      "We understand the ethical implications and have considered alternatives to artificial competition.",
+      "We have experience managing public perception, media narratives, or regulatory engagement."
+    ]
+  },
+  {
+    "id": "user-perception/brand-and-marketing",
+    "title": "Brand and Marketing",
+    "description": "Using traditional marketing and brand positioning to shape user perception.",
+    "tags": [
+      "brand-and-marketing",
+      "user-perception",
+      "branding",
+      "marketing",
+      "positioning",
+      "customer loyalty",
+      "messaging"
+    ],
+    "permalink": "/strategies/user-perception/brand-and-marketing/",
+    "category": "user-perception",
+    "mapSignals": [
+      "The market is saturated with functionally similar offerings, creating a premium on perceived differentiation.",
+      "Your mapping indicates a component or offering has moved toward commoditization, but perception lags behind its evolution.",
+      "User needs are increasingly shaped by identity, status, or emotional alignment rather than just functional performance.",
+      "The competitive environment is ripe for narrative framing. Your offering can plausibly be positioned as \"the choice for people like us.\"",
+      "There is room to move a component up and left on the map, making it more visible and perceived as more specialised or bespoke than it actually is.",
+      "Competitors are vulnerable to perception-based repositioning (e.g., being cast as generic, outdated, risky, or misaligned with audience values)."
+    ],
+    "readiness": [
+      "We have a clear understanding of our target segments’ values, aspirations, and self-perceptions.",
+      "We can craft coherent, resonant narratives and consistently apply them across all touchpoints (ads, sales, support, packaging, etc).",
+      "We have marketing execution capability (brand, comms, channels) that can reinforce user perception intentionally over time.",
+      "We understand how to position against competitors indirectly: through contrast, framing, and narrative, not just claims.",
+      "We can monitor perception shifts and adapt our messaging in response to cultural or competitive changes.",
+      "We maintain alignment between brand messaging and actual product/service quality to ensure authenticity and trust.",
+      "We avoid over-reliance on marketing by balancing perception work with real improvements in product, support, or delivery."
+    ]
+  },
+  {
+    "id": "user-perception/bundling",
+    "title": "Bundling",
+    "description": "Combining products or changes together so that a less desirable item is packaged with a desirable one, encouraging adoption of the whole package.",
+    "tags": [
+      "bundling",
+      "user-perception",
+      "packaging",
+      "adoption",
+      "hiding disadvantage",
+      "pricing"
+    ],
+    "permalink": "/strategies/user-perception/bundling/",
+    "category": "user-perception",
+    "mapSignals": [
+      "Our map shows a component facing user resistance or inertia.",
+      "We have a highly desirable product or service with strong demand.",
+      "The less desirable component is strategically important for our value chain or evolution.",
+      "Competitors are gaining traction with standalone offerings that threaten our ecosystem.",
+      "There is an opportunity to accelerate adoption of a new standard or feature."
+    ],
+    "readiness": [
+      "We understand our customers' needs and pain points well.",
+      "We can clearly communicate the value of the bundle.",
+      "We have the ability to monitor and respond to customer feedback rapidly.",
+      "We are prepared to address potential legal or regulatory concerns.",
+      "We can coordinate across product, marketing, and sales teams."
+    ]
+  },
+  {
+    "id": "markets/buyer-supplier-power",
+    "title": "Buyer-Supplier Power",
+    "description": "Strategically managing the power dynamics between buyers and suppliers as a market evolves to gain a competitive advantage.",
+    "tags": [
+      "markets",
+      "power-dynamics",
+      "negotiation",
+      "value-chain",
+      "leverage",
+      "commoditisation",
+      "chokepoint"
+    ],
+    "permalink": "/strategies/markets/buyer-supplier-power/",
+    "category": "markets",
+    "mapSignals": [
+      "Your map shows a dependency on a single, powerful supplier for a critical component.",
+      "Your map reveals an opportunity to become a \"chokepoint\" by controlling a key part of the value chain.",
+      "Competitors are vulnerable due to their own dependencies on powerful buyers or suppliers.",
+      "A component in your value chain is beginning to commoditize, creating an opportunity to shift the power balance."
+    ],
+    "readiness": [
+      "We have a deep understanding of our entire value chain and the power dynamics within it.",
+      "Our organization has strong negotiation skills and is not afraid to use its leverage.",
+      "We have the resources to invest in strategies like vertical integration or building a platform.",
+      "Our leadership thinks systemically and can analyze the second and third-order effects of power shifts."
+    ]
+  },
+  {
+    "id": "attacking/centre-of-gravity",
+    "title": "Center of Gravity",
+    "description": "Building a focal point of talent, expertise, or activity that attracts the best resources and shapes the direction of an industry or ecosystem.",
+    "tags": [
+      "center-of-gravity",
+      "attacking",
+      "talent",
+      "ecosystem",
+      "innovation",
+      "expertise",
+      "influence",
+      "attraction"
+    ],
+    "permalink": "/strategies/attacking/centre-of-gravity/",
+    "category": "attacking",
+    "mapSignals": [
+      "Your map shows a critical component or talent pool in an early stage of evolution.",
+      "You control a unique resource, dataset, or platform that others want access to.",
+      "There is a visible clustering of expertise, partners, or users around your organisation.",
+      "Competitors or partners are already referencing or aligning with your initiatives.",
+      "The market is networked, and being the hub yields outsized influence.",
+      "There is a clear opportunity to set standards or shape narratives."
+    ],
+    "readiness": [
+      "Your organisation can concentrate resources and sustain investment in a focal area.",
+      "You have a culture that attracts and retains top talent or partners.",
+      "You are skilled at building and maintaining ecosystems or communities.",
+      "You can manage the risks of overconcentration and maintain adaptability.",
+      "You are prepared to defend your position against counter-moves (e.g., talent raids, rival hubs).",
+      "You have mechanisms to continually refresh your gravitational pull (e.g., innovation, culture, incentives)."
+    ]
+  },
+  {
+    "id": "ecosystem/channel-conflict-and-disintermediation",
+    "title": "Channel Conflict and Disintermediation",
+    "description": "A strategy of deliberately creating tension between distribution channels to gain control, reshape value flows, and own the customer relationship.",
+    "tags": [
+      "ecosystem",
+      "channel-conflict",
+      "disintermediation",
+      "distribution",
+      "direct-to-consumer",
+      "partners",
+      "leverage"
+    ],
+    "permalink": "/strategies/ecosystem/channel-conflict-and-disintermediation/",
+    "category": "ecosystem",
+    "mapSignals": [
+      "Your map shows that powerful intermediaries (distributors, retailers) control access to your end users.",
+      "Your partners are slow-moving, have high margins, or are resistant to innovation.",
+      "There is a significant gap between your desired customer experience and what your partners are delivering.",
+      "A direct-to-consumer model is becoming viable in your industry due to new technology (e.g., e-commerce platforms)."
+    ],
+    "readiness": [
+      "We have a brand that is strong enough to attract customers directly.",
+      "We have the operational capability to manage logistics, customer service, and e-commerce.",
+      "Our leadership has the conviction to manage the inevitable backlash from our existing partners.",
+      "We have a clear plan for how to manage pricing and product availability across different channels."
+    ]
+  },
+  {
+    "id": "competitor/circling-and-probing",
+    "title": "Circling and Probing",
+    "description": "",
+    "tags": [
+      "circling-and-probing",
+      "competitor",
+      "circling",
+      "probing",
+      "exploration",
+      "experimentation",
+      "market testing",
+      "intelligence"
+    ],
+    "permalink": "/strategies/competitor/circling-and-probing/",
+    "category": "competitor",
+    "mapSignals": [
+      "We see a valuable market or user segment currently served by a competitor, but with unclear user satisfaction or unmet needs.",
+      "The competitor is strong but not invulnerable—there are signs of pricing, experience, or agility constraints.",
+      "Our map shows this area as adjacent to our current value chain but not yet fully mapped or explored.",
+      "The opportunity is uncertain or unvalidated, making a full-scale commitment premature.",
+      "We anticipate market change or inflection but need more insight before committing.",
+      "We would benefit from learning how the competitor reacts to unexpected moves or new offerings."
+    ],
+    "readiness": [
+      "We have the ability to rapidly create small-scale offerings (e.g., MVPs, limited pilots, betas).",
+      "We are culturally comfortable with controlled experimentation and learning through doing.",
+      "We can instrument and evaluate low-commitment probes to gain actionable intelligence.",
+      "We have the discipline to avoid premature scaling or overinterpreting small signals.",
+      "Our teams understand the distinction between core execution and experimental probes.",
+      "We can adapt quickly based on new intelligence gathered through market testing.",
+      "We have clear strategic intent guiding what we want to learn or provoke from the competitor."
+    ]
+  },
+  {
+    "id": "ecosystem/co-creation",
+    "title": "Co-creation",
+    "description": "A strategy of actively involving customers or users in the product development process to create more valuable and user-centric solutions.",
+    "tags": [
+      "ecosystem",
+      "collaboration",
+      "user-involvement",
+      "customer-feedback",
+      "innovation",
+      "community",
+      "open-innovation"
+    ],
+    "permalink": "/strategies/ecosystem/co-creation/",
+    "category": "ecosystem",
+    "mapSignals": [
+      "Your map shows a product or service where user needs are diverse, complex, or poorly understood.",
+      "There is a passionate, engaged community of users around your product or market.",
+      "Competitors are offering generic, one-size-fits-all solutions.",
+      "The value of your product is highly dependent on user context and creativity."
+    ],
+    "readiness": [
+      "We have a culture that is open to external ideas and values customer feedback.",
+      "We have the tools and platforms to facilitate collaboration with our user community.",
+      "Our leadership is willing to relinquish some control over the product development process.",
+      "We have a clear process for managing, evaluating, and integrating user contributions."
+    ]
+  },
+  {
+    "id": "ecosystem/co-opting",
+    "title": "Co-opting",
+    "description": "A strategy of adopting or mimicking a competitor's features, standards, or messaging to neutralize their advantage and attract their users.",
+    "tags": [
+      "ecosystem",
+      "influence",
+      "absorption",
+      "competition",
+      "neutralization",
+      "standards",
+      "ecosystem-control",
+      "fast-follower"
+    ],
+    "permalink": "/strategies/ecosystem/co-opting/",
+    "category": "ecosystem",
+    "mapSignals": [
+      "A competitor has a single, highly popular feature that is driving their growth.",
+      "Your map shows that a rival's point of differentiation is a feature, not a fundamental platform advantage.",
+      "Customers are switching to a competitor for a specific piece of functionality that you lack.",
+      "A new trend or technology is emerging, and a competitor is the current leader."
+    ],
+    "readiness": [
+      "We have the engineering agility to quickly replicate a competitor's feature.",
+      "Our product has a large enough user base to make our version of the feature instantly viable.",
+      "We can integrate the co-opted feature into our existing product in a way that provides unique value.",
+      "Our brand is strong enough to withstand potential accusations of being a \"copycat.\""
+    ]
+  },
+  {
+    "id": "user-perception/confusion-of-choice",
+    "title": "Confusion of Choice",
+    "description": "Overwhelming customers with too many options or complex choices so that making a rational decision becomes difficult.",
+    "tags": [
+      "user-perception",
+      "choice overload",
+      "complexity",
+      "inertia",
+      "comparison prevention"
+    ],
+    "permalink": "/strategies/user-perception/confusion-of-choice/",
+    "category": "user-perception",
+    "mapSignals": [
+      "Our map shows a critical user decision point with many possible options.",
+      "Competitors offer simpler, more transparent alternatives.",
+      "We control the default or recommended option in a complex choice set.",
+      "Switching costs are low unless confusion is introduced.",
+      "Market is mature and direct comparison is easy without intervention."
+    ],
+    "readiness": [
+      "We can manage operational complexity from multiple offerings.",
+      "We have strong product portfolio management skills.",
+      "We monitor customer feedback for signs of frustration or backlash.",
+      "We can quickly adapt if \"simplifier\" competitors gain traction.",
+      "We have clear ethical guidelines for choice architecture."
+    ]
+  },
+  {
+    "id": "accelerators/cooperation",
+    "title": "Cooperation",
+    "description": "Working with others, even competitors, to achieve a goal.",
+    "tags": [
+      "cooperation",
+      "accelerators",
+      "collaboration",
+      "partnerships",
+      "standards",
+      "alliances",
+      "ecosystem",
+      "mutual benefit"
+    ],
+    "permalink": "/strategies/accelerators/cooperation/",
+    "category": "accelerators",
+    "mapSignals": [
+      "We’re addressing a component in the Genesis or Custom stage that is too large, risky, or slow to develop alone.",
+      "Our competitors or peers face similar challenges and could benefit from a shared approach.",
+      "There is an emerging opportunity that would benefit from ecosystem expansion or standardisation.",
+      "Success in this area depends on interoperability, platform effects, or shared infrastructure.",
+      "Our current value chain includes adjacent players with complementary capabilities.",
+      "Market formation is more important than short-term control or differentiation.",
+      "There is strategic ambiguity that makes solo investment unattractive but joint exploration viable."
+    ],
+    "readiness": [
+      "We have mechanisms to build and maintain trust with external partners (e.g., transparent reporting, aligned incentives).",
+      "We are comfortable with shared governance and joint decision-making.",
+      "We have experience with partnerships or alliances, even informal ones.",
+      "We are capable of negotiating and managing co-created intellectual property or standards.",
+      "Our culture supports ecosystem thinking rather than zero-sum competition.",
+      "We can articulate clear value to prospective partners and are willing to share gains.",
+      "We have planned for exit scenarios and can manage partner divergence without destabilising our core business."
+    ]
+  },
+  {
+    "id": "user-perception/creating-artificial-needs",
+    "title": "Creating Artificial Needs",
+    "description": "Generating demand by inventing or amplifying a need that did not previously exist.",
+    "tags": [
+      "user perception",
+      "demand generation",
+      "marketing",
+      "consumers",
+      "influence",
+      "creating-artificial-needs"
+    ],
+    "permalink": "/strategies/user-perception/creating-artificial-needs/",
+    "category": "user-perception",
+    "mapSignals": [
+      "Our map shows a component with little or no existing demand.",
+      "We have identified a gap between current user behavior and a new product/service offering.",
+      "Competitors are not addressing this \"need\" or category.",
+      "There is potential to associate the offer with strong emotional or social drivers.",
+      "Market signals show openness to new trends or status symbols."
+    ],
+    "readiness": [
+      "We have strong marketing and narrative-building capabilities.",
+      "We can leverage influencers or social proof effectively.",
+      "We have processes for monitoring and responding to public sentiment.",
+      "We are prepared to manage ethical and reputational risks.",
+      "We can iterate quickly based on feedback and adoption rates."
+    ]
+  },
+  {
+    "id": "decelerators/creating-constraints",
+    "title": "Creating Constraints",
+    "description": "Purposefully introduce new bottlenecks to constrain competitors by shaping market, legal, or technical environments.",
+    "tags": [
+      "decelerators",
+      "creating-constraints",
+      "barriers-to-entry",
+      "supply-chain",
+      "exclusivity",
+      "regulation"
+    ],
+    "permalink": "/strategies/decelerators/creating-constraints/",
+    "category": "decelerators",
+    "mapSignals": [
+      "Our map shows a critical component at an early stage of evolution that will become a bottleneck.",
+      "We have identified a future resource that competitors currently take for granted."
+    ],
+    "readiness": [
+      "We have strong negotiation and legal capabilities.",
+      "We can commit the necessary resources to enforce exclusivity or regulation."
+    ]
+  },
+  {
+    "id": "defensive/defensive-regulation",
+    "title": "Defensive Regulation",
+    "description": "A defensive strategy where an incumbent company uses government regulation and lobbying to create barriers to entry and hinder competitors.",
+    "tags": [
+      "defensive",
+      "regulation",
+      "policy",
+      "lobbying",
+      "barriers-to-entry",
+      "incumbents",
+      "compliance",
+      "rent-seeking"
+    ],
+    "permalink": "/strategies/defensive/defensive-regulation/",
+    "category": "defensive",
+    "mapSignals": [
+      "Your industry is already heavily regulated, or is likely to become so.",
+      "A new technology or business model is emerging that threatens to bypass existing regulations.",
+      "Competitors are smaller and have fewer resources to deal with complex compliance requirements.",
+      "Public sentiment can be swayed to support regulations in the name of safety, privacy, or fairness."
+    ],
+    "readiness": [
+      "We have a sophisticated government relations or lobbying team.",
+      "We have the financial resources to engage in a long-term lobbying effort.",
+      "Our leadership has a high tolerance for the ethical and reputational risks associated with this strategy.",
+      "We can craft a narrative that frames our desired regulations as being in the public interest."
+    ]
+  },
+  {
+    "id": "poison/designed-to-fail",
+    "title": "designed-to-fail",
+    "description": "",
+    "tags": [
+      "poison",
+      "denial",
+      "sabotage",
+      "ecosystem-manipulation"
+    ],
+    "permalink": "/strategies/poison/designed-to-fail/",
+    "category": "poison",
+    "mapSignals": [
+      "An adjacent market is forming, but lacks standards or strong leaders.",
+      "We risk disruption if a serious player takes root there.",
+      "We have the credibility to seed a plausible initiative."
+    ],
+    "readiness": [
+      "We can resource a short-term launch without long-term dependency.",
+      "We have legal clearance and PR buffers in place.",
+      "We know how to shut it down cleanly."
+    ]
+  },
+  {
+    "id": "markets/differentiation",
+    "title": "Differentiation",
+    "description": "Creating a unique value proposition by focusing on unmet user needs in less-evolved market spaces.",
+    "tags": [
+      "markets",
+      "value-proposition",
+      "uniqueness",
+      "user-needs",
+      "competition",
+      "positioning",
+      "innovation"
+    ],
+    "permalink": "/strategies/markets/differentiation/",
+    "category": "markets",
+    "mapSignals": [
+      "Your map shows a component in the Genesis or Custom-Built stage, where user needs are still being discovered.",
+      "There is a high degree of uncertainty and potential for innovation in the market.",
+      "Competitors are offering one-size-fits-all solutions that fail to meet the specific needs of certain user segments.",
+      "You have identified a clear, unmet user need that you can address with a unique solution."
+    ],
+    "readiness": [
+      "We have a deep understanding of our target users and their pain points.",
+      "Our organization has a culture of experimentation and is not afraid to take risks.",
+      "We have the R&D capabilities to develop genuinely novel solutions.",
+      "Our marketing team is skilled at communicating the value of our unique features."
+    ]
+  },
+  {
+    "id": "attacking/directed-investment",
+    "title": "Directed Investment",
+    "description": "Making a targeted, venture-capital-style investment in a future change or emerging area to outpace rivals and seize first-mover advantage.",
+    "tags": [
+      "directed-investment",
+      "attacking",
+      "investment",
+      "innovation",
+      "strategic-bets",
+      "disruption",
+      "first-mover"
+    ],
+    "permalink": "/strategies/attacking/directed-investment/",
+    "category": "attacking",
+    "mapSignals": [
+      "Our map reveals a major shift or inevitability in the value chain.",
+      "We have identified a specific emerging area with high potential impact.",
+      "Competitors are slow or unaware of the coming change.",
+      "We have the resources to sustain a long-term, high-risk investment.",
+      "There is a clear path to integration or scaling if successful.",
+      "We understand the risks of isolation or premature integration.",
+      "We have mechanisms to monitor and adapt as the landscape evolves."
+    ],
+    "readiness": [
+      "We are comfortable with uncertainty and long time horizons.",
+      "We have a culture that supports exploration and learning from failure.",
+      "Leadership is willing to commit significant resources early.",
+      "We can protect the investment from short-term pressures.",
+      "We have experience with internal ventures or corporate VC.",
+      "We can balance autonomy and integration for the new initiative.",
+      "We have a process for exiting or pivoting if the bet fails."
+    ]
+  },
+  {
+    "id": "user-perception/education",
+    "title": "Education",
+    "description": "Educating the market or users to overcome their inertia to change by informing them of benefits or risks.",
+    "tags": [
+      "education",
+      "user-perception",
+      "inertia",
+      "adoption",
+      "awareness",
+      "information",
+      "training"
+    ],
+    "permalink": "/strategies/user-perception/education/",
+    "category": "user-perception",
+    "mapSignals": [
+      "Our map shows user or market inertia as a key blocker to adoption.",
+      "There are widespread misconceptions or lack of awareness about our solution or its category.",
+      "Competitors are using FUD or misinformation to slow adoption.",
+      "Adoption rates are low despite strong product/market fit.",
+      "Support or onboarding costs are high due to lack of user understanding."
+    ],
+    "readiness": [
+      "We have the capability to produce high-quality, accessible educational content.",
+      "We can commit to a long-term, sustained education effort.",
+      "We have channels to reach and engage our target audience effectively.",
+      "We are able to measure and iterate on educational impact.",
+      "We can maintain objectivity and credibility in our messaging."
+    ]
+  },
+  {
+    "id": "ecosystem/embrace-and-extend",
+    "title": "Embrace and Extend",
+    "description": "A strategy to gain market dominance by first adopting a widely used standard, then adding proprietary extensions to create a lock-in effect.",
+    "tags": [
+      "ecosystem",
+      "standards",
+      "competition",
+      "dominance",
+      "proprietary-extensions",
+      "lock-in",
+      "microsoft"
+    ],
+    "permalink": "/strategies/ecosystem/embrace-and-extend/",
+    "category": "ecosystem",
+    "mapSignals": [
+      "Your map shows a widely adopted, open standard that is central to a valuable ecosystem.",
+      "The existing standard has clear limitations or unmet user needs that you can address with proprietary extensions.",
+      "Competitors are committed to the open standard and are unlikely to be able to replicate your extensions quickly.",
+      "The ecosystem is fragmented, with no single player having dominant control."
+    ],
+    "readiness": [
+      "We have significant market power and resources to promote our extended version of the standard.",
+      "Our organization has the R&D capability to create genuinely valuable extensions.",
+      "We have a high tolerance for legal and reputational risk, as this strategy is highly controversial.",
+      "Our leadership is willing to play a long, aggressive game to achieve market dominance."
+    ]
+  },
+  {
+    "id": "attacking/experimentation",
+    "title": "Experimentation",
+    "description": "Rapidly testing ideas through hackdays, specialist groups and skunkworks to uncover and exploit opportunities.",
+    "tags": [
+      "experimentation",
+      "attacking",
+      "innovation",
+      "culture",
+      "skunkworks",
+      "hackathons",
+      "rapid iteration",
+      "learning"
+    ],
+    "permalink": "/strategies/attacking/experimentation/",
+    "category": "attacking",
+    "mapSignals": [
+      "Our map has large areas of uncertainty or emerging components.",
+      "Competitors are experimenting with new technologies.",
+      "We see potential new value chains but lack data on viability.",
+      "Internal bureaucracy slows normal development.",
+      "We have capacity to run small pilots without high risk."
+    ],
+    "readiness": [
+      "Leadership supports learning from failure.",
+      "We can dedicate time or teams to hackdays or labs.",
+      "There is a path to integrate successful experiments.",
+      "Metrics capture learning and impact.",
+      "Experimenters are shielded from excessive process."
+    ]
+  },
+  {
+    "id": "decelerators/exploiting-constraint",
+    "title": "Exploiting Existing Constraint",
+    "description": "Amplify an existing bottleneck to hinder competitors by increasing demand or restricting supply to stress their capacity.",
+    "tags": [
+      "decelerators",
+      "exploiting-constraint",
+      "constraint",
+      "bottleneck",
+      "market-manipulation"
+    ],
+    "permalink": "/strategies/decelerators/exploiting-constraint/",
+    "category": "decelerators",
+    "mapSignals": [
+      "Our map shows a competitor with a clear capacity limit in a critical activity.",
+      "Demand can be steered quickly through pricing, bundling, or partnership incentives.",
+      "The constrained component sits outside our own primary differentiators.",
+      "Switching or multi-sourcing is costly for the competitor we plan to target.",
+      "We can widen the bottleneck for our customers without drawing on the same scarce resources."
+    ],
+    "readiness": [
+      "We have alternate supply, reserve capacity, or credible substitutes to meet redirected demand.",
+      "Telemetry and market intelligence give us near real-time insight into the constraint's behaviour.",
+      "Finance, legal, and compliance teams are ready to support sustained pressure within regulatory bounds.",
+      "We can communicate transparently with customers and partners affected by the squeeze.",
+      "Leadership is aligned on exit criteria if the market response becomes destructive."
+    ]
+  },
+  {
+    "id": "accelerators/exploiting-network-effects",
+    "title": "Exploiting Network Effects",
+    "description": "Leveraging tactics that increase the value of your product as more users join",
+    "tags": [
+      "network-effects",
+      "accelerators",
+      "network effects",
+      "growth",
+      "platform",
+      "marketplace",
+      "critical mass",
+      "two-sided markets"
+    ],
+    "permalink": "/strategies/accelerators/exploiting-network-effects/",
+    "category": "accelerators",
+    "mapSignals": [
+      "The value of our offering increases for each user as more users join (same-side or cross-side).",
+      "We’re building or operating a platform, marketplace, or system with two or more interdependent user groups.",
+      "User participation improves the experience for others (e.g., content, data, liquidity, social validation).",
+      "Achieving scale is critical for defensibility and differentiation.",
+      "Competitors are beginning to reach a critical mass that threatens our growth path.",
+      "We face the “cold start problem” but believe our model can tip if enough users join early.",
+      "Data accumulation or user interaction is a key lever in our competitive positioning."
+    ],
+    "readiness": [
+      "We have the ability (and budget) to prioritize user growth over short-term profitability.",
+      "Our team understands the structure and dynamics of network effects (direct, indirect, local, etc.).",
+      "We’ve planned early-stage incentives to attract users (e.g., subsidies, referral loops, exclusives).",
+      "We monitor and act on quality and congestion issues that arise from rapid user growth.",
+      "Our platform is designed to facilitate user interactions and self-reinforcing activity (e.g., sharing, inviting, content generation).",
+      "We have strategies to maintain engagement and increase value as the network grows.",
+      "We are prepared to support a growing user base in terms of infrastructure and service quality."
+    ]
+  },
+  {
+    "id": "positional/fast-follower",
+    "title": "Fast Follower",
+    "description": "Leveraging the mistakes and groundwork of pioneers to enter markets at the optimal time with improved execution.",
+    "tags": [
+      "fast-follower",
+      "positional",
+      "timing",
+      "execution",
+      "imitation",
+      "learning",
+      "market entry"
+    ],
+    "permalink": "/strategies/positional/fast-follower/",
+    "category": "positional",
+    "mapSignals": [
+      "Pioneers have validated market demand and begun scaling.",
+      "Core components are in the product stage, reducing technical risk.",
+      "Customer needs and usage patterns are well understood.",
+      "Pioneer’s execution or cost structure shows clear inefficiencies.",
+      "Competitive focus shifts from exploration to optimisation."
+    ],
+    "readiness": [
+      "We excel at operational execution and rapid iteration.",
+      "We can allocate resources quickly to scale proven ideas.",
+      "Our culture embraces continuous improvement and learning.",
+      "We possess market intelligence to identify and exploit missteps.",
+      "We have processes to integrate and support new offerings."
+    ]
+  },
+  {
+    "id": "user-perception/fear-uncertainty-and-doubt",
+    "title": "Fear, Uncertainty and Doubt",
+    "description": "A classic tactic of spreading fear, uncertainty, and doubt to slow adoption of a competitor's innovation or to dissuade customers from switching.",
+    "tags": [
+      "user-perception",
+      "fud",
+      "competition",
+      "messaging",
+      "risk perception",
+      "slowing adoption"
+    ],
+    "permalink": "/strategies/user-perception/fear-uncertainty-and-doubt/",
+    "category": "user-perception",
+    "mapSignals": [
+      "Our map shows a competitor's offering in an early or unproven stage.",
+      "Customers express anxiety about change or new entrants.",
+      "We have a strong incumbent position with high customer inertia.",
+      "There is significant information asymmetry in the market.",
+      "Switching costs are psychological or reputational, not just technical."
+    ],
+    "readiness": [
+      "We have disciplined, consistent messaging across sales and marketing.",
+      "Our team understands the ethical and legal boundaries of competitive messaging.",
+      "We can monitor and respond to market sentiment quickly.",
+      "We have a crisis communication plan in place.",
+      "We are prepared to counter FUD if it is used against us."
+    ]
+  },
+  {
+    "id": "positional/first-mover",
+    "title": "First Mover",
+    "description": "Establishing a dominant position by industrialising or standardising a component before others.",
+    "tags": [
+      "first-mover",
+      "positional",
+      "timing",
+      "commoditisation",
+      "advantage",
+      "ecosystem",
+      "scale"
+    ],
+    "permalink": "/strategies/positional/first-mover/",
+    "category": "positional",
+    "mapSignals": [
+      "Emerging technology or component with high strategic value and unclear standards.",
+      "Strong signals of market demand but low current competition capacity.",
+      "Opportunities to define interfaces or protocols that others must follow.",
+      "Scale advantages will translate into cost leadership or ecosystem control."
+    ],
+    "readiness": [
+      "We have the capital to invest heavily at scale.",
+      "Our organisation can manage rapid industrial or platform development.",
+      "We possess strong ecosystem relationships and partnership capabilities.",
+      "We can absorb early risks and sustain losses until scale is achieved.",
+      "Our leadership is prepared to set and enforce preferred standards."
+    ]
+  },
+  {
+    "id": "attacking/fools-mate",
+    "title": "Fool's Mate",
+    "description": "A swift, often uncounterable strategic move that exploits a poorly understood or defended component in an opponent's value chain to cause cascading failure or commoditization.",
+    "tags": [
+      "attacking",
+      "industrialization",
+      "commoditisation",
+      "constraint",
+      "surprise",
+      "chess",
+      "disruption",
+      "value chain",
+      "asymmetric warfare"
+    ],
+    "permalink": "/strategies/attacking/fools-mate/",
+    "category": "attacking",
+    "mapSignals": [
+      "Your map reveals an opponent whose value chain depends on a critical component they misunderstand, undervalue, or poorly defend.",
+      "This critical component is susceptible to rapid commoditization or neutralization through means you can deploy (e.g., open-sourcing, new standard, superior free alternative).",
+      "The opponent exhibits low situational awareness regarding this specific vulnerability.",
+      "The commoditization of this component would likely cause a cascading failure or significant disruption in their higher-order systems or business model.",
+      "The market landscape suggests the opponent cannot easily adapt or switch away from this component once it's targeted."
+    ],
+    "readiness": [
+      "Your organization possesses superior situational awareness and a deep understanding of the competitive landscape and opponent's value chain.",
+      "You have the capability to execute the commoditization/neutralization move with exceptional speed and secrecy.",
+      "Your organization is willing to undertake bold, aggressive, and potentially high-risk maneuvers.",
+      "You have a clear strategy for how your organization will operate and benefit in the market landscape *after* the Fool's Mate is executed.",
+      "Your leadership has a high tolerance for ambiguity and the potential for unintended consequences.",
+      "You can withstand potential (though possibly delayed or disorganized) retaliation from the disrupted party."
+    ]
+  },
+  {
+    "id": "competitor/fragmentation",
+    "title": "Fragmentation",
+    "description": "",
+    "tags": [
+      "competitor",
+      "fragmentation",
+      "markets",
+      "underdog",
+      "disruption",
+      "divide and conquer"
+    ],
+    "permalink": "/strategies/competitor/fragmentation/",
+    "category": "competitor",
+    "mapSignals": [
+      "We are facing a dominant competitor who holds a consolidated market position or strong ecosystem control.",
+      "Our mapping reveals unmet needs or underserved customer segments within the competitor’s domain.",
+      "The incumbent’s offering is monolithic, expensive, proprietary, or rigid—leaving room for differentiated alternatives.",
+      "The market is showing signs of frustration, fatigue, or desire for more variety and decentralisation.",
+      "There are potential allies (vendors, communities, regulators) who would benefit from a more open or diverse landscape.",
+      "The competitor’s constraints (pricing, structure, pace of change) prevent them from addressing low-end or edge opportunities."
+    ],
+    "readiness": [
+      "We have or can develop a credible alternative offering that appeals to a specific market segment.",
+      "We can afford to undercut, subsidise, or open-source part of our offering to create market alternatives.",
+      "We understand the risks and trade-offs involved in disrupting a market rather than dominating it directly.",
+      "We are capable of building or supporting an ecosystem around the fragmenting wedge (e.g., partners, standards, community).",
+      "We have the strategic patience to allow fragmentation to unfold over time and the ability to adapt as the landscape changes.",
+      "We can manage a fragmented customer base and provide a clear path to long-term value capture.",
+      "We are prepared to handle counter-moves from the incumbent and mitigate retaliation or narrative shifts."
+    ]
+  },
+  {
+    "id": "markets/harvesting",
+    "title": "Harvesting",
+    "description": "Scaling innovation by observing a platform's ecosystem, identifying successful third-party offerings, and then acquiring, replicating, or integrating them.",
+    "tags": [
+      "markets",
+      "ecosystem",
+      "innovation",
+      "scaling",
+      "acquisition",
+      "replication",
+      "platform-strategy",
+      "sensing-engine"
+    ],
+    "permalink": "/strategies/markets/harvesting/",
+    "category": "markets",
+    "mapSignals": [
+      "Your map shows a platform with a growing ecosystem of third-party developers and solutions.",
+      "There is a high rate of experimentation and innovation happening within your ecosystem.",
+      "You can identify clear patterns of customer demand based on the success of third-party offerings.",
+      "The components being built by the ecosystem are adjacent to your core platform and could be logically integrated."
+    ],
+    "readiness": [
+      "We have a robust platform or ecosystem that is attractive to third-party developers.",
+      "We have effective \"sensing engines\" (e.g., analytics, community engagement) to monitor the ecosystem.",
+      "We have the technical capability to replicate or integrate new features into our platform.",
+      "Our leadership understands the delicate balance required to harvest without poisoning the ecosystem."
+    ]
+  },
+  {
+    "id": "accelerators/industrial-policy",
+    "title": "Industrial Policy",
+    "description": "Aligning with or influencing government investment and policy to accelerate strategic industry evolution.",
+    "tags": [
+      "industrial-policy",
+      "accelerators",
+      "policy",
+      "government",
+      "subsidies",
+      "regulation",
+      "strategic sectors"
+    ],
+    "permalink": "/strategies/accelerators/industrial-policy/",
+    "category": "accelerators",
+    "mapSignals": [
+      "Government announces initiatives or budgets for your sector (e.g., green technology, defense, semiconductors).",
+      "High capital or regulatory barriers exist and public support can materially reduce risk or cost.",
+      "Policy objectives (jobs, security, innovation) align with your strategic goals.",
+      "Political environment is stable enough for multi-year programs."
+    ],
+    "readiness": [
+      "You have resources and expertise for policy engagement or advocacy.",
+      "You can comply with public-sector reporting, audits, and transparency requirements.",
+      "You understand policy development processes and timelines.",
+      "You can deliver pilot projects or prototypes that demonstrate impact."
+    ]
+  },
+  {
+    "id": "ecosystem/innovate-leverage-commoditize",
+    "title": "Innovate, Leverage, Commoditize (ILC)",
+    "description": "A cyclical strategy of using an ecosystem as a sensing engine to guide innovation and maintain market leadership.",
+    "tags": [
+      "ecosystem",
+      "innovate-leverage-commoditize",
+      "ilc",
+      "innovate",
+      "platform",
+      "data",
+      "feedback-loop",
+      "ecosystem-monitoring",
+      "sensing-engine"
+    ],
+    "permalink": "/strategies/ecosystem/innovate-leverage-commoditize/",
+    "category": "ecosystem",
+    "mapSignals": [
+      "Your map shows an opportunity to create a new platform or utility that others can build upon.",
+      "There is a potential for a large and vibrant ecosystem of third-party developers or partners.",
+      "The value chain has multiple layers, allowing for new components to be built on top of existing ones.",
+      "The market is dynamic and fast-moving, making it difficult to predict the next winning feature."
+    ],
+    "readiness": [
+      "We have the capability to build and operate a reliable, scalable platform.",
+      "We have effective \"sensing engines\" – the ability to collect and analyze usage data to spot trends.",
+      "Our organization is agile enough to quickly commoditize a successful pattern once it's identified.",
+      "We understand the importance of balancing our own interests with the health of the ecosystem."
+    ]
+  },
+  {
+    "id": "poison/insertion",
+    "title": "insertion",
+    "description": "",
+    "tags": [
+      "poison",
+      "sabotage",
+      "influence",
+      "misdirection",
+      "competitor-manipulation"
+    ],
+    "permalink": "/strategies/poison/insertion/",
+    "category": "poison",
+    "mapSignals": [
+      "The map shows a competitor gaining momentum in a key component or capability.",
+      "They rely on specialized talent or strategic partnerships you can influence.",
+      "Their decision-making processes are reactive to external narratives.",
+      "There is opacity in their governance or community structures."
+    ],
+    "readiness": [
+      "We have access to channels for covert influence (hires, media, partnerships).",
+      "We can maintain plausible deniability to avoid detection.",
+      "We can monitor the competitor’s internal decisions indirectly.",
+      "We understand regulatory and ethical boundaries of influence operations."
+    ]
+  },
+  {
+    "id": "positional/land-grab",
+    "title": "Land Grab",
+    "description": "Positioning early in an emerging market to capture strategic ground and shape future competitive dynamics.",
+    "tags": [
+      "land-grab",
+      "positional",
+      "market entry",
+      "early mover",
+      "dominance",
+      "infrastructure",
+      "ecosystem control"
+    ],
+    "permalink": "/strategies/positional/land-grab/",
+    "category": "positional",
+    "mapSignals": [
+      "Mapping reveals an emerging space with undefined infrastructure or interfaces.",
+      "High strategic value and low competition in the target domain.",
+      "Opportunity to define standards or own scarce resources early.",
+      "Potential for compounding network effects or ecosystem gravity."
+    ],
+    "readiness": [
+      "We have the capital and tolerance for high upfront investment.",
+      "Our organisation can mobilise resources quickly to secure positions.",
+      "We possess strong relationships to onboard partners and stakeholders.",
+      "We can manage risk of unvalidated spaces and pivot if needed.",
+      "Leadership can sustain long-term commitment to position maintenance."
+    ]
+  },
+  {
+    "id": "markets/last-man-standing",
+    "title": "Last Man Standing",
+    "description": "A strategy of outlasting competitors in a commoditizing market to capture remaining market share.",
+    "tags": [
+      "markets",
+      "commoditisation",
+      "attrition",
+      "scale",
+      "efficiency",
+      "price-war",
+      "market-consolidation"
+    ],
+    "permalink": "/strategies/markets/last-man-standing/",
+    "category": "markets",
+    "mapSignals": [
+      "Your map shows a market that is clearly in the commodity stage of evolution.",
+      "Price is the primary factor in purchasing decisions, and brand loyalty is low.",
+      "Competitors are showing signs of financial distress or are beginning to exit the market.",
+      "The total addressable market, while not growing, is stable and large enough to be valuable."
+    ],
+    "readiness": [
+      "We have a significant cost advantage due to superior scale, automation, or operational efficiency.",
+      "Our organization has the financial resilience to withstand a prolonged period of low or zero margins.",
+      "Our leadership has the discipline and long-term focus to execute a strategy of attrition.",
+      "We have a culture that is obsessed with cost control and efficiency."
+    ]
+  },
+  {
+    "id": "poison/licensing",
+    "title": "Licensing",
+    "description": "Using legal terms to restrict competitors and lock in an ecosystem.",
+    "tags": [
+      "poison",
+      "intellectual-property",
+      "restriction",
+      "lock-in"
+    ],
+    "permalink": "/strategies/poison/licensing/",
+    "category": "poison",
+    "mapSignals": [
+      "Our map highlights critical components that competitors must use.",
+      "There is significant network effect or data dependency in the technology.",
+      "Competitors rely on integrating or extending our IP.",
+      "The legal environment supports robust IP enforcement."
+    ],
+    "readiness": [
+      "We have legal expertise to draft and defend complex licenses.",
+      "We can manage community and partner relations under restrictive terms.",
+      "We have resources to enforce agreements if challenged.",
+      "We understand market tolerance for license complexity."
+    ]
+  },
+  {
+    "id": "defensive/limitation-of-competition",
+    "title": "Limitation of Competition",
+    "description": "Structurally reducing or preventing competitive pressure through regulatory, legal, or environmental barriers.",
+    "tags": [
+      "defensive",
+      "anti-competitive",
+      "barriers-to-entry",
+      "regulation",
+      "incumbents",
+      "market-control",
+      "decelerators"
+    ],
+    "permalink": "/strategies/defensive/limitation-of-competition/",
+    "category": "defensive",
+    "mapSignals": [
+      "Our map shows a critical component or market position at risk from new entrants or substitutes.",
+      "We have, or could gain, significant influence over regulators, standards bodies, or key customers.",
+      "There are existing or emerging rules that could be shaped to our advantage.",
+      "Competitors are seeking to disrupt or bypass current barriers.",
+      "We can credibly justify barriers as serving the public interest (e.g., safety, quality, stability).",
+      "There is a window of opportunity to act before the environment shifts."
+    ],
+    "readiness": [
+      "We have strong relationships with policymakers, regulators, or industry groups.",
+      "We understand the regulatory and standards landscape in detail.",
+      "We can mobilise resources for lobbying, legal, or standards-setting efforts.",
+      "We are prepared for public scrutiny or backlash if our actions are seen as anti-competitive.",
+      "We have contingency plans if barriers are removed or bypassed.",
+      "We can balance defensive plays with ongoing innovation."
+    ]
+  },
+  {
+    "id": "user-perception/lobbying",
+    "title": "Lobbying",
+    "description": "Influencing government or regulatory bodies to shape the environment in your favour, often as a precursor to regulation or limitation of competition.",
+    "tags": [
+      "user-perception",
+      "lobbying",
+      "regulation",
+      "policy",
+      "influence",
+      "government-relations",
+      "alliances",
+      "standards",
+      "defensive",
+      "counterplay"
+    ],
+    "permalink": "/strategies/user-perception/lobbying/",
+    "category": "user-perception",
+    "mapSignals": [
+      "The map shows a critical component or market position at risk from regulatory or policy change.",
+      "There are emerging or proposed rules that could be shaped to your advantage (or to a competitor's disadvantage).",
+      "You have, or could build, influence with policymakers, regulators, or standards bodies.",
+      "Public or user sentiment can be credibly aligned with your position.",
+      "Competitors are actively lobbying for changes that would harm your interests.",
+      "There is a window of opportunity before the environment shifts or rules are set."
+    ],
+    "readiness": [
+      "You have strong relationships with policymakers, regulators, or industry groups.",
+      "You understand the regulatory and standards landscape in detail.",
+      "You can mobilise resources for lobbying, coalition-building, or public campaigns.",
+      "Your organisation can credibly frame its position as serving the public or user interest.",
+      "You have contingency plans for regulatory or political backlash.",
+      "You can coordinate across legal, communications, and technical teams."
+    ]
+  },
+  {
+    "id": "defensive/managing-inertia",
+    "title": "Managing Inertia",
+    "description": "A defensive strategy focused on proactively identifying and overcoming an organization's internal resistance to change to enable adaptation and agility.",
+    "tags": [
+      "defensive",
+      "inertia",
+      "change-management",
+      "adaptation",
+      "organizational-change",
+      "resistance",
+      "culture"
+    ],
+    "permalink": "/strategies/defensive/managing-inertia/",
+    "category": "defensive",
+    "mapSignals": [
+      "Your map shows that your current, profitable business model is built on components that are evolving towards commodity.",
+      "There is a significant gap between how your organization operates and the methods required to succeed in a new, emerging market.",
+      "Competitors are using more modern, agile practices and are gaining market share.",
+      "A new technology or business model threatens to disrupt your industry."
+    ],
+    "readiness": [
+      "Our leadership team is aligned on the need for change and is willing to lead the effort.",
+      "We have a culture that is open to self-reflection and honest assessment of our weaknesses.",
+      "We are willing to challenge long-held assumptions and sacred cows.",
+      "We have the resources and patience to invest in a long-term transformation."
+    ]
+  },
+  {
+    "id": "accelerators/market-enablement",
+    "title": "Market Enablement",
+    "description": "Actively encouraging the growth of a competitive market around a component or service to accelerate its evolution and adoption.",
+    "tags": [
+      "accelerators",
+      "markets",
+      "adoption",
+      "competition",
+      "ecosystem",
+      "open standards",
+      "open approaches",
+      "platform",
+      "value creation"
+    ],
+    "permalink": "/strategies/accelerators/market-enablement/",
+    "category": "accelerators",
+    "mapSignals": [
+      "Our map shows a component whose evolution could be accelerated by broader ecosystem participation.",
+      "There's an opportunity to create or grow a market that would, in turn, benefit our core offerings.",
+      "We can define or influence an open standard that would encourage wider adoption and interoperability.",
+      "The current market for a necessary component is too small, too slow-moving, or too expensive.",
+      "Our business model allows us to capture value from a larger, more competitive market (e.g., through complementary services, data, or scale).",
+      "Competitors are hesitant to invest in growing the market themselves, creating an opening for enablement."
+    ],
+    "readiness": [
+      "Our organization has a long-term strategic vision that values ecosystem growth over direct control in specific areas.",
+      "We are capable of influencing or contributing effectively to industry standards or open platforms.",
+      "We have the resources (financial, technical, personnel) to support market enablement activities (e.g., tool development, community management, funding).",
+      "Our leadership is comfortable with the idea of helping potential competitors if it serves a larger strategic purpose.",
+      "We have a clear plan for how market enablement will ultimately benefit our organization.",
+      "We possess strong communication and relationship-building skills to engage with ecosystem partners.",
+      "We are prepared to handle potential risks, such as loss of direct control or enabling stronger competitors."
+    ]
+  },
+  {
+    "id": "competitor/misdirection",
+    "title": "Misdirection",
+    "description": "",
+    "tags": [
+      "misdirection",
+      "competitor",
+      "deception",
+      "assumptions",
+      "signals",
+      "influence",
+      "competitor intelligence"
+    ],
+    "permalink": "/strategies/competitor/misdirection/",
+    "category": "competitor",
+    "mapSignals": [
+      "Our strategy depends on timing, secrecy, or avoiding early competitive response.",
+      "We expect close monitoring by competitors—through public filings, media, patents, or announcements.",
+      "Our competitor is resource-constrained or prone to overreacting to market shifts.",
+      "The competitive landscape rewards surprise and first-mover advantage.",
+      "There is a viable narrative or decoy path we can promote without internal disruption.",
+      "We need to delay or deflect competitive attention from our true area of focus."
+    ],
+    "readiness": [
+      "We understand the intelligence channels our competitors monitor and how they interpret signals.",
+      "We can coordinate internal and external messaging to maintain a consistent decoy narrative.",
+      "We have disciplined execution and security practices to prevent accidental leaks of the real strategy.",
+      "We have a clear internal understanding of the misdirection vs. real intent across relevant teams.",
+      "We are prepared to monitor and assess competitor behavior in response to our signals.",
+      "We can manage stakeholder trust and minimize fallout if the misdirection is uncovered.",
+      "We have a timeline and trigger for revealing or pivoting from the decoy to the real move."
+    ]
+  },
+  {
+    "id": "accelerators/open-approaches",
+    "title": "Open Approaches",
+    "description": "Making something open—source, standards, data, or APIs—to accelerate adoption, drive commoditisation, and enable ecosystem growth.",
+    "tags": [
+      "open approaches",
+      "accelerators",
+      "open source",
+      "open standards",
+      "open data",
+      "collaboration",
+      "community",
+      "commoditisation"
+    ],
+    "permalink": "/strategies/accelerators/open-approaches/",
+    "category": "accelerators",
+    "mapSignals": [
+      "Our map shows a component that is utility-like or becoming a commodity.",
+      "There is significant friction (cost, licensing, integration) in adoption.",
+      "Competitors or the market are held back by proprietary barriers.",
+      "Ecosystem growth or network effects will impact our other components.",
+      "We are positioned to capture value above the open layer."
+    ],
+    "readiness": [
+      "We are skilled at community management and governance.",
+      "We have a clear alternative revenue model (e.g., services, premium features).",
+      "We can outpace competitors that might benefit from our openness.",
+      "We can maintain quality and security in an open environment.",
+      "We have the resources to support an open community."
+    ]
+  },
+  {
+    "id": "decelerators/ipr",
+    "title": "Patents & Intellectual Property Rights",
+    "description": "Use patents and other IP rights to legally fence competitors and slow their technological progress.",
+    "tags": [
+      "decelerators",
+      "ipr",
+      "intellectual-property",
+      "patents",
+      "licensing"
+    ],
+    "permalink": "/strategies/decelerators/ipr/",
+    "category": "decelerators",
+    "mapSignals": [
+      "We have identified a critical technology with high future impact.",
+      "Our map shows competitors relying on unprotected alternatives."
+    ],
+    "readiness": [
+      "We have resources to manage filings, portfolios, and enforcement.",
+      "We can sustain potential litigation or licensing negotiations."
+    ]
+  },
+  {
+    "id": "dealing-with-toxicity/pig-in-a-poke",
+    "title": "Pig in a Poke",
+    "description": "Disguising toxic assets as valuable to offload risk before their true nature emerges.",
+    "tags": [
+      "dealing-with-toxicity",
+      "pig-in-a-poke",
+      "deception",
+      "misrepresentation",
+      "exit-strategy",
+      "risk-mitigation"
+    ],
+    "permalink": "/strategies/dealing-with-toxicity/pig-in-a-poke/",
+    "category": "dealing-with-toxicity",
+    "mapSignals": [
+      "Our map shows an asset in decline but with residual market excitement.",
+      "Operational metrics can be temporarily inflated or spun positively.",
+      "Buyers are eager for growth opportunities and may cut corners on due diligence.",
+      "Market sentiment is in a bubble or speculative phase."
+    ],
+    "readiness": [
+      "We can control the narrative and presentation of asset health.",
+      "Legal exposure from misrepresentation is manageable or mitigated.",
+      "We have the speed and agility to complete a sale before scrutiny intensifies.",
+      "Leadership is willing to accept reputational risk in exchange for exit gain."
+    ]
+  },
+  {
+    "id": "ecosystem/platform-envelopment",
+    "title": "Platform Envelopment",
+    "description": "A platform provider expands its market influence by integrating or bundling functionality of another platform, or by directly competing with its own users.",
+    "tags": [
+      "platform-envelopment",
+      "ecosystem",
+      "platform",
+      "bundling",
+      "absorption",
+      "integration"
+    ],
+    "permalink": "/strategies/ecosystem/platform-envelopment/",
+    "category": "ecosystem",
+    "mapSignals": [
+      "Our platform has a significant, established user base.",
+      "There is a high degree of overlap between our user base and the users of an adjacent service.",
+      "We can identify functionalities that, if integrated, would significantly enhance our platform's value proposition.",
+      "Our map shows opportunities to absorb custom-built services offered by our users into standardized platform features."
+    ],
+    "readiness": [
+      "We have the engineering and product resources to integrate or build new functionalities.",
+      "Our organization is prepared to manage the potential channel conflict or alienation of partners/users.",
+      "We have a strong understanding of the competitive landscape and potential anti-trust implications.",
+      "Our platform architecture is flexible enough to incorporate new services."
+    ]
+  },
+  {
+    "id": "attacking/playing-both-sides",
+    "title": "Playing Both Sides",
+    "description": "Profiting from or hedging by engaging with two opposing sides in a market or standards war, so that whichever side wins, you benefit.",
+    "tags": [
+      "attacking",
+      "markets",
+      "standards",
+      "arbitrage",
+      "uncertainty",
+      "hedging",
+      "neutrality"
+    ],
+    "permalink": "/strategies/attacking/playing-both-sides/",
+    "category": "attacking",
+    "mapSignals": [
+      "The market is split between two or more competing standards or platforms.",
+      "The outcome of the competition is highly uncertain.",
+      "We can act as a neutral intermediary or supplier to all sides.",
+      "The cost of supporting multiple sides is lower than the potential cost of choosing the wrong one."
+    ],
+    "readiness": [
+      "We have the resources to support multiple product lines or initiatives.",
+      "Our brand can withstand the ambiguity of not picking a side.",
+      "We have strong capabilities in managing complex partnerships.",
+      "Our stakeholders are comfortable with a strategy of neutrality."
+    ]
+  },
+  {
+    "id": "attacking/press-release-process",
+    "title": "Press Release Process",
+    "description": "Using Amazon's \"working backwards\" method to ensure clarity of vision and market fit.",
+    "tags": [
+      "press-release-process",
+      "attacking",
+      "marketing",
+      "product development",
+      "working backwards",
+      "customer focus",
+      "amazon",
+      "clarity"
+    ],
+    "permalink": "/strategies/attacking/press-release-process/",
+    "category": "attacking",
+    "mapSignals": [
+      "We're initiating development of a new product, feature, or user-facing service.",
+      "Our maps show high user visibility but unclear or underdefined value propositions.",
+      "The supporting components are largely evolved (Product/Commodity) and suitable for industrialisation.",
+      "We’ve struggled in the past with alignment, scope creep, or launching initiatives with weak customer traction.",
+      "There’s a mismatch between technical enthusiasm and market pull in our current pipeline.",
+      "We need a mechanism to surface capability gaps early and steer resource allocation accordingly."
+    ],
+    "readiness": [
+      "We have teams willing and able to adopt narrative-driven development practices (e.g., writing a press release first).",
+      "We are comfortable iterating product ideas at a narrative level before committing to build.",
+      "We have the strategic discipline to let user-facing narrative shape scope and priorities, not the other way around.",
+      "We can map value chains and assess component maturity to validate feasibility of the proposed press release.",
+      "We are able to integrate marketing, product, and engineering perspectives early in the development process.",
+      "We can use narrative friction (e.g., press release feels weak) as a legitimate signal to rethink or stop.",
+      "We treat the press release as a living artefact that continues to guide execution—not just a kickoff ritual."
+    ]
+  },
+  {
+    "id": "markets/pricing-policy",
+    "title": "Pricing Policy",
+    "description": "Using pricing as a strategic tool to manipulate demand, shape markets, and gain competitive advantage.",
+    "tags": [
+      "markets",
+      "pricing",
+      "elasticity",
+      "demand-manipulation",
+      "value-capture",
+      "commoditisation",
+      "fragmentation"
+    ],
+    "permalink": "/strategies/markets/pricing-policy/",
+    "category": "markets",
+    "mapSignals": [
+      "Your map shows a component that is ripe for commoditization through aggressive pricing.",
+      "There is a high degree of price elasticity in your market, meaning demand is sensitive to price changes.",
+      "Your competitors have rigid pricing structures that are slow to adapt.",
+      "There are opportunities to fragment the market with modular or tiered pricing."
+    ],
+    "readiness": [
+      "We have a deep understanding of our cost structure and the value our products provide to customers.",
+      "Our finance and marketing teams work closely together to set and manage prices.",
+      "We have the systems in place to experiment with different pricing models and measure the results.",
+      "Our leadership is willing to use pricing as a strategic lever, even if it means short-term margin reduction."
+    ]
+  },
+  {
+    "id": "defensive/procrastination",
+    "title": "Procrastination",
+    "description": "A defensive strategy of deliberately waiting for competitors to bear the costs and risks of developing a new market or technology before entering.",
+    "tags": [
+      "defensive",
+      "waiting",
+      "fast-follower",
+      "risk-mitigation",
+      "cost-reduction",
+      "observation",
+      "second-mover-advantage"
+    ],
+    "permalink": "/strategies/defensive/procrastination/",
+    "category": "defensive",
+    "mapSignals": [
+      "Your map shows a component in the Genesis stage that is highly uncertain and requires significant investment to develop.",
+      "Competitors are rushing to invest in this new, unproven area.",
+      "The component is not part of your core, differentiated value proposition.",
+      "There is no significant, lasting first-mover advantage in this market."
+    ],
+    "readiness": [
+      "Our organization has the discipline and patience to wait while competitors make the first move.",
+      "We have strong market intelligence capabilities to monitor the progress of the pioneers.",
+      "We have the agility to move quickly and decisively when the time is right to enter the market.",
+      "Our leadership can effectively communicate and defend a strategy of deliberate inaction."
+    ]
+  },
+  {
+    "id": "defensive/raising-barriers-to-entry",
+    "title": "Raising Barriers to Entry",
+    "description": "A defensive strategy of increasing the complexity and scope of a product or service to make it more difficult for new competitors to enter the market.",
+    "tags": [
+      "defensive",
+      "barriers-to-entry",
+      "competition",
+      "incumbents",
+      "market-expectations",
+      "complexity",
+      "bundling"
+    ],
+    "permalink": "/strategies/defensive/raising-barriers-to-entry/",
+    "category": "defensive",
+    "mapSignals": [
+      "Your map shows that your product is part of a larger value chain with many adjacent components that could be bundled.",
+      "New entrants are attempting to enter the market by focusing on a single, niche component of your offering.",
+      "Customers are showing a preference for integrated solutions over a collection of point solutions.",
+      "You have the capability to build or acquire and integrate these adjacent components."
+    ],
+    "readiness": [
+      "We have a strong market position and the resources to invest in expanding our product portfolio.",
+      "Our organization is skilled at integrating different products and technologies into a cohesive user experience.",
+      "We have a strong brand that can be leveraged to promote the bundled solution.",
+      "Our leadership is willing to increase complexity to build a long-term defensive moat."
+    ]
+  },
+  {
+    "id": "dealing-with-toxicity/refactoring",
+    "title": "refactoring",
+    "description": "",
+    "tags": [
+      "refactoring",
+      "dealing-with-toxicity",
+      "legacy",
+      "transformation",
+      "reuse",
+      "reorganization",
+      "internal disposal"
+    ],
+    "permalink": "/strategies/dealing-with-toxicity/refactoring/",
+    "category": "dealing-with-toxicity",
+    "mapSignals": [
+      "We are managing a legacy system or operation whose relevance or value is declining.",
+      "Our mapping reveals subcomponents of the legacy asset with ongoing or potential value.",
+      "The cost of full disposal is high, politically or practically, and we need a less abrupt exit.",
+      "There are internal dependencies or knowledge embedded in the system worth preserving.",
+      "We foresee a decline curve that allows time for planned transformation, rather than emergency action.",
+      "There is an opportunity to integrate salvaged components into emerging strategic initiatives.",
+      "The legacy asset is a source of internal toxicity or inertia that must be addressed methodically."
+    ],
+    "readiness": [
+      "We have the capacity to assess legacy components for reuse (skills, tech, data, infrastructure).",
+      "We are able to execute internal reorganizations without destabilizing other operations.",
+      "We can support dual operations temporarily (legacy and new systems in parallel).",
+      "Our culture tolerates gradual change and has experience with transformation projects.",
+      "We have mechanisms in place to retrain or redeploy people effectively and respectfully.",
+      "We can communicate clearly across teams and functions during transitions.",
+      "We have a defined timeline and governance structure to keep the refactoring on track."
+    ]
+  },
+  {
+    "id": "competitor/reinforcing-competitor-inertia",
+    "title": "Reinforcing Competitor Inertia",
+    "description": "",
+    "tags": [
+      "reinforcing-competitor-inertia",
+      "competitor",
+      "inertia",
+      "change",
+      "resistance",
+      "obsolescence",
+      "innovation"
+    ],
+    "permalink": "/strategies/competitor/reinforcing-competitor-inertia/",
+    "category": "competitor",
+    "mapSignals": [
+      "A dominant competitor is visibly tied to a legacy business model, architecture, or operational approach.",
+      "Market trends, user behaviours, or enabling technologies are clearly evolving away from that model.",
+      "The competitor’s revenue, cost structure, or brand positioning depends heavily on the status quo.",
+      "There are emerging options or platforms that challenge the dominant model but require further legitimacy or scale.",
+      "Your mapping suggests the current strategic direction of the competitor is increasingly mismatched with user needs.",
+      "The competitive environment is dynamic enough that small shifts can accumulate into structural market change."
+    ],
+    "readiness": [
+      "We have sufficient agility to adopt and promote the new model, while absorbing initial inefficiencies or lower margins.",
+      "We can operate in a mode of deliberate contrast—offering something genuinely different and future-facing.",
+      "We’re capable of articulating a compelling narrative that positions our approach as modern or inevitable.",
+      "We understand how to subtly provoke the competitor—e.g., through pricing, product positioning, or public framing—without triggering a meaningful pivot.",
+      "We monitor competitor behaviour closely and can detect signals of defensive entrenchment or reactive inertia.",
+      "We’re confident in our interpretation of the market shift and have contingency plans if the transition unfolds differently than expected.",
+      "We have safeguards in place to avoid internal inertia mirroring that of the competitor we seek to exploit."
+    ]
+  },
+  {
+    "id": "competitor/restriction-of-movement",
+    "title": "Restriction of Movement",
+    "description": "",
+    "tags": [
+      "restriction-of-movement",
+      "competitor",
+      "circling",
+      "ecosystem",
+      "cornering",
+      "constraint",
+      "control",
+      "limitation"
+    ],
+    "permalink": "/strategies/competitor/restriction-of-movement/",
+    "category": "competitor",
+    "mapSignals": [
+      "The competitor depends heavily on a limited set of suppliers, channels, technologies, or partnerships to compete.",
+      "The ecosystem shows signs of centralisation: critical enablers (e.g., platforms, standards, IP, influencers) can be controlled or preempted.",
+      "Market boundaries are shifting, making it possible to act ahead of the competitor in adjacent segments.",
+      "Your mapping reveals vulnerable access points (e.g., talent hubs, regulatory choke points, key APIs or standards) that the competitor relies on.",
+      "The competitor has made recent moves that expose overdependence or lack of diversification in their strategic options.",
+      "You have identified untapped user needs or areas where you can over-service the market to preempt lateral moves."
+    ],
+    "readiness": [
+      "We have the operational scale or ecosystem reach to preemptively lock in key resources (e.g., suppliers, partners, infrastructure).",
+      "We can coordinate across functions (product, legal, partnerships, marketing) to execute a coherent constraint strategy.",
+      "We maintain strong intelligence on competitor movements and ecosystem dynamics to detect shifts quickly.",
+      "We understand how to frame our actions to avoid regulatory or reputational blowback (e.g., as innovation or customer service).",
+      "We have diversified capabilities that allow us to respond flexibly while restricting the movement of others.",
+      "We can model and monitor multiple fronts of competitive interaction (technology, market access, partnerships, talent).",
+      "We maintain ethical and strategic clarity to avoid escalation or overreach that damages long-term position."
+    ]
+  },
+  {
+    "id": "competitor/sapping",
+    "title": "Sapping",
+    "description": "",
+    "tags": [
+      "sapping",
+      "competitor",
+      "multi-front",
+      "attrition",
+      "endurance",
+      "resource drain",
+      "distraction"
+    ],
+    "permalink": "/strategies/competitor/sapping/",
+    "category": "competitor",
+    "mapSignals": [
+      "The competitor holds a focused position or limited scope, making them vulnerable to attacks from multiple directions.",
+      "The landscape includes multiple battlegrounds (product lines, geographies, pricing tiers, partnerships) where competitive pressure can be applied concurrently.",
+      "There is no dominant centre of gravity in the competitor's position—weaknesses are distributed across areas rather than concentrated in one.",
+      "The market is fluid enough that pressure on one front can create ripple effects across others (e.g. customer trust, talent drain, partner defection).",
+      "The competitor's past responses suggest limited coordination capacity or resource depth to handle simultaneous disruption.",
+      "Your mapping suggests strategic congestion: the competitor is over-reliant on a few defensive levers across many fronts."
+    ],
+    "readiness": [
+      "We have sufficient resources (capital, people, infrastructure) to sustain pressure across multiple fronts without overextending.",
+      "We maintain organisational agility and can pivot or shift intensity as outcomes unfold across different domains.",
+      "We have robust internal coordination mechanisms—cross-functional teams, shared intelligence, strategic alignment—to synchronise effort across fronts.",
+      "We have clear success criteria and escalation plans for each front to avoid resource drain on non-performing initiatives.",
+      "We can quickly learn from competitor responses and redistribute focus where it’s most effective.",
+      "We’ve prepared countermeasures in case the competitor consolidates and retaliates strongly on one or more fronts.",
+      "We have leadership bandwidth and morale resilience to guide a prolonged, multi-front engagement without strategic drift."
+    ]
+  },
+  {
+    "id": "markets/signal-distortion",
+    "title": "Signal Distortion",
+    "description": "Manipulating market signals to mislead competitors and influence their strategic decisions.",
+    "tags": [
+      "markets",
+      "perception",
+      "information-warfare",
+      "competitor",
+      "influence",
+      "hype",
+      "signals",
+      "misdirection"
+    ],
+    "permalink": "/strategies/markets/signal-distortion/",
+    "category": "markets",
+    "mapSignals": [
+      "Your competitors are known to be heavily influenced by industry analysts and media reports.",
+      "The market is characterized by a high degree of uncertainty and speculation.",
+      "There are established and trusted channels for disseminating information that you can leverage.",
+      "Your competitors have a history of reacting strongly to perceived threats or opportunities."
+    ],
+    "readiness": [
+      "We have a sophisticated public relations and marketing team capable of crafting and disseminating complex narratives.",
+      "Our organization has a high tolerance for ethical ambiguity and the associated risks.",
+      "We have the resources to create credible-looking signals and sustain the narrative over time.",
+      "Our leadership is skilled in strategic communication and understands the psychology of the market."
+    ]
+  },
+  {
+    "id": "markets/standards-game",
+    "title": "Standards Game",
+    "description": "Driving adoption of your technology or process until it becomes the dominant standard, locking in customers and constraining competitors.",
+    "tags": [
+      "standards",
+      "markets",
+      "dominance",
+      "competition",
+      "differentiation",
+      "switching costs",
+      "lock-in"
+    ],
+    "permalink": "/strategies/markets/standards-game/",
+    "category": "markets",
+    "mapSignals": [
+      "The market suffers from fragmentation or competing formats.",
+      "We control a technology that others depend on or want access to.",
+      "Adoption of a common approach would create network effects.",
+      "Competitors are divided among incompatible alternatives."
+    ],
+    "readiness": [
+      "We can provide and maintain a reference implementation.",
+      "We have influence with regulators or standards bodies.",
+      "Our brand or market share is strong enough to drive adoption.",
+      "We are committed to supporting the standard long term."
+    ]
+  },
+  {
+    "id": "dealing-with-toxicity/disposal-of-liability",
+    "title": "Strategic Divestment and Disposal of Liability",
+    "description": "Strategically restructuring by separating or selling off business units, assets, or divisions to unlock value, enhance focus, or dispose of liabilities.",
+    "tags": [
+      "dealing-with-toxicity",
+      "legacy",
+      "divestment",
+      "exit-strategy",
+      "inertia",
+      "obsolescence",
+      "risk-mitigation",
+      "strategic-divestment",
+      "spin-off",
+      "carve-out",
+      "restructuring"
+    ],
+    "permalink": "/strategies/dealing-with-toxicity/disposal-of-liability/",
+    "category": "dealing-with-toxicity",
+    "mapSignals": [
+      "Our map shows key components stuck in a mature or commodity stage.",
+      "Maintaining these components ties up significant resources.",
+      "Internal teams resist moving away from established but unproductive assets.",
+      "The asset creates strategic inertia, blocking new initiatives."
+    ],
+    "readiness": [
+      "We have authority to make divestment decisions.",
+      "Leadership is willing to champion disposal despite pushback.",
+      "We can support stakeholders through transition (customers, employees).",
+      "We have legal and operational plans for divestment or shutdown."
+    ]
+  },
+  {
+    "id": "dealing-with-toxicity/sweat-and-dump",
+    "title": "Sweat & Dump",
+    "description": "Outsource operation of a legacy asset to a third party, extract remaining value, and exit before the cost curve turns against you.",
+    "tags": [
+      "dealing-with-toxicity",
+      "sweat-and-dump",
+      "outsourcing",
+      "third-party",
+      "exit-strategy",
+      "cost-reduction",
+      "risk-mitigation",
+      "capex",
+      "inertia"
+    ],
+    "permalink": "/strategies/dealing-with-toxicity/sweat-and-dump/",
+    "category": "dealing-with-toxicity",
+    "mapSignals": [
+      "Key components are mature or in decline but still producing revenue.",
+      "Legacy operations distract from high-priority initiatives and modern system development.",
+      "Specialist operators exist who will take on capex and run down assets cost-effectively.",
+      "Immediate shutdown would destroy residual value or harm relationships.",
+      "The cost of maintaining and investing in the legacy system outweighs its strategic value."
+    ],
+    "readiness": [
+      "We can identify and contract reliable third parties willing to invest.",
+      "We have clear transfer protocols for staff, data, contracts, and asset ownership/operation.",
+      "We can define exit criteria and performance milestones related to value extraction and our own modernization efforts.",
+      "We are prepared to handle brand and quality risks externally while focusing on new systems."
+    ]
+  },
+  {
+    "id": "competitor/talent-raid",
+    "title": "Talent Raid",
+    "description": "Removing or absorbing key talent from a rival organisation.",
+    "tags": [
+      "talent-raid",
+      "competitor",
+      "talent",
+      "human resources",
+      "acquisition",
+      "poaching",
+      "expertise",
+      "weakening rivals"
+    ],
+    "permalink": "/strategies/competitor/talent-raid/",
+    "category": "competitor",
+    "mapSignals": [
+      "The competitor’s capabilities heavily depend on identifiable individuals or elite teams rather than scalable systems.",
+      "Your mapping reveals bottlenecks or critical initiatives within the competitor’s organisation led by high-impact talent.",
+      "The competitive landscape shows a scarcity of domain expertise, making individual contributors disproportionately valuable.",
+      "The pace of innovation is closely tied to talent mobility. I.e., knowledge transfer has immediate strategic impact.",
+      "The competitor is vulnerable to disruption via internal morale shocks, e.g., key departures trigger cascading exits or project slowdowns.",
+      "The market or technology area is in early stages of evolution, where individual expertise carries more strategic weight than process maturity."
+    ],
+    "readiness": [
+      "We can identify and assess high-value individuals or teams within competitors, including their likely motivations and risk tolerance.",
+      "We offer an environment (culture, mission, comp structure) attractive to top-tier talent, especially those leaving high-pressure roles.",
+      "We have legal, HR, and onboarding capabilities to execute poaching sensitively, including managing non-competes, IP issues, and integration.",
+      "We understand the optics. Our leadership can manage internal morale and external perception when executing a visible talent raid.",
+      "We have systems in place to quickly harness and amplify the incoming talent’s strengths (e.g., clear roles, support, follow-on hires).",
+      "We avoid overdependence on raiding by maintaining strong internal talent development and succession pipelines.",
+      "We can model and monitor the downstream impact. E.g., knowledge gained, competitor project disruption, market influence of new hires."
+    ]
+  },
+  {
+    "id": "competitor/tech-drops",
+    "title": "Tech Drops",
+    "description": "Surprising competitors with significant and unexpected technological advances to seize initiative and reshape the market.",
+    "tags": [
+      "competitor",
+      "surprise",
+      "innovation",
+      "technology",
+      "tech-drop",
+      "disruption",
+      "proactive",
+      "market-creation"
+    ],
+    "permalink": "/strategies/competitor/tech-drops/",
+    "category": "competitor",
+    "mapSignals": [
+      "We have a capability that competitors see as low-evolution, but we've industrialized it.",
+      "Competitors are locked into predictable roadmaps or public development cycles.",
+      "We can surprise a market segment showing signs of stagnation or unmet need.",
+      "We control a critical bottleneck or dependency in the value chain that enables a surprise move."
+    ],
+    "readiness": [
+      "We've developed this in secret with strong information control and security.",
+      "Our infrastructure, supply chain, and support teams are ready to scale on launch day.",
+      "Marketing and launch coordination are in place for a high-impact, coordinated release.",
+      "We have a fallback plan if competitors react more quickly or negatively than expected.",
+      "The innovation is significant and defensible, not just an incremental feature."
+    ]
+  },
+  {
+    "id": "defensive/threat-acquisition",
+    "title": "Threat Acquisition",
+    "description": "A defensive strategy where a company acquires a potential competitor to neutralize a threat and maintain market position.",
+    "tags": [
+      "defensive",
+      "acquisition",
+      "competition",
+      "market-consolidation",
+      "mergers",
+      "neutralization"
+    ],
+    "permalink": "/strategies/defensive/threat-acquisition/",
+    "category": "defensive",
+    "mapSignals": [
+      "A new entrant on your map is gaining traction in a key market segment.",
+      "A competitor is developing a technology that could disrupt your business model.",
+      "A smaller company holds a key patent or intellectual property that is critical to your industry.",
+      "The cost of acquiring the threat is significantly lower than the potential loss of market share."
+    ],
+    "readiness": [
+      "We have a dedicated team for market scanning and competitor analysis.",
+      "Our leadership is experienced in mergers and acquisitions.",
+      "We have the financial resources to make a strategic acquisition without jeopardizing our core business.",
+      "We have a clear process for integrating new companies and technologies."
+    ]
+  },
+  {
+    "id": "ecosystem/tower-and-moat",
+    "title": "Tower and Moat",
+    "description": "Establishing a dominant position in a future market (the Tower) and building defensive barriers (the Moat) to prevent competition.",
+    "tags": [
+      "ecosystem",
+      "dominance",
+      "defensive",
+      "barriers-to-entry",
+      "platform",
+      "network-effects",
+      "commoditisation",
+      "innovate-leverage-commoditize"
+    ],
+    "permalink": "/strategies/ecosystem/tower-and-moat/",
+    "category": "ecosystem",
+    "mapSignals": [
+      "Your map shows a component in the Genesis or Custom-Built stage that you believe will become a critical utility in the future.",
+      "You can see a path for this component to become a central hub in a future, valuable ecosystem.",
+      "There are adjacent, higher-order components that could be commoditized to build a moat.",
+      "No competitor has yet recognized or begun to build this future Tower."
+    ],
+    "readiness": [
+      "We have a strong, long-term vision and the ability to make significant, sustained investments with delayed returns.",
+      "Our organization has the R&D capability to build the Tower and the agility to commoditize emerging threats.",
+      "We are skilled at building and nurturing large-scale ecosystems.",
+      "Our leadership has the conviction to pursue a high-risk, high-reward strategy."
+    ]
+  },
+  {
+    "id": "ecosystem/two-factor-markets",
+    "title": "Two-Sided Markets",
+    "description": "Creating a platform that brings together two distinct groups of users (e.g., buyers and sellers) to create value through network effects.",
+    "tags": [
+      "ecosystem",
+      "platform",
+      "marketplace",
+      "network-effects",
+      "providers",
+      "consumers",
+      "data-aggregation"
+    ],
+    "permalink": "/strategies/ecosystem/two-factor-markets/",
+    "category": "ecosystem",
+    "mapSignals": [
+      "Your map shows two distinct and fragmented groups of users who could benefit from being connected.",
+      "There is a potential for strong, positive network effects between the two groups.",
+      "No existing platform is effectively serving the needs of both sides of the market.",
+      "The interactions between the two sides can generate valuable data."
+    ],
+    "readiness": [
+      "We have a clear strategy for solving the \"chicken and egg\" problem to attract both sides of the market.",
+      "We have the technical capability to build and scale a robust and trustworthy platform.",
+      "Our organization is skilled at community management and balancing the needs of different user groups.",
+      "We have a plan for monetizing the platform without alienating either side."
+    ]
+  },
+  {
+    "id": "attacking/undermining-barriers-to-entry",
+    "title": "Undermining Barriers to Entry",
+    "description": "An offensive strategy focused on identifying and dismantling a key barrier that protects an incumbent, thereby opening the market to new competition.",
+    "tags": [
+      "attacking",
+      "barriers-to-entry",
+      "inertia",
+      "competition",
+      "open-source",
+      "open-approaches",
+      "disruption",
+      "challenger"
+    ],
+    "permalink": "/strategies/attacking/undermining-barriers-to-entry/",
+    "category": "attacking",
+    "mapSignals": [
+      "Your map shows an incumbent protected by a single, clear barrier to entry (e.g., a proprietary component, high cost of entry).",
+      "This barrier is a source of frustration for customers or other players in the ecosystem.",
+      "You have a technology or business model that can significantly reduce or eliminate this barrier.",
+      "The market is stagnant, with little innovation due to the incumbent's protected position."
+    ],
+    "readiness": [
+      "We are a challenger, not the incumbent who benefits from the barrier.",
+      "We have a clear strategy for how we will compete and win in the more competitive market we are about to create.",
+      "We have the resources and the risk appetite to take on a powerful incumbent directly.",
+      "Our brand is associated with disruption, openness, or being on the side of the customer."
+    ]
+  },
+  {
+    "id": "dealing-with-toxicity/value-chain-disaggregation-and-re-aggregation",
+    "title": "Value Chain Disaggregation and Re-aggregation",
+    "description": "Strategically breaking down and recombining value chain components to unlock new operating models and market opportunities.",
+    "tags": [
+      "value chain",
+      "disaggregation",
+      "re-aggregation",
+      "dealing-with-toxicity",
+      "transformation",
+      "reorganization",
+      "strategic-shift",
+      "modularization"
+    ],
+    "permalink": "/strategies/dealing-with-toxicity/value-chain-disaggregation-and-re-aggregation/",
+    "category": "dealing-with-toxicity",
+    "mapSignals": [
+      "Our current value chain is monolithic and struggles to adapt to market changes.",
+      "Mapping reveals that significant value is locked in integrated components that could be more efficient or innovative if separated.",
+      "New technologies or business models are emerging that threaten our integrated approach.",
+      "Competitors are successfully leveraging disaggregated models to capture market share.",
+      "There are opportunities to create new value by recombining disaggregated components in novel ways.",
+      "Our map shows user needs that are unmet by the current, integrated value chain."
+    ],
+    "readiness": [
+      "We have strong capabilities in strategic analysis and business model innovation.",
+      "Our leadership is willing to undertake significant organizational and structural change.",
+      "We can manage complex partner ecosystems and multi-party collaborations.",
+      "We have the technical capabilities to modularize systems and processes.",
+      "Our organizational culture can adapt to new roles and ways of working.",
+      "We have a clear vision for how disaggregation and re-aggregation will create value.",
+      "We can invest significant resources (time, capital, talent) into this transformation."
+    ]
+  },
+  {
+    "id": "positional/weak-signal-horizon",
+    "title": "Weak Signal (Horizon)",
+    "description": "Detecting subtle economic, technological, and behavioural patterns to anticipate market shifts before they become obvious.",
+    "tags": [
+      "weak-signal-horizon",
+      "positional",
+      "sensing",
+      "anticipation",
+      "foresight",
+      "market shifts",
+      "patterns",
+      "signals"
+    ],
+    "permalink": "/strategies/positional/weak-signal-horizon/",
+    "category": "positional",
+    "mapSignals": [
+      "Value chain mapping shows components nearing transition points.",
+      "Multiple weak indicators converge on a potential strategic shift.",
+      "Early adopters or niche segments show emerging behaviours.",
+      "Technological readiness signals (e.g., cost curves, prototypes) are present."
+    ],
+    "readiness": [
+      "We have data collection and analysis capabilities.",
+      "Our culture values curiosity and early experimentation.",
+      "We can rapidly translate insights into pilot initiatives.",
+      "Leadership supports investment in sensing and foresight.",
+      "We maintain cross-functional collaboration to interpret signals."
+    ]
+  }
+];
+
+export default strategies;

--- a/src/pages/strategy-navigator/index.tsx
+++ b/src/pages/strategy-navigator/index.tsx
@@ -1,0 +1,469 @@
+import React, {useMemo, useState} from 'react';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+import clsx from 'clsx';
+import strategies, {StrategyMetadata} from '@site/src/data/strategyIndex';
+import styles from './styles.module.css';
+
+type SignalOption = {
+  text: string;
+  count: number;
+};
+
+function buildSignalOptions(
+  data: StrategyMetadata[],
+  key: 'mapSignals' | 'readiness',
+): SignalOption[] {
+  const counts = new Map<string, number>();
+  data.forEach((strategy) => {
+    strategy[key].forEach((statement) => {
+      const trimmed = statement.trim();
+      if (!trimmed) {
+        return;
+      }
+      counts.set(trimmed, (counts.get(trimmed) ?? 0) + 1);
+    });
+  });
+
+  return Array.from(counts.entries())
+    .map(([text, count]) => ({text, count}))
+    .sort((a, b) => {
+      if (b.count === a.count) {
+        return a.text.localeCompare(b.text);
+      }
+      return b.count - a.count;
+    });
+}
+
+function useSignalSuggestions(
+  options: SignalOption[],
+  selected: string[],
+  search: string,
+): SignalOption[] {
+  const lowerSearch = search.trim().toLowerCase();
+  return useMemo(() => {
+    return options
+      .filter((option) => !selected.includes(option.text))
+      .filter((option) =>
+        lowerSearch ? option.text.toLowerCase().includes(lowerSearch) : true,
+      )
+      .slice(0, 8);
+  }, [lowerSearch, options, selected]);
+}
+
+function normaliseCategory(category: string): string {
+  return category.replace(/-/g, ' ');
+}
+
+type Result = {
+  strategy: StrategyMetadata;
+  mapMatches: string[];
+  readinessMatches: string[];
+  score: number;
+};
+
+type ResultRow = Result & {
+  matchesSearch: boolean;
+  matchesCategory: boolean;
+  matchesSignals: boolean;
+};
+
+export default function StrategyNavigatorPage(): JSX.Element {
+  const categories = useMemo(() => {
+    return Array.from(new Set(strategies.map((item) => item.category))).sort((a, b) =>
+      a.localeCompare(b),
+    );
+  }, []);
+
+  const mapOptions = useMemo(() => buildSignalOptions(strategies, 'mapSignals'), []);
+  const readinessOptions = useMemo(
+    () => buildSignalOptions(strategies, 'readiness'),
+    [],
+  );
+
+  const [selectedMapSignals, setSelectedMapSignals] = useState<string[]>([]);
+  const [selectedReadinessSignals, setSelectedReadinessSignals] = useState<string[]>([]);
+  const [mapSearch, setMapSearch] = useState('');
+  const [readinessSearch, setReadinessSearch] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+
+  const mapSuggestions = useSignalSuggestions(
+    mapOptions,
+    selectedMapSignals,
+    mapSearch,
+  );
+  const readinessSuggestions = useSignalSuggestions(
+    readinessOptions,
+    selectedReadinessSignals,
+    readinessSearch,
+  );
+
+  const addMapSignal = (signal: string) => {
+    setSelectedMapSignals((current) =>
+      current.includes(signal) ? current : [...current, signal],
+    );
+    setMapSearch('');
+  };
+
+  const addReadinessSignal = (signal: string) => {
+    setSelectedReadinessSignals((current) =>
+      current.includes(signal) ? current : [...current, signal],
+    );
+    setReadinessSearch('');
+  };
+
+  const removeMapSignal = (signal: string) => {
+    setSelectedMapSignals((current) => current.filter((item) => item !== signal));
+  };
+
+  const removeReadinessSignal = (signal: string) => {
+    setSelectedReadinessSignals((current) =>
+      current.filter((item) => item !== signal),
+    );
+  };
+
+  const toggleCategory = (category: string) => {
+    setSelectedCategories((current) =>
+      current.includes(category)
+        ? current.filter((item) => item !== category)
+        : [...current, category],
+    );
+  };
+
+  const clearSignals = () => {
+    setSelectedMapSignals([]);
+    setSelectedReadinessSignals([]);
+  };
+
+  const lowerSearchTerm = searchTerm.trim().toLowerCase();
+  const hasSignalFilters =
+    selectedMapSignals.length > 0 || selectedReadinessSignals.length > 0;
+  const selectedCategorySet = useMemo(
+    () => new Set(selectedCategories),
+    [selectedCategories],
+  );
+
+  const results = useMemo(() => {
+    return strategies
+      .map<ResultRow>((strategy) => {
+        const mapMatches = strategy.mapSignals.filter((signal) =>
+          selectedMapSignals.includes(signal),
+        );
+        const readinessMatches = strategy.readiness.filter((signal) =>
+          selectedReadinessSignals.includes(signal),
+        );
+        const searchHaystack = [
+          strategy.title,
+          strategy.description,
+          strategy.category,
+          ...strategy.tags,
+          ...strategy.mapSignals,
+          ...strategy.readiness,
+        ]
+          .join(' ')
+          .toLowerCase();
+        const matchesSearch = lowerSearchTerm
+          ? searchHaystack.includes(lowerSearchTerm)
+          : true;
+        const matchesCategory =
+          selectedCategorySet.size === 0 || selectedCategorySet.has(strategy.category);
+        const matchesSignals =
+          !hasSignalFilters || mapMatches.length + readinessMatches.length > 0;
+        const score = mapMatches.length * 3 + readinessMatches.length * 2;
+        return {
+          strategy,
+          mapMatches,
+          readinessMatches,
+          score,
+          matchesSearch,
+          matchesCategory,
+          matchesSignals,
+        } satisfies ResultRow;
+      })
+      .filter(
+        (entry) => entry.matchesSearch && entry.matchesCategory && entry.matchesSignals,
+      )
+      .sort((a, b) => {
+        if (hasSignalFilters) {
+          if (b.score !== a.score) {
+            return b.score - a.score;
+          }
+          if (b.mapMatches.length !== a.mapMatches.length) {
+            return b.mapMatches.length - a.mapMatches.length;
+          }
+          if (b.readinessMatches.length !== a.readinessMatches.length) {
+            return b.readinessMatches.length - a.readinessMatches.length;
+          }
+        }
+        return a.strategy.title.localeCompare(b.strategy.title);
+      });
+  }, [
+    hasSignalFilters,
+    lowerSearchTerm,
+    selectedCategorySet,
+    selectedMapSignals,
+    selectedReadinessSignals,
+  ]);
+
+  return (
+    <Layout
+      title="Strategy Navigator"
+      description="Filter Wardley strategies by the signals you see on your map and the doctrine you have in place."
+    >
+      <main className={styles.page}>
+        <header className={styles.hero}>
+          <h1>Strategy Navigator</h1>
+          <p>
+            Choose the context you see on your map and the doctrine your organisation has
+            mastered. The navigator ranks Wardley strategies that best align with your
+            situation and highlights the signals they expect to see.
+          </p>
+          {hasSignalFilters ? (
+            <button type="button" className="button button--sm button--secondary" onClick={clearSignals}>
+              Clear selected signals
+            </button>
+          ) : null}
+        </header>
+
+        <section className={styles.filtersSection}>
+          <div className={styles.filterGrid}>
+            <div className={styles.filterCard}>
+              <h2>Landscape signals</h2>
+              <p className={styles.filterIntro}>
+                Add statements that describe what you see on the map. We’ll match strategies that
+                reference the same signals.
+              </p>
+              <input
+                type="text"
+                className={styles.searchInput}
+                value={mapSearch}
+                onChange={(event) => setMapSearch(event.target.value)}
+                placeholder="Search landscape signals"
+              />
+              <div className={styles.chipList}>
+                {selectedMapSignals.map((signal) => (
+                  <span key={signal} className={styles.chip}>
+                    {signal}
+                    <button
+                      type="button"
+                      aria-label={`Remove ${signal}`}
+                      onClick={() => removeMapSignal(signal)}
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
+              </div>
+              <div className={styles.suggestionList}>
+                {mapSuggestions.length === 0 ? (
+                  <p className={styles.emptyState}>No matching signals yet.</p>
+                ) : (
+                  mapSuggestions.map((option) => (
+                    <button
+                      key={option.text}
+                      type="button"
+                      className={styles.suggestionButton}
+                      onClick={() => addMapSignal(option.text)}
+                    >
+                      <span>{option.text}</span>
+                      <span className={styles.suggestionCount}>{option.count}</span>
+                    </button>
+                  ))
+                )}
+              </div>
+            </div>
+
+            <div className={styles.filterCard}>
+              <h2>Doctrine readiness</h2>
+              <p className={styles.filterIntro}>
+                Add doctrine statements your organisation satisfies. Matching strategies surface when
+                their readiness list aligns with your strengths.
+              </p>
+              <input
+                type="text"
+                className={styles.searchInput}
+                value={readinessSearch}
+                onChange={(event) => setReadinessSearch(event.target.value)}
+                placeholder="Search doctrine readiness"
+              />
+              <div className={styles.chipList}>
+                {selectedReadinessSignals.map((signal) => (
+                  <span key={signal} className={styles.chip}>
+                    {signal}
+                    <button
+                      type="button"
+                      aria-label={`Remove ${signal}`}
+                      onClick={() => removeReadinessSignal(signal)}
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
+              </div>
+              <div className={styles.suggestionList}>
+                {readinessSuggestions.length === 0 ? (
+                  <p className={styles.emptyState}>No matching readiness signals yet.</p>
+                ) : (
+                  readinessSuggestions.map((option) => (
+                    <button
+                      key={option.text}
+                      type="button"
+                      className={styles.suggestionButton}
+                      onClick={() => addReadinessSignal(option.text)}
+                    >
+                      <span>{option.text}</span>
+                      <span className={styles.suggestionCount}>{option.count}</span>
+                    </button>
+                  ))
+                )}
+              </div>
+            </div>
+
+            <div className={styles.filterCard}>
+              <h2>Refine the results</h2>
+              <p className={styles.filterIntro}>
+                Combine text search with category filters to drill into specific areas of play.
+              </p>
+              <input
+                type="text"
+                className={styles.searchInput}
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                placeholder="Search titles, tags and descriptions"
+              />
+              <div className={styles.categoryList}>
+                {categories.map((category) => (
+                  <button
+                    key={category}
+                    type="button"
+                    className={clsx(styles.categoryButton, {
+                      [styles.categoryButtonActive]: selectedCategories.includes(category),
+                    })}
+                    onClick={() => toggleCategory(category)}
+                  >
+                    {normaliseCategory(category)}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.resultsSection}>
+          <div className={styles.resultsHeader}>
+            <h2>Recommended strategies</h2>
+            <p>
+              {results.length} strategy{results.length === 1 ? '' : 'ies'} match your current filters.
+              Strategies with more matching signals rise to the top.
+            </p>
+          </div>
+          {results.length === 0 ? (
+            <div className={styles.emptyResults}>
+              <p>No strategies match all of your selections yet.</p>
+              <p>Try removing a filter or broadening your search terms.</p>
+            </div>
+          ) : (
+            <div className={styles.strategyGrid}>
+              {results.map(({strategy, mapMatches, readinessMatches, score}) => {
+                const remainingMapSignals = strategy.mapSignals
+                  .filter((signal) => !mapMatches.includes(signal))
+                  .slice(0, 3);
+                const remainingReadiness = strategy.readiness
+                  .filter((signal) => !readinessMatches.includes(signal))
+                  .slice(0, 3);
+                return (
+                  <article key={strategy.id} className={styles.strategyCard}>
+                    <header className={styles.strategyHeader}>
+                      <div>
+                        <Link to={strategy.permalink} className={styles.strategyTitle}>
+                          {strategy.title}
+                        </Link>
+                        <span className={styles.categoryBadge}>
+                          {normaliseCategory(strategy.category)}
+                        </span>
+                      </div>
+                      {hasSignalFilters ? (
+                        <div className={styles.scoreBadge}>
+                          <span className={styles.scoreValue}>{score}</span>
+                          <span className={styles.scoreLabel}>fit score</span>
+                        </div>
+                      ) : null}
+                    </header>
+                    <p className={styles.strategyDescription}>{strategy.description}</p>
+                    <div className={styles.tagList}>
+                      {strategy.tags.slice(0, 6).map((tag) => (
+                        <span key={tag} className={styles.tag}>
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+
+                    {mapMatches.length > 0 ? (
+                      <div className={styles.matchBlock}>
+                        <h3>Landscape match</h3>
+                        <ul>
+                          {mapMatches.map((signal) => (
+                            <li key={signal}>{signal}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    ) : null}
+
+                    {readinessMatches.length > 0 ? (
+                      <div className={styles.matchBlock}>
+                        <h3>Doctrine match</h3>
+                        <ul>
+                          {readinessMatches.map((signal) => (
+                            <li key={signal}>{signal}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    ) : null}
+
+                    {(remainingMapSignals.length > 0 || remainingReadiness.length > 0) && (
+                      <div className={styles.remainingSignals}>
+                        {remainingMapSignals.length > 0 ? (
+                          <div>
+                            <span className={styles.remainingLabel}>Also looks for</span>
+                            <div className={styles.remainingChips}>
+                              {remainingMapSignals.map((signal) => (
+                                <button
+                                  key={signal}
+                                  type="button"
+                                  onClick={() => addMapSignal(signal)}
+                                >
+                                  {signal}
+                                </button>
+                              ))}
+                            </div>
+                          </div>
+                        ) : null}
+                        {remainingReadiness.length > 0 ? (
+                          <div>
+                            <span className={styles.remainingLabel}>Needs readiness such as</span>
+                            <div className={styles.remainingChips}>
+                              {remainingReadiness.map((signal) => (
+                                <button
+                                  key={signal}
+                                  type="button"
+                                  onClick={() => addReadinessSignal(signal)}
+                                >
+                                  {signal}
+                                </button>
+                              ))}
+                            </div>
+                          </div>
+                        ) : null}
+                      </div>
+                    )}
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </section>
+      </main>
+    </Layout>
+  );
+}

--- a/src/pages/strategy-navigator/styles.module.css
+++ b/src/pages/strategy-navigator/styles.module.css
@@ -1,0 +1,321 @@
+.page {
+  padding: 2rem 0 4rem;
+}
+
+.hero {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.hero p {
+  max-width: 56rem;
+  margin: 0 auto 1.5rem;
+  color: var(--ifm-color-emphasis-600);
+  font-size: 1.05rem;
+}
+
+.filtersSection {
+  margin-bottom: 3rem;
+}
+
+.filterGrid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.filterCard {
+  background: var(--ifm-card-background-color);
+  border-radius: 14px;
+  padding: 1.5rem;
+  box-shadow: var(--ifm-global-shadow-lw);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.filterCard h2 {
+  font-size: 1.2rem;
+  margin-bottom: 0.25rem;
+}
+
+.filterIntro {
+  color: var(--ifm-color-emphasis-600);
+  margin-bottom: 0.5rem;
+}
+
+.searchInput {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 0.6rem;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  width: 100%;
+}
+
+.chipList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chip {
+  background: var(--ifm-color-primary-contrast-background);
+  border: 1px solid var(--ifm-color-primary);
+  color: var(--ifm-color-primary-darker);
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.65rem;
+  font-size: 0.8rem;
+}
+
+.chip button {
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0;
+}
+
+.suggestionList {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.suggestionButton {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.suggestionButton:hover {
+  border-color: var(--ifm-color-primary);
+  transform: translateY(-1px);
+}
+
+.suggestionCount {
+  background: var(--ifm-color-emphasis-200);
+  border-radius: 999px;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-800);
+}
+
+.emptyState {
+  color: var(--ifm-color-emphasis-500);
+  font-style: italic;
+  margin: 0;
+}
+
+.categoryList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.categoryButton {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: transparent;
+  color: var(--ifm-color-emphasis-700);
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.categoryButtonActive {
+  background: var(--ifm-color-primary);
+  border-color: var(--ifm-color-primary);
+  color: #fff;
+}
+
+.resultsSection {
+  margin-top: 2rem;
+}
+
+.resultsHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.resultsHeader p {
+  color: var(--ifm-color-emphasis-600);
+  margin: 0;
+}
+
+.emptyResults {
+  background: var(--ifm-card-background-color);
+  border-radius: 14px;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: var(--ifm-global-shadow-lw);
+  color: var(--ifm-color-emphasis-600);
+}
+
+.strategyGrid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+}
+
+.strategyCard {
+  background: var(--ifm-card-background-color);
+  border-radius: 16px;
+  padding: 1.75rem;
+  box-shadow: var(--ifm-global-shadow-lw);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.strategyCard:hover {
+  border-color: var(--ifm-color-primary-lightest);
+  transform: translateY(-2px);
+}
+
+.strategyHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.strategyTitle {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--ifm-color-primary-darker);
+}
+
+.strategyTitle:hover {
+  text-decoration: underline;
+}
+
+.categoryBadge {
+  display: inline-block;
+  margin-top: 0.3rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-emphasis-800);
+  font-size: 0.75rem;
+  text-transform: capitalize;
+}
+
+.scoreBadge {
+  background: var(--ifm-color-primary-contrast-background);
+  border-radius: 12px;
+  padding: 0.3rem 0.7rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.1rem;
+  min-width: 70px;
+}
+
+.scoreValue {
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: var(--ifm-color-primary-darker);
+}
+
+.scoreLabel {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.strategyDescription {
+  color: var(--ifm-color-emphasis-600);
+  margin: 0;
+}
+
+.tagList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.tag {
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-color-emphasis-700);
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.75rem;
+}
+
+.matchBlock h3 {
+  font-size: 0.95rem;
+  margin-bottom: 0.3rem;
+}
+
+.matchBlock ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.remainingSignals {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+  padding-top: 0.75rem;
+}
+
+.remainingLabel {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.remainingChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.3rem;
+}
+
+.remainingChips button {
+  border: 1px dashed var(--ifm-color-emphasis-300);
+  background: transparent;
+  color: var(--ifm-color-emphasis-700);
+  border-radius: 999px;
+  padding: 0.3rem 0.65rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.remainingChips button:hover {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+}
+
+@media (max-width: 768px) {
+  .hero {
+    text-align: left;
+  }
+
+  .hero p {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- add a generator script that builds `src/data/strategyIndex.ts` from the strategy markdown and document how to run it
- introduce an interactive Strategy Navigator page with multi-signal filtering and contextual recommendations powered by the generated index
- expose the navigator through the main navigation bar and style the new experience

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9c14a4d6c832baa2d59e50261ab1f