### PR TITLE
Add interactive strategy explorer and metadata plugin

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -2,6 +2,7 @@ import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import storeSiteDataPlugin from './src/plugins/storeSiteData';
+import strategyMetadataPlugin from './src/plugins/strategyMetadata';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
@@ -109,6 +110,10 @@ const config: Config = {
         {
           label: 'Strategies',
           to: '/strategies',
+        },
+        {
+          label: 'Strategy Explorer',
+          to: '/strategy-explorer',
         },
         {
           label: 'Doctrines',
@@ -220,7 +225,8 @@ const config: Config = {
   plugins: [
     require.resolve('docusaurus-lunr-search'),
     '@docusaurus/plugin-vercel-analytics',
-    storeSiteDataPlugin
+    storeSiteDataPlugin,
+    strategyMetadataPlugin,
   ],
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "docusaurus-lunr-search": "^3.6.0",
+        "gray-matter": "^4.0.3",
         "lucide-react": "^0.523.0",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "docusaurus-lunr-search": "^3.6.0",
+    "gray-matter": "^4.0.3",
     "lucide-react": "^0.523.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.1.0",

--- a/src/components/StrategyExplorer/index.tsx
+++ b/src/components/StrategyExplorer/index.tsx
@@ -1,0 +1,541 @@
+import React, {useMemo, useState} from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import Heading from '@theme/Heading';
+import {usePluginData} from '@docusaurus/useGlobalData';
+import type {
+  StrategyMetadata,
+  StrategyMetadataGlobalData,
+} from '@site/src/types/strategyMetadata';
+import styles from './styles.module.css';
+
+type FilteredStrategy = {
+  strategy: StrategyMetadata;
+  score: number;
+  matchingSkills: string[];
+};
+
+type FilterKind =
+  | 'Category'
+  | 'Evolution stage'
+  | 'Strategic insight area'
+  | 'Ethical alignment'
+  | 'Leadership skill';
+
+type ActiveFilterChip = {
+  type: FilterKind;
+  value: string;
+  onRemove: () => void;
+};
+
+function normalizeLabel(value: string): string {
+  return value
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function useSortedUnique(values: (string | undefined)[]): string[] {
+  return useMemo(() => {
+    return Array.from(
+      new Set(values.filter((value): value is string => Boolean(value?.trim()))),
+    ).sort((a, b) => a.localeCompare(b));
+  }, [values]);
+}
+
+function FilterGroup({
+  title,
+  options,
+  selected,
+  onToggle,
+  limit,
+}: {
+  title: string;
+  options: string[];
+  selected: Set<string>;
+  onToggle: (value: string) => void;
+  limit?: number;
+}): JSX.Element {
+  const [showAll, setShowAll] = useState(false);
+  const visibleOptions = useMemo(() => {
+    if (!limit || showAll || options.length <= limit) {
+      return options;
+    }
+    return options.slice(0, limit);
+  }, [limit, options, showAll]);
+
+  const hasHiddenOptions = Boolean(limit) && options.length > (limit ?? 0);
+
+  return (
+    <section className={styles.filterSection}>
+      <header className={styles.filterSectionHeader}>
+        <Heading as="h3" className={styles.filterSectionTitle}>
+          {title}
+        </Heading>
+        {hasHiddenOptions && (
+          <button
+            type="button"
+            className={styles.showMoreButton}
+            onClick={() => setShowAll((value) => !value)}>
+            {showAll ? 'Show fewer' : `Show all ${options.length}`}
+          </button>
+        )}
+      </header>
+      <div className={styles.filterOptions}>
+        {visibleOptions.map((option) => (
+          <label key={option} className={styles.filterOption}>
+            <input
+              type="checkbox"
+              checked={selected.has(option)}
+              onChange={() => onToggle(option)}
+            />
+            <span>{option}</span>
+          </label>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function StrategyCard({
+  item,
+  selectedSkills,
+}: {
+  item: FilteredStrategy;
+  selectedSkills: Set<string>;
+}): JSX.Element {
+  const {strategy, matchingSkills} = item;
+  const humanCategory = normalizeLabel(strategy.category);
+  const skills = strategy.leadershipSkills;
+  const nonMatchingSkills = skills.filter((skill) => !selectedSkills.has(skill));
+
+  return (
+    <article className={clsx('card shadow--md', styles.strategyCard)}>
+      <div className={styles.cardHeader}>
+        <Heading as="h3" className={styles.cardTitle}>
+          <Link to={strategy.permalink}>{strategy.title}</Link>
+        </Heading>
+        <span className={styles.categoryPill}>{humanCategory}</span>
+      </div>
+      {strategy.description && (
+        <p className={styles.cardDescription}>{strategy.description}</p>
+      )}
+      <div className={styles.metaRow}>
+        {strategy.evolutionStage && (
+          <span className={styles.metaBadge}>
+            Evolution: {strategy.evolutionStage}
+          </span>
+        )}
+        {strategy.strategicInsightArea && (
+          <span className={styles.metaBadge}>
+            Insight: {strategy.strategicInsightArea}
+          </span>
+        )}
+        {strategy.ethicalAlignment && (
+          <span className={styles.metaBadge}>
+            Ethics: {strategy.ethicalAlignment}
+          </span>
+        )}
+      </div>
+      {selectedSkills.size > 0 && (
+        <p className={styles.matchSummary}>
+          Matches {matchingSkills.length} of {selectedSkills.size} selected leadership skills
+        </p>
+      )}
+      {skills.length > 0 && (
+        <div className={styles.skillsList}>
+          {matchingSkills.map((skill) => (
+            <span key={`match-${skill}`} className={clsx(styles.skillChip, styles.skillChipActive)}>
+              {skill}
+            </span>
+          ))}
+          {nonMatchingSkills.map((skill) => (
+            <span key={skill} className={styles.skillChip}>
+              {skill}
+            </span>
+          ))}
+        </div>
+      )}
+      <div className={styles.contextGrid}>
+        {strategy.whenToUse && (
+          <div className={styles.contextBlock}>
+            <strong>Use when</strong>
+            <p>{strategy.whenToUse}</p>
+          </div>
+        )}
+        {strategy.whenToAvoid && (
+          <div className={styles.contextBlock}>
+            <strong>Avoid when</strong>
+            <p>{strategy.whenToAvoid}</p>
+          </div>
+        )}
+        {strategy.coreChallenge && (
+          <div className={styles.contextBlock}>
+            <strong>Core challenge</strong>
+            <p>{strategy.coreChallenge}</p>
+          </div>
+        )}
+      </div>
+      <div className={styles.cardFooter}>
+        <Link className="button button--primary button--sm" to={strategy.permalink}>
+          Open strategy
+        </Link>
+        {strategy.tags.slice(0, 3).length > 0 && (
+          <div className={styles.tagList}>
+            {strategy.tags.slice(0, 3).map((tag) => (
+              <span key={tag} className={styles.tagChip}>
+                #{tag}
+              </span>
+            ))}
+            {strategy.tags.length > 3 && <span className={styles.tagOverflow}>+{strategy.tags.length - 3}</span>}
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}
+
+export default function StrategyExplorer(): JSX.Element {
+  const pluginData = usePluginData<StrategyMetadataGlobalData>('strategy-metadata-plugin');
+  const strategies = pluginData?.strategies ?? [];
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+  const [selectedEvolutionStages, setSelectedEvolutionStages] = useState<string[]>([]);
+  const [selectedInsightAreas, setSelectedInsightAreas] = useState<string[]>([]);
+  const [selectedEthicalAlignment, setSelectedEthicalAlignment] = useState<string[]>([]);
+  const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
+
+  const categoryOptions = useMemo(
+    () =>
+      Array.from(new Set(strategies.map((strategy) => normalizeLabel(strategy.category)))).sort(
+        (a, b) => a.localeCompare(b),
+      ),
+    [strategies],
+  );
+  const evolutionOptions = useSortedUnique(strategies.map((strategy) => strategy.evolutionStage));
+  const insightOptions = useSortedUnique(
+    strategies.map((strategy) => strategy.strategicInsightArea),
+  );
+  const ethicalOptions = useSortedUnique(
+    strategies.map((strategy) => strategy.ethicalAlignment),
+  );
+  const skillOptions = useSortedUnique(
+    strategies.flatMap((strategy) => strategy.leadershipSkills),
+  );
+
+  const selectedCategorySlugs = useMemo(
+    () =>
+      new Set(
+        selectedCategories.map((label) =>
+          label
+            .toLowerCase()
+            .split(' ')
+            .join('-'),
+        ),
+      ),
+    [selectedCategories],
+  );
+
+  const selectedEvolutionSet = useMemo(
+    () => new Set(selectedEvolutionStages),
+    [selectedEvolutionStages],
+  );
+  const selectedInsightSet = useMemo(
+    () => new Set(selectedInsightAreas),
+    [selectedInsightAreas],
+  );
+  const selectedEthicalSet = useMemo(
+    () => new Set(selectedEthicalAlignment),
+    [selectedEthicalAlignment],
+  );
+  const selectedSkillsSet = useMemo(() => new Set(selectedSkills), [selectedSkills]);
+
+  const filteredStrategies = useMemo(() => {
+    const search = searchQuery.trim().toLowerCase();
+    return strategies
+      .map<FilteredStrategy | null>((strategy) => {
+        if (selectedCategorySlugs.size > 0 && !selectedCategorySlugs.has(strategy.category)) {
+          return null;
+        }
+        if (
+          selectedEvolutionSet.size > 0 &&
+          (!strategy.evolutionStage || !selectedEvolutionSet.has(strategy.evolutionStage))
+        ) {
+          return null;
+        }
+        if (
+          selectedInsightSet.size > 0 &&
+          (!strategy.strategicInsightArea || !selectedInsightSet.has(strategy.strategicInsightArea))
+        ) {
+          return null;
+        }
+        if (
+          selectedEthicalSet.size > 0 &&
+          (!strategy.ethicalAlignment || !selectedEthicalSet.has(strategy.ethicalAlignment))
+        ) {
+          return null;
+        }
+
+        const matchingSkills = strategy.leadershipSkills.filter((skill) =>
+          selectedSkillsSet.has(skill),
+        );
+        if (selectedSkillsSet.size > 0 && matchingSkills.length !== selectedSkillsSet.size) {
+          return null;
+        }
+
+        const haystack = [
+          strategy.title,
+          strategy.description,
+          strategy.whenToUse,
+          strategy.whenToAvoid,
+          strategy.coreChallenge,
+          strategy.strategicInsightArea,
+          strategy.evolutionStage,
+          strategy.ethicalAlignment,
+          strategy.category,
+          ...strategy.tags,
+          ...strategy.leadershipSkills,
+        ]
+          .filter(Boolean)
+          .join(' ')
+          .toLowerCase();
+        if (search && !haystack.includes(search)) {
+          return null;
+        }
+
+        let score = 0;
+        if (search) {
+          const title = strategy.title.toLowerCase();
+          const description = strategy.description.toLowerCase();
+          if (title.includes(search)) {
+            score += 4;
+          } else if (description.includes(search)) {
+            score += 2;
+          } else {
+            score += 1;
+          }
+        }
+        if (selectedCategorySlugs.size > 0) {
+          score += 2;
+        }
+        if (selectedEvolutionSet.size > 0) {
+          score += 2;
+        }
+        if (selectedInsightSet.size > 0) {
+          score += 2;
+        }
+        if (selectedEthicalSet.size > 0) {
+          score += 1;
+        }
+        score += matchingSkills.length * 2;
+
+        return {strategy, score, matchingSkills};
+      })
+      .filter((item): item is FilteredStrategy => item !== null)
+      .sort((a, b) => b.score - a.score || a.strategy.title.localeCompare(b.strategy.title));
+  }, [
+    strategies,
+    searchQuery,
+    selectedCategorySlugs,
+    selectedEvolutionSet,
+    selectedInsightSet,
+    selectedEthicalSet,
+    selectedSkillsSet,
+  ]);
+
+  const activeFilterChips: ActiveFilterChip[] = useMemo(() => {
+    const chips: ActiveFilterChip[] = [];
+    selectedCategories.forEach((value) =>
+      chips.push({
+        type: 'Category',
+        value,
+        onRemove: () =>
+          setSelectedCategories((current) => current.filter((item) => item !== value)),
+      }),
+    );
+    selectedEvolutionStages.forEach((value) =>
+      chips.push({
+        type: 'Evolution stage',
+        value,
+        onRemove: () =>
+          setSelectedEvolutionStages((current) => current.filter((item) => item !== value)),
+      }),
+    );
+    selectedInsightAreas.forEach((value) =>
+      chips.push({
+        type: 'Strategic insight area',
+        value,
+        onRemove: () =>
+          setSelectedInsightAreas((current) => current.filter((item) => item !== value)),
+      }),
+    );
+    selectedEthicalAlignment.forEach((value) =>
+      chips.push({
+        type: 'Ethical alignment',
+        value,
+        onRemove: () =>
+          setSelectedEthicalAlignment((current) => current.filter((item) => item !== value)),
+      }),
+    );
+    selectedSkills.forEach((value) =>
+      chips.push({
+        type: 'Leadership skill',
+        value,
+        onRemove: () => setSelectedSkills((current) => current.filter((item) => item !== value)),
+      }),
+    );
+    return chips;
+  }, [
+    selectedCategories,
+    selectedEvolutionStages,
+    selectedInsightAreas,
+    selectedEthicalAlignment,
+    selectedSkills,
+  ]);
+
+  const activeFilterCount = activeFilterChips.length + (searchQuery.trim() ? 1 : 0);
+
+  return (
+    <div className={styles.layout}>
+      <aside className={styles.filterPanel}>
+        <div className={styles.searchGroup}>
+          <label htmlFor="strategy-search" className={styles.searchLabel}>
+            Search for scenarios, tags, or keywords
+          </label>
+          <input
+            id="strategy-search"
+            type="search"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            className={styles.searchInput}
+            placeholder="e.g. network effects, regulation, accelerate"
+          />
+        </div>
+        <FilterGroup
+          title="Category"
+          options={categoryOptions}
+          selected={new Set(selectedCategories)}
+          onToggle={(value) =>
+            setSelectedCategories((current) =>
+              current.includes(value)
+                ? current.filter((item) => item !== value)
+                : [...current, value],
+            )
+          }
+        />
+        <FilterGroup
+          title="Evolution stage"
+          options={evolutionOptions}
+          selected={selectedEvolutionSet}
+          onToggle={(value) =>
+            setSelectedEvolutionStages((current) =>
+              current.includes(value)
+                ? current.filter((item) => item !== value)
+                : [...current, value],
+            )
+          }
+        />
+        <FilterGroup
+          title="Strategic insight area"
+          options={insightOptions}
+          selected={selectedInsightSet}
+          onToggle={(value) =>
+            setSelectedInsightAreas((current) =>
+              current.includes(value)
+                ? current.filter((item) => item !== value)
+                : [...current, value],
+            )
+          }
+        />
+        <FilterGroup
+          title="Ethical alignment"
+          options={ethicalOptions}
+          selected={selectedEthicalSet}
+          onToggle={(value) =>
+            setSelectedEthicalAlignment((current) =>
+              current.includes(value)
+                ? current.filter((item) => item !== value)
+                : [...current, value],
+            )
+          }
+        />
+        <FilterGroup
+          title="Leadership skills"
+          options={skillOptions}
+          selected={selectedSkillsSet}
+          onToggle={(value) =>
+            setSelectedSkills((current) =>
+              current.includes(value)
+                ? current.filter((item) => item !== value)
+                : [...current, value],
+            )
+          }
+          limit={10}
+        />
+        <button
+          type="button"
+          className={styles.clearFiltersButton}
+          onClick={() => {
+            setSearchQuery('');
+            setSelectedCategories([]);
+            setSelectedEvolutionStages([]);
+            setSelectedInsightAreas([]);
+            setSelectedEthicalAlignment([]);
+            setSelectedSkills([]);
+          }}
+          disabled={activeFilterCount === 0}>
+          Clear all filters
+        </button>
+      </aside>
+      <section className={styles.resultsSection}>
+        <header className={styles.resultsHeader}>
+          <div>
+            <Heading as="h2" className={styles.resultsTitle}>
+              {filteredStrategies.length} matching strategies
+            </Heading>
+            <p className={styles.resultsSubtitle}>
+              Showing the best-fit Wardley plays out of {strategies.length} strategies in the library.
+            </p>
+          </div>
+          {activeFilterCount > 0 && (
+            <div className={styles.activeFiltersSummary}>
+              Active filters ({activeFilterCount})
+            </div>
+          )}
+        </header>
+        {activeFilterChips.length > 0 && (
+          <div className={styles.activeFilters}>
+            {activeFilterChips.map((chip) => (
+              <button
+                key={`${chip.type}-${chip.value}`}
+                type="button"
+                className={styles.activeFilterChip}
+                onClick={chip.onRemove}>
+                <span className={styles.activeFilterChipLabel}>
+                  {chip.type}: {chip.value}
+                </span>
+                <span aria-hidden="true">×</span>
+              </button>
+            ))}
+          </div>
+        )}
+        {filteredStrategies.length === 0 ? (
+          <div className={styles.noResults}>
+            <Heading as="h3">No strategies match this combination yet</Heading>
+            <p>
+              Try removing a filter or broadening your search — the compendium includes plays for acceleration,
+              defence, ecosystems, and user perception.
+            </p>
+          </div>
+        ) : (
+          <div className={styles.strategyList}>
+            {filteredStrategies.map((item) => (
+              <StrategyCard key={item.strategy.id} item={item} selectedSkills={selectedSkillsSet} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/StrategyExplorer/styles.module.css
+++ b/src/components/StrategyExplorer/styles.module.css
@@ -1,0 +1,345 @@
+.layout {
+  display: grid;
+  gap: 2rem;
+}
+
+@media screen and (min-width: 996px) {
+  .layout {
+    grid-template-columns: minmax(260px, 320px) 1fr;
+    align-items: start;
+  }
+}
+
+.filterPanel {
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--ifm-card-border-radius);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  position: sticky;
+  top: calc(var(--ifm-navbar-height) + 1rem);
+  max-height: calc(100vh - var(--ifm-navbar-height) - 2rem);
+  overflow: auto;
+}
+
+.searchGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.searchLabel {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.searchInput {
+  width: 100%;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-card-border-radius);
+  padding: 0.6rem 0.75rem;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.searchInput:focus {
+  outline: none;
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 0 0 2px rgba(var(--ifm-color-primary-rgb), 0.1);
+}
+
+.filterSection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.filterSectionHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.filterSectionTitle {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ifm-color-emphasis-800);
+}
+
+.showMoreButton {
+  border: none;
+  background: none;
+  color: var(--ifm-color-primary);
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0;
+}
+
+.showMoreButton:hover {
+  text-decoration: underline;
+}
+
+.filterOptions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.filterOption {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.filterOption input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.filterOption span {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.75rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 999px;
+  font-size: 0.85rem;
+  transition: all 0.2s ease;
+  cursor: pointer;
+}
+
+.filterOption span:hover {
+  border-color: var(--ifm-color-primary);
+}
+
+.filterOption input:checked + span {
+  background: var(--ifm-color-primary);
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-font-color-base-inverse);
+}
+
+.clearFiltersButton {
+  margin-top: 0.5rem;
+  align-self: flex-start;
+}
+
+.resultsSection {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.resultsHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media screen and (min-width: 768px) {
+  .resultsHeader {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+}
+
+.resultsTitle {
+  margin-bottom: 0.25rem;
+}
+
+.resultsSubtitle {
+  margin: 0;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.activeFiltersSummary {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.activeFilters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.activeFilterChip {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-surface-color);
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.8rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.activeFilterChip:hover {
+  border-color: var(--ifm-color-primary);
+  background: var(--ifm-color-primary-contrast-background);
+}
+
+.activeFilterChipLabel {
+  font-weight: 600;
+}
+
+.noResults {
+  border: 1px dashed var(--ifm-color-emphasis-200);
+  border-radius: var(--ifm-card-border-radius);
+  padding: 2rem;
+  text-align: center;
+  background: var(--ifm-background-surface-color);
+}
+
+.strategyList {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.strategyCard {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cardHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+@media screen and (min-width: 768px) {
+  .cardHeader {
+    flex-direction: row;
+    align-items: baseline;
+    justify-content: space-between;
+  }
+}
+
+.cardTitle {
+  margin: 0;
+}
+
+.cardDescription {
+  margin: 0;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.categoryPill {
+  background: var(--ifm-color-primary-contrast-background);
+  color: var(--ifm-color-primary-darker);
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.metaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.metaBadge {
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.matchSummary {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.skillsList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.skillChip {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.75rem;
+}
+
+.skillChipActive {
+  background: var(--ifm-color-primary-lightest);
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary-darker);
+}
+
+.contextGrid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+@media screen and (min-width: 768px) {
+  .contextGrid {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+}
+
+.contextBlock {
+  background: var(--ifm-color-emphasis-100);
+  border-radius: var(--ifm-card-border-radius);
+  padding: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.contextBlock p {
+  margin: 0.35rem 0 0;
+}
+
+.cardFooter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.tagList {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.tagChip {
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+}
+
+.tagOverflow {
+  color: var(--ifm-color-emphasis-500);
+}
+
+@media screen and (max-width: 995px) {
+  .filterPanel {
+    position: static;
+    max-height: none;
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,6 +30,11 @@ function HomepageHeader() {
             to="/about">
             Learn More
           </Link>
+          <Link
+            className="button button--outline button--lg"
+            to="/strategy-explorer">
+            Strategy Explorer
+          </Link>
         </div>
       </div>
     </header>

--- a/src/pages/strategy-explorer/index.tsx
+++ b/src/pages/strategy-explorer/index.tsx
@@ -1,0 +1,29 @@
+import type {ReactNode} from 'react';
+import Layout from '@theme/Layout';
+import Heading from '@theme/Heading';
+import clsx from 'clsx';
+import StrategyExplorer from '@site/src/components/StrategyExplorer';
+import styles from './styles.module.css';
+
+export default function StrategyExplorerPage(): ReactNode {
+  return (
+    <Layout
+      title="Strategy Explorer"
+      description="Filter Wardley Mapping strategies by context, evolution stage, and leadership skills to find the best fit for your situation.">
+      <header className={clsx('hero hero--primary', styles.hero)}>
+        <div className="container">
+          <Heading as="h1" className="hero__title text--secondary">
+            Strategy Explorer
+          </Heading>
+          <p className="hero__subtitle">
+            Quickly narrow down 60+ Wardley strategies based on the landscape you are facing.
+            Combine filters to surface plays that match your signals, organisational readiness, and ethical stance.
+          </p>
+        </div>
+      </header>
+      <main className="container margin-vert--lg">
+        <StrategyExplorer />
+      </main>
+    </Layout>
+  );
+}

--- a/src/pages/strategy-explorer/styles.module.css
+++ b/src/pages/strategy-explorer/styles.module.css
@@ -1,0 +1,16 @@
+.hero {
+  background: linear-gradient(135deg, rgba(var(--ifm-color-primary-rgb), 0.9), rgba(var(--ifm-color-primary-dark-rgb), 0.9));
+  text-align: left;
+  padding-bottom: 3rem;
+}
+
+.hero :global(.hero__subtitle) {
+  max-width: 720px;
+}
+
+@media screen and (max-width: 768px) {
+  .hero {
+    text-align: left;
+    padding-top: 3.5rem;
+  }
+}

--- a/src/plugins/strategyMetadata.ts
+++ b/src/plugins/strategyMetadata.ts
@@ -1,0 +1,123 @@
+import path from 'path';
+import {promises as fs} from 'fs';
+import matter from 'gray-matter';
+import type {LoadContext, Plugin} from '@docusaurus/types';
+import type {StrategyMetadata, StrategyMetadataGlobalData} from '../types/strategyMetadata';
+
+type FrontMatter = Record<string, unknown>;
+
+async function readFileSafely(filePath: string): Promise<string> {
+  return fs.readFile(filePath, 'utf8');
+}
+
+function ensureStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string');
+  }
+  if (typeof value === 'string') {
+    return [value];
+  }
+  return [];
+}
+
+function ensureString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+async function collectStrategyFiles(rootDir: string): Promise<string[]> {
+  const files: string[] = [];
+
+  async function traverse(currentDir: string) {
+    const entries = await fs.readdir(currentDir, {withFileTypes: true});
+    await Promise.all(
+      entries.map(async (entry) => {
+        const fullPath = path.join(currentDir, entry.name);
+        if (entry.isDirectory()) {
+          await traverse(fullPath);
+        } else if (entry.isFile() && entry.name === 'index.md') {
+          files.push(fullPath);
+        }
+      }),
+    );
+  }
+
+  await traverse(rootDir);
+  return files;
+}
+
+function buildMetadata({
+  frontMatter,
+  relativePath,
+}: {
+  frontMatter: FrontMatter;
+  relativePath: string;
+}): StrategyMetadata | null {
+  const segments = relativePath.split(path.sep);
+  if (segments.length !== 3) {
+    return null;
+  }
+  const [category, strategyFolder, fileName] = segments;
+  if (fileName !== 'index.md') {
+    return null;
+  }
+
+  const slug = `${category}/${strategyFolder}`;
+  const permalink = `/strategies/${slug}/`;
+
+  const title = ensureString(frontMatter.title) ?? strategyFolder.replace(/-/g, ' ');
+  const description = ensureString(frontMatter.description) ?? '';
+  const tags = ensureStringArray(frontMatter.tags);
+  const leadershipSkills = ensureStringArray(frontMatter.leadership_skills_needed);
+  const relatedStrategies = ensureStringArray(frontMatter.related_strategies);
+  const authors = ensureStringArray(frontMatter.authors);
+
+  return {
+    id: slug,
+    title,
+    description,
+    permalink,
+    category,
+    tags,
+    evolutionStage: ensureString(frontMatter.evolution_stage),
+    strategicInsightArea: ensureString(frontMatter.strategic_insight_area),
+    ethicalAlignment: ensureString(frontMatter.ethical_alignment),
+    leadershipSkills,
+    whenToUse: ensureString(frontMatter.when_to_use),
+    whenToAvoid: ensureString(frontMatter.when_to_avoid),
+    coreChallenge: ensureString(frontMatter.core_challenge),
+    relatedStrategies,
+    authors,
+  };
+}
+
+export default function strategyMetadataPlugin(
+  context: LoadContext,
+): Plugin<StrategyMetadataGlobalData> {
+  return {
+    name: 'strategy-metadata-plugin',
+    async loadContent() {
+      const strategiesDir = path.join(context.siteDir, 'docs', 'strategies');
+      const allFiles = await collectStrategyFiles(strategiesDir);
+
+      const strategies: StrategyMetadata[] = [];
+      for (const file of allFiles) {
+        const relativePath = path.relative(strategiesDir, file);
+        const parsed = matter(await readFileSafely(file));
+        const metadata = buildMetadata({
+          frontMatter: parsed.data ?? {},
+          relativePath,
+        });
+        if (metadata) {
+          strategies.push(metadata);
+        }
+      }
+
+      strategies.sort((a, b) => a.title.localeCompare(b.title));
+      return {strategies};
+    },
+    async contentLoaded({content, actions}) {
+      const {setGlobalData} = actions;
+      setGlobalData(content);
+    },
+  };
+}

--- a/src/types/strategyMetadata.ts
+++ b/src/types/strategyMetadata.ts
@@ -1,0 +1,21 @@
+export type StrategyMetadata = {
+  id: string;
+  title: string;
+  description: string;
+  permalink: string;
+  category: string;
+  tags: string[];
+  evolutionStage?: string;
+  strategicInsightArea?: string;
+  ethicalAlignment?: string;
+  leadershipSkills: string[];
+  whenToUse?: string;
+  whenToAvoid?: string;
+  coreChallenge?: string;
+  relatedStrategies: string[];
+  authors: string[];
+};
+
+export type StrategyMetadataGlobalData = {
+  strategies: StrategyMetadata[];
+};


### PR DESCRIPTION
## Summary
- expose strategy front matter through a build-time metadata plugin for reuse in the UI
- add a Strategy Explorer page with filtering, scoring and contextual strategy cards powered by the new metadata
- highlight the explorer in the navbar and homepage while styling the new experience

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9c14a4d6c832baa2d59e50261ab1f