### PR TITLE
Add AI leadership article on continuous map governance

### DIFF
--- a/docs/ai-and-leadership/continuous-map-governance.md
+++ b/docs/ai-and-leadership/continuous-map-governance.md
@@ -1,0 +1,37 @@
+---
+title: Continuous Map Governance
+description: Why AI-native leadership requires living Wardley Maps that instrument decisions and feedback loops.
+tags: [ai, leadership, wardley-mapping, governance]
+---
+
+**AI-native leadership depends on maps that move as fast as the agents they command.** Traditional strategy cycles assumed that the landscape stayed still long enough for quarterly reviews. Wardley Mapping showed that components evolve, value chains shift, and doctrine must respond. In an era where autonomous agents execute in minutes, leaders must treat their maps as living systems, instrumented with telemetry, guardrails, and feedback loops that keep decisions aligned with reality.
+
+## From artefact to operating system
+
+Wardley Maps began as artefacts that captured a moment in time. With AI accelerating evolution, the utility of a static map collapses; competitive advantage now comes from the cadence of remapping. Leaders should view the map as an operating system that coordinates how autonomous services, human teams, and partner ecosystems learn from one another. The focus shifts from "did we draw the map?" to "how quickly can the map absorb signals and adjust the playbook?".
+
+## Instrumenting evolution
+
+An AI-enabled stack can stream live data into the map: usage telemetry reveals where user needs fragment, cost analytics highlight components sliding toward commodity, and anomaly detection uncovers new genesis experiments at the edge. Instrumentation turns doctrine into code—policies decide when to trigger [Pioneers, Settlers, Town Planners](/doctrines/climate/pioneers-settlers-town-planners) hand-offs or when to retire bespoke solutions in favour of utilities. Leaders define thresholds that automatically flag when agents overstep their evolutionary lane.
+
+## Leadership loops in three horizons
+
+1. **Sense** – Agents watch the landscape for shifts in user need, competitor posture, and ecosystem signals. The leadership task is to decide which signals matter and to prune noise so the map remains legible.
+2. **Decide** – Doctrine libraries embed preferred plays for each evolutionary stage. When the map detects a shift, leaders select the next move—standardise, commoditise, partner, or intentionally hold a component in custom mode to slow a competitor.
+3. **Act** – Execution agents implement the decision while governance agents log outcomes back onto the map. This closes the loop, enabling the organisation to measure momentum and inertia without waiting for quarterly retrospectives.
+
+## Governing autonomy safely
+
+AI expands autonomy length, but without guardrails it also accelerates misalignment. Continuous map governance sets explicit boundaries: which components agents can evolve, which must remain under human supervision, and what data can be accessed. Leaders deploy "break-glass" controls—automatic escalation when an agent moves a component leftward (toward custom) without approval, or when commoditisation risks eroding a differentiating capability.
+
+## Strategic dividends
+
+Live maps surface optionality sooner. Leaders can spot when a utility provider becomes a dependency worth hedging against, or when a nascent component deserves directed investment before rivals notice. Continuous governance also clarifies when to stop investing; once a capability crosses the product-to-commodity boundary, the map should automatically trigger procurement to seek external utilities and reassign teams to higher-order differentiation.
+
+## Preparing the organisation
+
+Treat mapping literacy as a leadership competency. Train teams to annotate maps with telemetry, update doctrinal triggers, and rehearse map-driven decision drills. Align incentives so that squads earn recognition for retiring bespoke code as much as for shipping new features. Continuous governance only works when the culture values transparency over heroics and treats the map as the shared memory of the enterprise.
+
+## Looking ahead
+
+As models become agents that negotiate, procure, and design autonomously, the map becomes the contract those agents must obey. Continuous map governance offers a leadership pattern that keeps human intent ahead of machine execution. The organisations that win will be those whose maps evolve at least as quickly as their capabilities.

--- a/docs/ai-and-leadership/continuous-map-governance.md
+++ b/docs/ai-and-leadership/continuous-map-governance.md
@@ -12,7 +12,7 @@ Wardley Maps began as artefacts that captured a moment in time. With AI accelera
 
 ## Instrumenting evolution
 
-An AI-enabled stack can stream live data into the map: usage telemetry reveals where user needs fragment, cost analytics highlight components sliding toward commodity, and anomaly detection uncovers new genesis experiments at the edge. Instrumentation turns doctrine into code—policies decide when to trigger [Pioneers, Settlers, Town Planners](/doctrines/climate/pioneers-settlers-town-planners) hand-offs or when to retire bespoke solutions in favour of utilities. Leaders define thresholds that automatically flag when agents overstep their evolutionary lane.
+An AI-enabled stack can stream live data into the map: usage telemetry reveals where user needs fragment, cost analytics highlight components sliding toward commodity, and anomaly detection uncovers new genesis experiments at the edge. Instrumentation turns doctrine into code—policies decide when to trigger Pioneers, Settlers, Town Planners hand-offs or when to retire bespoke solutions in favour of utilities. Leaders define thresholds that automatically flag when agents overstep their evolutionary lane.
 
 ## Leadership loops in three horizons
 


### PR DESCRIPTION
## Summary
- add a new AI and leadership article on continuous map governance
- outline instrumentation, leadership loops, and guardrails for living Wardley Maps

## Testing
- python -m pytest tests
- npm run lint:md:fix

------
https://chatgpt.com/codex/tasks/task_e_68dc2edf7234832b94b7ff19f598eef0