### PR TITLE
Add article on autonomously executed strategy

### DIFF
--- a/docs/ai-and-leadership/autonomous-strategy-execution.md
+++ b/docs/ai-and-leadership/autonomous-strategy-execution.md
@@ -1,0 +1,71 @@
+---
+title: Autonomously Executed Strategy
+description: How leaders prepare doctrine, data, and guardrails so AI agents can deploy Wardley plays without waiting for human hands.
+tags: [ai, leadership, wardley-mapping, doctrine, automation]
+---
+
+**The next phase of map governance is letting the plays fire themselves.** Continuous map governance turned static Wardley Maps into living control rooms. The follow-on step is allowing autonomous agents to interpret those maps and launch strategic plays the moment signals cross their thresholds. This demands leadership that treats doctrine as runnable code, evolves guardrails faster than competitors evolve capabilities, and choreographs humans as the editors of intent rather than the operators of every move.
+
+## From playbook to executable doctrine
+
+Once maps are instrumented, the decisions within them can be expressed as policies. Leaders translate doctrines such as "automate once a component hits commodity" or "trigger open standards when ecosystem risk spikes" into machine-readable rules. Agent frameworks watch the telemetry layers of the map—usage, cost, supply chain health, regulatory change—and fire the appropriate play automatically. Humans move from deciding *if* to act to specifying *when* and *how much* freedom the system has to respond.
+
+## Architecture of autonomous plays
+
+1. **Telemetry spine** – Data pipelines keep the map alive: component maturity scores, dependency health, demand shifts, partner behaviour, and compliance posture.
+2. **Doctrine engine** – Encodes the organisation's preferred plays as executable policies with confidence thresholds, escalation paths, and cost guardrails.
+3. **Agent mesh** – Specialised AI services handle procurement, contract negotiation, engineering automation, marketing experiments, or migration runbooks. Each agent knows which map components it owns and which doctrine clauses apply.
+4. **Supervision lattice** – Governance agents audit actions, reconcile map updates, and open break-glass channels whenever anomalies or ethical triggers fire. Humans intervene on judgement calls, ethics, or model drift.
+
+## Doctrine prerequisites
+
+Autonomous strategy only works when core Wardley doctrine is institutionalised:
+
+- **Know your users** – Agents require clear user needs, value chains, and success metrics or they will optimise for the wrong objective.
+- **Focus on high situational awareness** – Map literacy and shared vocabularies ensure teams and agents interpret signals the same way.
+- **Challenge assumptions** – Red-team agents should continuously probe the doctrine engine for blind spots, testing inertia and bias.
+- **Manage inertia** – Escalation thresholds must surface when an agent's recommended move clashes with political or regulatory inertia that still matters.
+- **Use appropriate methods** – Doctrine dictates which delivery approach (explore, build, operate) is permissible at each evolutionary stage, so agents pick the right tooling.
+- **Optimise flow** – Workflows, funding models, and API contracts must allow agents to execute without human queueing bottlenecks.
+
+## Plays ready for automation
+
+- **Utility migration** – When cost curves show that a component has fully commoditised, procurement agents can automatically source a utility vendor, negotiate pricing, and spin down internal instances while the supervision lattice monitors risk.
+- **Standard acceleration** – Ecosystem agents can trigger open API or open-source releases once copy latency drops below an agreed threshold, locking in de facto standards faster than rivals can react.
+- **Intelligent decommissioning** – Observability agents identify bespoke features with declining usage and coordinate retirement campaigns, customer comms, and archival workflows without human scheduling.
+- **Dynamic hedging** – Supply chain agents monitor single-point dependencies highlighted on the map and autonomously diversify providers or create synthetic substitutes when resilience indicators dip.
+- **Regulated roll-outs** – Compliance-aware agents embed policy-as-code checks so that any play touching a regulated component auto-generates audit trails, approvals, and regulator notifications.
+
+## Leadership jobs when agents run the plays
+
+Leaders do not vanish; their craft shifts upstream and downstream of execution.
+
+- **Intent designers** – Define the purpose, guardrails, and acceptable risk envelopes that doctrine engines must respect.
+- **Pattern librarians** – Curate, test, and retire playbooks as markets evolve. Doctrine must reflect reality faster than agents can exploit it.
+- **Ethical stewards** – Decide when an action requires human empathy, negotiate societal trade-offs, and ensure transparency around automated choices.
+- **Capability gardeners** – Invest in training so teams can interpret agent-generated telemetry, debug policy conflicts, and understand when to pull the plug.
+- **Alliance brokers** – Coordinate with partners whose agents touch the same ecosystem, establishing cross-organisational guardrails and dispute channels.
+
+## Safeguards for autonomous execution
+
+Autonomous plays multiply risk if oversight collapses. Effective safeguards include:
+
+- **Twin maps** – Maintain a simulation environment where plays run in synthetic landscapes before touching production systems.
+- **Counter-agent monitoring** – Deploy watchdog agents that look for adversarial manipulation of data streams, poisoned models, or vendor lock-in.
+- **Progressive autonomy** – Gradually lengthen autonomy windows only after post-incident reviews show doctrine and guardrails held.
+- **Transparent logging** – Immutable ledgers record every play decision, making it easier to audit bias, ensure compliance, and refine doctrine.
+- **Human veto rights** – Critical components retain manual kill switches and staged approvals, especially where irreversible harm is possible.
+
+## Momentum signals to track
+
+Leaders should instrument metrics that reveal whether autonomous strategy execution is compounding advantage:
+
+- Time from signal detection to play execution.
+- Percentage of plays executed without human intervention and without post-play remediation.
+- Autonomy length per agent domain and its trend.
+- Incident rate per autonomous play versus human-executed plays.
+- Doctrine update frequency and dwell time between policy change and deployment.
+
+## The horizon ahead
+
+Once strategic plays can run themselves, competitive cycles compress even further. Organisations with weak doctrine or brittle data pipelines will drown in conflicting agent actions. Those who treat doctrine as a living API, cultivate teams who can debate machines, and maintain relentless transparency will turn autonomous execution into a flywheel. Leadership focus shifts from "Can we do this?" to "Should we let the system do this yet?"—a question answered not by intuition alone but by continuously evolving maps and the doctrine encoded within them.


### PR DESCRIPTION
## Summary
- add a follow-on AI leadership article explaining how to let Wardley plays execute autonomously
- document the doctrine prerequisites, leadership roles, safeguards, and automation-ready plays for autonomous agents

## Testing
- npm run lint:md:fix
- python -m pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68dc380679c0832b842c85baed1d4598