### PR TITLE
Add strategy page best practices guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ or at least generic skills that make it clear where they are applied in relation
 
 ### Strategic Insights
 
-The `## 🧠 **Strategic Insights**` section of a strategy is where the big ideas live. It's critical that these are well thought out, expert insights that are related to the specific strategy. Not just a vague idea or summary. These should add significant depth to the page. They can even expand the strategy beyond its confines a bit, whether that's more practical business thoughts, mental models, philosophy (don't get carried away!), left field techniques or practices, etc. See [notes/authoritative-content-writing.md](./notes/authoritative-content-writing.md) for additional guidance on writing with authority.
+The `## 🧠 **Strategic Insights**` section of a strategy is where the big ideas live. It's critical that these are well thought out, expert insights that are related to the specific strategy. Not just a vague idea or summary. These should add significant depth to the page. They can even expand the strategy beyond its confines a bit, whether that's more practical business thoughts, mental models, philosophy (don't get carried away!), left field techniques or practices, etc. See [notes/authoritative-content-writing.md](./notes/authoritative-content-writing.md) for additional guidance on writing with authority, and [notes/strategy-page-best-practices.md](./notes/strategy-page-best-practices.md) for examples of what high-quality strategy content covers.
 
 - Only put relevant insights here, not generic ones.
 - Consider evolution stages, counterplay, value chains, users, markets, leverage, higher order thinking, wider goals, etc.

--- a/notes/strategy-page-best-practices.md
+++ b/notes/strategy-page-best-practices.md
@@ -1,0 +1,17 @@
+# Strategy Page Content Best Practices
+
+## What Great Looks Like
+
+- **Anchor the play in its Wardley context.** Lead with the strategic problem, how the play shifts the landscape, and the component stages involved. Strong pages explain the ecosystem forces before diving into mechanics, such as how [Cooperation](/strategies/accelerators/cooperation) reframes collaboration as accelerating evolution rather than generic teamwork, or how [Directed Investment](/strategies/attacking/directed-investment) positions bold bets against inevitabilities.
+- **Explain the strategy from multiple lenses.** Pair the core definition with why it matters, how it works, and the variants a team might encounter. Rich pages layer "what/why/how" guidance with typologies or cadences (e.g., [Weak Signal (Horizon)](/strategies/positional/weak-signal-horizon) outlines sensing loops, while [Alliances](/strategies/ecosystem/alliances) distinguishes alliances from general cooperation).
+- **Tie moves to real landscapes.** Blend concrete success stories, counter-examples, and well-labelled hypotheticals so readers see how the play behaves in different environments. The best pages connect those stories back to map positions or ecosystem pressures instead of letting anecdotes stand alone.
+- **Show leaders how to decide and act.** Go beyond a checklist by clarifying leadership challenges, required skills, and ethical tensions. Pages like [Procrastination](/strategies/defensive/procrastination) unpack the discipline needed to wait, while [Directed Investment](/strategies/attacking/directed-investment) stresses portfolio stewardship and risk appetite.
+- **Quantify readiness and success.** Use assessment prompts, trigger conditions, and outcome metrics that mirror real strategic decision points. Effective pages surface the signals to watch, readiness gaps to close, and how impact will present in operations or markets.
+- **Reveal interplay across strategies and patterns.** Make it obvious how the play complements, conflicts with, or unlocks other moves and climatic patterns. The strongest pages give relational blurbs (not just links) so a strategist immediately sees sequencing, counterplay, or ecosystem choreography options.
+- **End with distinctive insights.** Reserve the "Strategic Insights" section for original synthesis that teaches a new mental model, timing nuance, or competitive response pattern. Pages feel complete when this section crystallises lessons the reader cannot infer from earlier summaries.
+
+## Opportunities to Raise the Bar Further
+
+- **Explicitly connect maps or visuals to decisions.** When including diagrams or mind maps, add a short interpretation so readers know what to copy, adapt, or watch for in their own landscape.
+- **Balance breadth with focus in storytelling.** Keep case studies tightly linked to the strategic mechanism, and use contrasting examples to highlight boundaries (e.g., where the play fails, or when to hand off to an adjacent strategy).
+- **Surface follow-on plays.** Close with guidance on likely next moves once the strategy lands—who to partner with next, which doctrines to reinforce, or what counterplay to anticipate—so practitioners can maintain momentum.


### PR DESCRIPTION
## Summary
- add a new notes/strategy-page-best-practices.md guide capturing domain-focused traits of strong strategy content
- reference the new guide from CONTRIBUTING.md so contributors can find it alongside other writing guidance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc2b761dc0832b9d7c68c8744a0254