### PR TITLE
Add AI-focused climatic patterns and extend automation commentary

### DIFF
--- a/docs/climatic-patterns/autonomy-length-expands.md
+++ b/docs/climatic-patterns/autonomy-length-expands.md
@@ -1,0 +1,10 @@
+---
+title: "Autonomy length expands"
+tags: [speed, automation]
+---
+
+Automation no longer stops at single tasks. Systems now handle multi-step outcomes, stitching together decision-making, execution, and follow-up actions without constant human intervention.
+
+As autonomy length grows, people increasingly work by setting intent rather than micromanaging each action. Triggering a capability kicks off cascades of work that would previously have taken teams days or weeks to complete.
+
+Landscapes tilt toward those who can orchestrate these longer chains effectively. The winners govern guardrails, monitor performance, and continually evaluate where human judgement needs to re-enter the loop.

--- a/docs/climatic-patterns/competitors-actions-will-change-the-game.md
+++ b/docs/climatic-patterns/competitors-actions-will-change-the-game.md
@@ -6,6 +6,8 @@ tags: [competitors]
 
 No strategy lives in a vacuum. Moves by rivals alter the landscape and force you to respond or reposition.
 
+Competitors’ actions will change the game: Early movers who industrialise their operating model will reshape the landscape for everyone else.
+
 ## 🔀 Related Strategies
 
 - [Experimentation](/strategies/attacking/experimentation) – trigger: small tests help you react quickly to competitive moves.

--- a/docs/climatic-patterns/efficiency-enables-innovation.md
+++ b/docs/climatic-patterns/efficiency-enables-innovation.md
@@ -8,6 +8,8 @@ When an activity becomes standardised and efficient, it forms a dependable build
 
 From electricity grids to cloud computing, each wave of industrialisation has sparked fresh waves of creativity. A world of interchangeable parts frees organisations to focus on higher order ideas rather than reinventing the basics.
 
+Efficiency enables innovation: AI and automation commoditises execution, freeing human capacity for higher-order judgement and invention.
+
 ## 🔀 Related Strategies
 
 - [Open Approaches](/strategies/accelerators/open-approaches) – trigger: once a component becomes efficient, opening it up can drive further innovation.

--- a/docs/climatic-patterns/everything-evolves.md
+++ b/docs/climatic-patterns/everything-evolves.md
@@ -8,3 +8,5 @@ All parts of a value chain move from novel beginnings toward well defined commod
 Supply and demand competition drives this progression.
 
 This evolution means every component has a history and a future. Knowing that change is inevitable helps leaders anticipate when once "special" capabilities will become routine services and when new components may be about to appear.
+
+Everything evolves: AI and automation capability is no exception. It’s diffusing from novel prototypes to industrialised utilities, with agents following the same product-to-commodity trajectory.

--- a/docs/climatic-patterns/evolution-of-communication-mechanisms-can-increase-the-speed-of-evolution-overall-and-the-diffusion-of-a-single-example-of-change.md
+++ b/docs/climatic-patterns/evolution-of-communication-mechanisms-can-increase-the-speed-of-evolution-overall-and-the-diffusion-of-a-single-example-of-change.md
@@ -5,3 +5,5 @@ tags: [speed]
 
 
 Better ways of sharing information accelerate how quickly new ideas spread. Faster diffusion of one change often sparks further waves of evolution.
+
+Evolution of communication mechanisms increases overall speed: AI mediates and accelerates communication between humans and systems, pushing coordination costs down dramatically.

--- a/docs/climatic-patterns/index.md
+++ b/docs/climatic-patterns/index.md
@@ -19,6 +19,7 @@ Patterns in this category describe how different parts of a system mature and in
 - [No choice on evolution](/climatic-patterns/no-choice-on-evolution)
 - [No one size fits all](/climatic-patterns/no-one-size-fits-all)
 - [Rates of evolution can vary by ecosystem](/climatic-patterns/rates-of-evolution-can-vary-by-ecosystem)
+- [Synthetic labour becomes a commodity](/climatic-patterns/synthetic-labour-becomes-a-commodity)
 
 ## Competitors
 
@@ -65,4 +66,5 @@ Speed patterns examine the pace of change and how stability affects agility.
 - [Efficiency enables innovation](/climatic-patterns/efficiency-enables-innovation)
 - [Evolution of communication mechanisms increases overall speed](/climatic-patterns/evolution-of-communication-mechanisms-can-increase-the-speed-of-evolution-overall-and-the-diffusion-of-a-single-example-of-change)
 - [Increased stability of lower order systems boosts agility](/climatic-patterns/increased-stability-of-lower-order-systems-increases-agility-and-speed-of-re-combination)
+- [Autonomy length expands](/climatic-patterns/autonomy-length-expands)
 - [Shifts from product to utility show punctuated equilibrium](/climatic-patterns/shifts-from-product-to-utility-tend-to-demonstrate-a-punctuated-equilibrium)

--- a/docs/climatic-patterns/synthetic-labour-becomes-a-commodity.md
+++ b/docs/climatic-patterns/synthetic-labour-becomes-a-commodity.md
@@ -1,0 +1,10 @@
+---
+title: "Synthetic labour becomes a commodity"
+tags: [components, automation]
+---
+
+As AI agents become cheap, abundant, and reliable, the cost of competence collapses. Synthetic labour shifts from an expensive, human-bound resource to a tradable service you can invoke on demand.
+
+When execution is ubiquitous and utility-like, scarcity moves up the stack. Advantage comes from the quality of judgement, the trust you command, and the distribution you can reach, not from access to basic capability.
+
+Leaders have to re-evaluate what they consider differentiating. Owning the orchestration, governance, and ethics around these agent ecosystems becomes more important than performing the work yourself.


### PR DESCRIPTION
## Summary
- add climatic pattern pages covering synthetic labour commoditisation and expanding automation autonomy
- extend relevant climatic patterns with new AI-focused guidance and refresh the category index

## Testing
- npm run lint:md:fix
- python -m pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68cd99a8a754832b836a60b60ee30760