### PR TITLE
Add AI and Leadership docs section

### DIFF
--- a/docs/ai-and-leadership/index.md
+++ b/docs/ai-and-leadership/index.md
@@ -1,0 +1,9 @@
+# AI and Leadership
+
+This section will collect articles and resources that explore the intersection of artificial intelligence and leadership.
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```


### PR DESCRIPTION
## Summary
- add a new AI and Leadership docs section with an index page
- include a DocCardList so the section autolists its content

## Testing
- npm run lint:md:fix
- python -m pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68cd92048be0832bad1d699a40d5b09d