### PR TITLE
Add article aligning Cynefin sensemaking with AI leadership

### DIFF
--- a/docs/ai-and-leadership/cynefin-ai-leadership.md
+++ b/docs/ai-and-leadership/cynefin-ai-leadership.md
@@ -1,0 +1,40 @@
+---
+title: Navigating AI Leadership with Cynefin
+description: Applying Cynefin's sensemaking approach to orchestrate AI systems and human teams across complexity.
+tags: [ai, leadership, cynefin, sensemaking, wardley-mapping]
+---
+
+**AI leadership needs Cynefin's sensemaking discipline to decide when to experiment, when to codify, and when to get out of the way.** Wardley Mapping explains how components evolve along the value chain, but leaders still have to choose the right play for the terrain in front of them. Cynefin complements Wardley Mapping by framing how decision-making should adapt when the landscape is obvious, complicated, complex, or chaotic—exactly the challenge AI agents introduce.
+
+## Why Cynefin matters for AI-era leadership
+
+AI collapses the time it takes for capabilities to evolve, pushing organisations through multiple Wardley evolutionary stages in a single planning cycle. Cynefin keeps leaders from defaulting to a single management style. It reminds them that automation does not erase complexity; it often creates more of it by connecting systems and actors that behave unpredictably. Bringing Cynefin to AI strategy equips leadership teams with language and guardrails for switching between doctrine, experimentation, and containment as the map shifts.
+
+## Linking Cynefin domains to Wardley evolution
+
+### Clear domain – codify and scale
+
+When a capability has matured into a commodity on the map, it usually lands in Cynefin's clear domain. Here leaders should codify best practice, embed doctrine in automation, and push the work into utilities or platform services. Metrics focus on reliability and cost. AI can run almost unsupervised provided ethical guardrails and monitoring are in place.
+
+### Complicated domain – engineer for assurance
+
+Capabilities sitting in the product or transitional stages often belong in the complicated domain. They are knowable with enough expertise. Pair Wardley Maps with Cynefin to assign these components to Town Planners and specialist agents. Governance should emphasise peer review, simulation, and scenario planning so AI-driven decisions remain auditable.
+
+### Complex domain – probe with guardrails
+
+Genesis and custom-built components typically live in the complex domain where cause and effect emerge only after experimentation. Leaders should deploy Pioneers, establish safe-to-fail probes, and treat AI agents as hypothesis engines rather than production services. Success metrics emphasise learning velocity, not output volume. Link insights back onto the map so Settlers know when to stabilise discoveries.
+
+### Chaotic domain – stabilise then sense
+
+Crises caused by unexpected model behaviour, security incidents, or runaway automation drag components into chaos. The first task is containment: freeze automated actions, assemble cross-functional response teams, and re-establish a minimum viable map of the affected value chain. Only once stability returns should leaders decide whether the component belongs back in complex exploration or complicated engineering.
+
+## Practical leadership moves
+
+- **Map and sense simultaneously.** Run mapping sessions alongside Cynefin workshops so teams identify where each component sits and which leadership posture it requires.
+- **Design playbooks per domain.** Document escalation paths, decision rights, and oversight cadence for each domain. This prevents teams from applying complicated-domain controls to complex-domain experiments.
+- **Instrument transitions.** Use telemetry to trigger alerts when components shift domains—such as an AI service moving from complex experimentation into clear automation—so governance and doctrine can adjust.
+- **Train for domain switching.** Leaders and agents should rehearse moving between sensemaking modes, especially when AI outputs nudge a system from complicated to chaotic faster than humans can react.
+
+## Strategic implications
+
+Cynefin plus Wardley Mapping reframes AI leadership as a dynamic practice: sense where a component sits, decide which domain playbook applies, and evolve doctrine as the system learns. Leaders who embrace both models build organisations that can scale clear-domain automation without losing the ability to explore complex terrain or respond to chaos. The result is an adaptive command structure that keeps human judgement ahead of machine speed.


### PR DESCRIPTION
## Summary
- add a new AI and leadership article showing how Cynefin complements Wardley Mapping for governing AI systems
- outline guidance for applying domain-specific playbooks across clear, complicated, complex, and chaotic situations
- provide practical leadership moves for monitoring transitions and adapting doctrine as automation scales

## Testing
- npm run lint:md:fix
- python -m pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68dc32328bbc832b9b2f6729c844fa81