### PR TITLE
Add organisational chaos engineering guide for anti-fragile leadership

### DIFF
--- a/docs/ai-and-leadership/anti-fragile-chaos-engineering.md
+++ b/docs/ai-and-leadership/anti-fragile-chaos-engineering.md
@@ -1,0 +1,100 @@
+---
+title: Anti-Fragile Leadership Through Organisational Chaos Engineering
+description: How leaders can engineer stressors across sociotechnical systems so their organisations benefit from volatility rather than collapse under it.
+tags: [ai, leadership, antifragile, organisational-design]
+---
+
+**Anti-fragile organisations do not merely survive shocks; they metabolise them into sharper judgement and faster adaptation.** Chaos engineering, born in distributed computing, now offers leadership a disciplined way to inject volatility across sociotechnical systems and build muscles that thrive under disorder. Applied well, it turns AI-augmented enterprises into learning organisms rather than brittle automation wrappers.
+
+## From Resilience to Anti-Fragility in Wardley Terms
+
+Resilience seeks to snap back to an earlier state. Anti-fragility learns forward. On a Wardley Map this means shifting attention from preserving existing high-utility components to accelerating movement of evolving components into more industrialised forms while elevating human judgement and ethics to the focus of investment.
+
+- **Value chain rebalancing:** As AI commoditises execution, leadership needs to pressure-test the higher-order decisions—purpose, policies, escalation paths—that remain artisanal. Injecting controlled disorder exposes which of those differentiating components lack codification or slack.
+- **Climate patterns of constant change:** Climatic forces such as "Everything Evolves" and "Competitors' actions will change the game" imply recurring stress. Chaos engineering embraces these as design constraints, running experiments that mirror inevitable shocks before the market delivers them.
+- **Doctrine reinforcement:** Plays like "Use appropriate methods" and "Be transparent" become measurable when teams rehearse failure openly. Anti-fragility grows through doctrinal discipline applied under simulated duress.
+
+## Designing Organisational Chaos Experiments
+
+Chaos engineering in an organisational setting is not about breaking infrastructure. It is about surfacing weak couplings and flawed narratives across technology, process, and culture.
+
+### 1. Choose the capability under examination
+
+Map the capability to its components: data pipelines, AI agents, compliance controls, decision authorities, customer touchpoints. Identify where automation sits versus where human discretion governs outcomes. Target the seams between them.
+
+### 2. Formulate hypotheses about failure and learning
+
+The goal is dual: reveal fragilities *and* specify what improvement should look like. Example hypotheses:
+
+- If we remove a key subject-matter expert from the escalation chain for a week, the policy team will clarify tacit rules into artefacts within two days.
+- If the model monitoring dashboard feeds conflicting signals, frontline teams will escalate to governance rather than bypassing controls.
+- If a synthetic customer complaint campaign triggers our service channels, the brand team can identify manipulation within four hours.
+
+### 3. Inject controlled volatility
+
+Deploy perturbations that emulate real climatic pressures:
+
+- **Rotating constraints:** Temporarily withdraw a privileged AI tool, revoke a dataset, or ban a commonly used prompt library to examine how teams reconfigure workflows.
+- **Synthetic narrative attacks:** Seed contradictory memos, leaked "competitor" announcements, or regulator inquiries to evaluate interpretive capability and trust networks.
+- **Decision latency drills:** Compress or extend decision-making windows to see whether governance processes flex or gridlock.
+- **Role inversion sprints:** Assign AI systems to propose strategic options while humans play "red team" to test interpretability, bias detection, and escalation thresholds.
+
+### 4. Instrument for anti-fragile signals
+
+Traditional KPIs (uptime, error counts) are insufficient. Leaders should capture:
+
+- Time-to-learning: duration from perturbation to documented insight.
+- Policy codification rate: how rapidly tacit knowledge becomes explicit playbooks or automation.
+- Trust elasticity: degree of cross-team collaboration during ambiguity, measured through communication graphs or sentiment audits.
+- Recovery deltas: whether post-experiment performance exceeds the pre-shock baseline rather than simply recovers.
+
+### 5. Close the loop deliberately
+
+Chaos experiments must culminate in tangible shifts—new doctrine, map updates, investment decisions. Without explicit follow-through, teams learn that disruption is performative rather than developmental.
+
+## Leadership Challenges and Enablers
+
+Chaos engineering rewires power structures. Leaders must cultivate environments where discomfort is safe and purpose-driven.
+
+- **Psychological safety under stress:** Anti-fragility collapses if people fear blame. Establish clear rules of engagement, pre-commitment from executives, and after-action rituals focused on learning.
+- **Governance for experimentation:** Define guardrails around legal, ethical, and customer exposure. Set thresholds for when synthetic experiments must involve compliance, risk, or unions.
+- **AI literacy and humility:** Leaders should demand interpretability from AI components and be willing to suspend or tune them when experiments reveal bias or brittleness.
+- **Portfolio thinking:** Sequence experiments from low-stakes internal drills to market-facing rehearsals. Track compounded capability gains, not isolated wins.
+
+## When Chaos Engineering Backfires
+
+Anti-fragility is not an excuse for reckless disruption. Watch for failure modes:
+
+- **Fatigue and cynicism:** Excessive or poorly explained experiments erode trust and degrade baseline performance.
+- **Data poisoning and hallucination loops:** Synthetic inputs can contaminate training data or normalise fictitious signals if not quarantined.
+- **Compliance breaches:** Simulated malfeasance may trigger real regulatory reporting obligations. Legal counsel should co-design edge-case drills.
+- **Shadow hierarchies:** If only elite teams run experiments, the organisation entrenches fragility elsewhere.
+
+## Organisational Case Sketches
+
+- **AI-enabled customer operations:** A global services firm rotates AI co-pilots offline one region at a time, forcing local teams to renegotiate workflows, document tacit knowledge, and refine escalation criteria. Over six months, mean time to resolution improves because human teams become better orchestrators rather than passive overseers.
+- **Synthetic supply chain shocks:** A manufacturer seeds phantom supplier outages in its planning systems. Cross-functional teams run decision latency drills that reveal a bias toward centralised approvals. Reforms push authority to the edge with policy guardrails, reducing real-world response times when an actual geopolitical disruption occurs.
+- **Narrative chaos in policy teams:** A public sector agency simulates coordinated misinformation attacks against its AI-assisted benefits adjudication process. Chaos sprints test communications protocols, leading to the creation of rapid-response cells and data provenance dashboards that become permanent capabilities.
+
+## Interplay with Other Strategies
+
+- **Weak Signal sensing:** Chaos experiments amplify the organisation's ability to notice weak signals by training teams to interpret ambiguous inputs without paralysis.
+- **Directed Investment:** Insights from stress tests identify which differentiating components merit accelerated funding versus which can be industrialised or outsourced.
+- **Counterplay readiness:** Practising narrative and supply shocks primes the organisation to confront competitor ambushes or regulatory pivots with rehearsed responses.
+
+## Readiness Checklist
+
+Leaders can gauge anti-fragile maturity through recurring assessments:
+
+- Have we mapped the sociotechnical components and identified which experiments keep judgement artisanal versus which push toward commoditisation?
+- Do we maintain a backlog of chaos hypotheses tied to strategic risks, with owners and sunset criteria?
+- Are experiment retrospectives feeding into doctrine updates, training programs, and AI model governance gates?
+- Can any team request a chaos drill, or is experimentation hoarded by central innovation groups?
+- Do we measure how chaos learnings influence portfolio allocation, partnerships, or market positioning decisions?
+
+## Strategic Insights
+
+1. **Chaos is a leadership capability, not an ops stunt.** Treating chaos engineering as an infrastructure novelty leaves human systems fragile. Executives must own the learning agenda.
+2. **AI increases the stakes.** Automated execution amplifies both the blast radius of failure and the speed of recovery when lessons are captured. Anti-fragility requires integrated AI governance, not bolt-on controls.
+3. **Maps must evolve alongside muscles.** Each experiment should redraw Wardley Maps to reflect new component maturity levels and strategic options. Without cartographic updates, the organisation reverts to intuition.
+4. **Discomfort is the price of preparedness.** Volatility reveals whether doctrines like transparency, communication, and user focus survive stress. Celebrate the teams that surface painful truths; they are the anti-fragile core.


### PR DESCRIPTION
## Summary
- add a new AI and Leadership article positioning chaos engineering as an organisational anti-fragility discipline
- outline experiment design steps, leadership enablers, pitfalls, case sketches, and readiness checks for AI-augmented teams

## Testing
- npm run lint:md:fix
- python -m pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68dc3bfd373c832ba46dd8237dbcc3d9