### PR TITLE
Add strategy metadata highlights to strategy pages

### DIFF
--- a/src/components/StrategyMetadata/index.tsx
+++ b/src/components/StrategyMetadata/index.tsx
@@ -1,0 +1,136 @@
+import React, {type ReactNode} from 'react';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import clsx from 'clsx';
+
+import styles from './styles.module.css';
+
+type StrategyFrontMatter = {
+  goals?: unknown;
+  stages?: unknown;
+  evolution_stage?: unknown;
+  effort_level?: unknown;
+  time_horizon?: unknown;
+  leadership_focus?: unknown;
+};
+
+type StrategyMetadataItem = {
+  label: string;
+  value: string;
+};
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    const cleaned = value
+      .map((item) => (typeof item === 'string' ? item.trim() : ''))
+      .filter((item) => item.length > 0);
+
+    return cleaned.length > 0 ? cleaned : undefined;
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return [value.trim()];
+  }
+
+  return undefined;
+}
+
+function shouldRenderForStrategy(permalink?: string): boolean {
+  return typeof permalink === 'string' && permalink.startsWith('/strategies/');
+}
+
+function buildOverviewItems(frontMatter: StrategyFrontMatter): StrategyMetadataItem[] {
+  const items: StrategyMetadataItem[] = [];
+
+  if (isNonEmptyString(frontMatter.effort_level)) {
+    items.push({label: 'Effort level', value: frontMatter.effort_level.trim()});
+  }
+
+  if (isNonEmptyString(frontMatter.time_horizon)) {
+    items.push({label: 'Time horizon', value: frontMatter.time_horizon.trim()});
+  }
+
+  const stages = asStringArray(frontMatter.stages) ?? asStringArray(frontMatter.evolution_stage);
+  if (stages && stages.length > 0) {
+    items.push({label: 'Evolution focus', value: stages.join(' • ')});
+  }
+
+  return items;
+}
+
+export function StrategyAtAGlance(): ReactNode {
+  const {metadata, frontMatter} = useDoc();
+  if (!shouldRenderForStrategy(metadata.permalink)) {
+    return null;
+  }
+
+  const strategyFrontMatter = frontMatter as StrategyFrontMatter;
+  const goals = asStringArray(strategyFrontMatter.goals);
+  const items = buildOverviewItems(strategyFrontMatter);
+
+  if ((!goals || goals.length === 0) && items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.overviewCard}>
+      {goals && goals.length > 0 && (
+        <div className={styles.goalsSection}>
+          <p className={styles.sectionLabel}>Goals it supports</p>
+          <div className={styles.pillGroup}>
+            {goals.map((goal) => (
+              <span key={goal} className={styles.pill}>
+                {goal}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {items.length > 0 && (
+        <div className={clsx(styles.metaGrid, {[styles.metaGridCompact]: !goals || goals.length === 0})}>
+          {items.map((item) => (
+            <div key={item.label} className={styles.metaItem}>
+              <span className={styles.metaLabel}>{item.label}</span>
+              <span className={styles.metaValue}>{item.value}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function LeadershipFocusPills(): ReactNode {
+  const {metadata, frontMatter} = useDoc();
+  if (!shouldRenderForStrategy(metadata.permalink)) {
+    return null;
+  }
+
+  const strategyFrontMatter = frontMatter as StrategyFrontMatter;
+  const leadershipFocus = asStringArray(strategyFrontMatter.leadership_focus);
+
+  if (!leadershipFocus || leadershipFocus.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.leadershipContainer}>
+      <span className={styles.sectionLabel}>Leadership emphasis</span>
+      <div className={styles.pillGroup}>
+        {leadershipFocus.map((focus) => (
+          <span key={focus} className={styles.pill}>
+            {focus}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/StrategyMetadata/styles.module.css
+++ b/src/components/StrategyMetadata/styles.module.css
@@ -1,0 +1,89 @@
+.overviewCard {
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: 16px;
+  background: var(--ifm-card-background-color);
+  padding: 1.5rem;
+  margin: 1.5rem 0 2.5rem;
+  box-shadow: var(--ifm-global-shadow-lw);
+}
+
+.goalsSection {
+  margin-bottom: 1.5rem;
+}
+
+.sectionLabel {
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ifm-font-color-secondary);
+  margin-bottom: 0.5rem;
+  display: block;
+  font-weight: 600;
+}
+
+.pillGroup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  background: rgba(37, 194, 160, 0.12);
+  border: 1px solid rgba(37, 194, 160, 0.45);
+  border-radius: 999px;
+  color: var(--ifm-color-primary);
+  padding: 0.35rem 0.95rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.metaGrid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.metaGridCompact {
+  margin-top: 0.5rem;
+}
+
+.metaItem {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.5rem 0;
+}
+
+.metaLabel {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ifm-font-color-secondary);
+}
+
+.metaValue {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.leadershipContainer {
+  margin: 1rem 0 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+@media screen and (max-width: 600px) {
+  .overviewCard {
+    padding: 1.25rem;
+    margin: 1.25rem 0 2rem;
+  }
+
+  .pill {
+    font-size: 0.85rem;
+    padding: 0.3rem 0.85rem;
+  }
+}

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -20,6 +20,7 @@ import DocItemContent from '@theme/DocItem/Content';
 import DocBreadcrumbs from '@theme/DocBreadcrumbs';
 import ContentVisibility from '@theme/ContentVisibility';
 import type {Props} from '@theme/DocItem/Layout';
+import {StrategyAtAGlance} from '@site/src/components/StrategyMetadata';
 
 import styles from './styles.module.css';
 
@@ -50,6 +51,7 @@ function useDocTOC() {
 export default function DocItemLayout({children}: Props): ReactNode {
   const docTOC = useDocTOC();
   const {metadata, frontMatter} = useDoc();
+  const isStrategyDoc = metadata.permalink?.startsWith('/strategies/');
   return (
     <div className="row">
       <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
@@ -60,6 +62,7 @@ export default function DocItemLayout({children}: Props): ReactNode {
             <DocBreadcrumbs />
             <DocVersionBadge />
             {docTOC.mobile}
+            {isStrategyDoc && <StrategyAtAGlance />}
             <DocItemContent>{children}</DocItemContent>
             <DocItemFooter />
             {frontMatter.authors && frontMatter.authors.length > 0 && (

--- a/src/theme/Heading/index.tsx
+++ b/src/theme/Heading/index.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
+import {useThemeConfig} from '@docusaurus/theme-common';
+import Link from '@docusaurus/Link';
+import useBrokenLinks from '@docusaurus/useBrokenLinks';
+import type {Props} from '@theme/Heading';
+
+import styles from './styles.module.css';
+import {LeadershipFocusPills} from '@site/src/components/StrategyMetadata';
+
+function shouldShowLeadershipFocus(as: Props['as'], id?: string): boolean {
+  return as === 'h2' && id === 'leadership';
+}
+
+export default function Heading({as: As, id, ...props}: Props): ReactNode {
+  const brokenLinks = useBrokenLinks();
+  const {
+    navbar: {hideOnScroll},
+  } = useThemeConfig();
+
+  if (As === 'h1' || !id) {
+    const heading = <As {...props} id={undefined} />;
+    return shouldShowLeadershipFocus(As, id) ? (
+      <>
+        {heading}
+        <LeadershipFocusPills />
+      </>
+    ) : (
+      heading
+    );
+  }
+
+  brokenLinks.collectAnchor(id);
+
+  const anchorTitle = translate(
+    {
+      id: 'theme.common.headingLinkTitle',
+      message: 'Direct link to {heading}',
+      description: 'Title for link to heading',
+    },
+    {
+      heading: typeof props.children === 'string' ? props.children : id,
+    },
+  );
+
+  const heading = (
+    <As
+      {...props}
+      className={clsx(
+        'anchor',
+        hideOnScroll
+          ? styles.anchorWithHideOnScrollNavbar
+          : styles.anchorWithStickyNavbar,
+        props.className,
+      )}
+      id={id}>
+      {props.children}
+      <Link
+        className="hash-link"
+        to={`#${id}`}
+        aria-label={anchorTitle}
+        title={anchorTitle}>
+        &#8203;
+      </Link>
+    </As>
+  );
+
+  return shouldShowLeadershipFocus(As, id) ? (
+    <>
+      {heading}
+      <LeadershipFocusPills />
+    </>
+  ) : (
+    heading
+  );
+}

--- a/src/theme/Heading/styles.module.css
+++ b/src/theme/Heading/styles.module.css
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+When the navbar is sticky, ensure that on anchor click,
+the browser does not scroll that anchor behind the navbar
+See https://x.com/JoshWComeau/status/1332015868725891076
+*/
+.anchorWithStickyNavbar {
+  scroll-margin-top: calc(var(--ifm-navbar-height) + 0.5rem);
+}
+
+.anchorWithHideOnScrollNavbar {
+  scroll-margin-top: 0.5rem;
+}
+
+:global(.hash-link) {
+  opacity: 0;
+  padding-left: 0.5rem;
+  transition: opacity var(--ifm-transition-fast);
+  user-select: none;
+}
+
+:global(.hash-link::before) {
+  content: '#';
+}
+
+:global(.hash-link:focus),
+:global(*:hover > .hash-link) {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- add a StrategyAtAGlance component that surfaces goals, effort, horizon, and evolution metadata at the top of strategy docs
- render leadership focus metadata as pills beneath the leadership heading with navigator-inspired styling
- hook the new components into the doc layout and heading overrides so strategy pages display the metadata automatically

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb0babf4a8832ba5f4368027351bd4