### PR TITLE
Refactor AI PR review workflow to use prompt file

### DIFF
--- a/.github/prompts/ai-code-review.prompt.yml
+++ b/.github/prompts/ai-code-review.prompt.yml
@@ -1,0 +1,13 @@
+messages:
+  - role: system
+    content: |-
+      You are a strict code reviewer. Return concise, actionable bullets.
+      If nothing material stands out, respond with exactly "LGTM".
+  - role: user
+    content: |-
+      PR context:
+      {{context}}
+
+      Diff:
+      {{diff}}
+model: openai/gpt-4o-mini

--- a/.github/scripts/collect-pr-context.js
+++ b/.github/scripts/collect-pr-context.js
@@ -1,0 +1,50 @@
+module.exports = async function collectPrContext({ github, context, core }) {
+  const { data: files } = await github.rest.pulls.listFiles({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: context.issue.number,
+    per_page: 100,
+  });
+
+  const diff = files
+    .map((file) => `# ${file.filename}\n${file.patch ?? ''}`)
+    .join('\n\n')
+    .slice(0, 30000);
+
+  const { data: pr } = await github.rest.pulls.get({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: context.issue.number,
+  });
+
+  const { data: commits } = await github.rest.pulls.listCommits({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: context.issue.number,
+    per_page: 250,
+  });
+
+  const commitSummaries = commits
+    .slice(0, 20)
+    .map(
+      (commit) =>
+        `- ${commit.sha.slice(0, 7)} ${commit.commit.message.split('\n')[0]}`,
+    )
+    .join('\n');
+
+  const body = (pr.body ?? '').trim() || '(empty)';
+
+  const contextDetails = [
+    `Title: ${pr.title}`,
+    `Author: ${pr.user?.login ?? 'unknown'}`,
+    `Head: ${pr.head.label} (${pr.head.sha.slice(0, 7)})`,
+    `Base: ${pr.base.label} (${pr.base.sha.slice(0, 7)})`,
+    `Draft: ${pr.draft ? 'yes' : 'no'}`,
+    `URL: ${pr.html_url}`,
+    `Body:\n${body}`,
+    `Commits:\n${commitSummaries || '(none listed)'}`,
+  ].join('\n\n');
+
+  core.setOutput('diff', JSON.stringify(diff));
+  core.setOutput('context', JSON.stringify(contextDetails));
+};

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -9,71 +9,24 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Collect diff (patches)
         id: diff
         uses: actions/github-script@v8
         with:
           result-encoding: string
           script: |
-            const {data: files} = await github.rest.pulls.listFiles({
-              owner: context.repo.owner, repo: context.repo.repo,
-              pull_number: context.issue.number, per_page: 100
-            });
-
-            const diff = files
-              .map((file) => `# ${file.filename}\n${file.patch ?? ''}`)
-              .join('\n\n')
-              .slice(0, 30000);
-
-            const {data: pr} = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-            });
-
-            const {data: commits} = await github.rest.pulls.listCommits({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-              per_page: 250,
-            });
-
-            const commitSummaries = commits
-              .slice(0, 20)
-              .map((commit) => `- ${commit.sha.slice(0, 7)} ${commit.commit.message.split('\n')[0]}`)
-              .join('\n');
-
-            const body = (pr.body ?? '').trim() || '(empty)';
-
-            const contextDetails = [
-              `Title: ${pr.title}`,
-              `Author: ${pr.user?.login ?? 'unknown'}`,
-              `Head: ${pr.head.label} (${pr.head.sha.slice(0, 7)})`,
-              `Base: ${pr.base.label} (${pr.base.sha.slice(0, 7)})`,
-              `Draft: ${pr.draft ? 'yes' : 'no'}`,
-              `URL: ${pr.html_url}`,
-              `Body:\n${body}`,
-              `Commits:\n${commitSummaries || '(none listed)'}`,
-            ].join('\n\n');
-
-            core.setOutput('diff', JSON.stringify(diff));
-            core.setOutput('context', JSON.stringify(contextDetails));
-
-            return 'ok';
+            const run = require('./.github/scripts/collect-pr-context.js');
+            await run({ github, context, core });
       - name: Review with a model
         id: ai
         uses: actions/ai-inference@v1
         with:
-          model: openai/gpt-4o-mini
-          system-prompt: |
-            You are a strict code reviewer. Return concise, actionable bullets.
-            If nothing material: return "LGTM".
-          prompt: |
-            PR context:
-            ${{ fromJson(steps.diff.outputs.context) }}
-
-            Diff:
-            ${{ fromJson(steps.diff.outputs.diff) }}
+          prompt-file: ./.github/prompts/ai-code-review.prompt.yml
+          input: |
+            context: ${{ fromJson(steps.diff.outputs.context) }}
+            diff: ${{ fromJson(steps.diff.outputs.diff) }}
       - name: Comment on PR
         uses: actions/github-script@v8
         with:


### PR DESCRIPTION
## Summary
- extract the PR context gathering logic into a reusable script file
- switch the AI review step to use a shared prompt file and check out the repo so the file is available

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e280459dac832bb7bd021d20c398b8