### PR TITLE
Add blog post on accelerating AI evolution and leadership

### DIFF
--- a/blog/2025-10-06-collapse-of-differentiation.md
+++ b/blog/2025-10-06-collapse-of-differentiation.md
@@ -1,0 +1,66 @@
+---
+title: The Collapse of Differentiation in the AI Red Ocean
+description: Why Wardley Mapping leaders must anticipate the accelerating evolution of software components.
+tags:
+  - ai-and-leadership
+  - ai
+  - leadership
+  - wardley-mapping
+  - evolution
+slug: ai-and-leadership/collapse-of-differentiation
+authors:
+  - dave-hulbert
+---
+
+**AI is compressing the evolution of software so quickly that differentiation evaporates before leadership teams can mobilise around it.** Wardley Mapping reminds us that [everything evolves](/climatic-patterns/everything-evolves), yet AI also accelerates the very mechanisms of evolution—communication, automation, recombination—so the curve itself steepens.
+
+<!-- truncate -->
+
+## 1. Mapping the acceleration
+
+Design, engineering, testing, and deployment once defined the product era of software. Now they industrialise instantly: design mockups become production code overnight; global deployment is a single pipeline run. This is more than productivity—it is evolutionary compression. What sat in the product stage last quarter arrives in the utility column this quarter, pushing leaders to treat once-differentiating capabilities as table stakes.
+
+In mapping terms, components that felt unique migrate to the far right of the map at machine speed. The doctrine of differentiation becomes vanity when AI-assisted teams can replicate surface features before your launch announcement finishes trending.
+
+## 2. The mirage of standing out
+
+For two decades the mantra was "be different." It worked when design systems, infrastructure, and data pipelines were still maturing. Today AI erodes that buffer. Assistants can clone your elegant flow or novel pricing model as soon as it becomes visible. Creativity is not dead; it simply needs to live further left on the map where uncertainty and exploration still exist. Differentiation is contextual doctrine—powerful at the genesis edge, wasteful once components hit commodity.
+
+## 3. Evolution evolving
+
+The climatic pattern that everything evolves now sits beside a second truth: evolution itself evolves. The mechanisms of change mutate too—[communication breakthroughs accelerate diffusion](/climatic-patterns/evolution-of-communication-mechanisms-can-increase-the-speed-of-evolution-overall-and-the-diffusion-of-a-single-example-of-change), and ecosystem feedback loops compound learning. Faster feedback cycles, model-to-model conversations, synthetic data, and automated governance all steepen the curve. Leaders must assume that the rate-of-change is accelerating, not stable. Waiting for markets to normalise is a category error; the tempo will only increase.
+
+## 4. Where advantage migrates
+
+When visible features commoditise, advantage moves to the less obvious terrain:
+
+- **Distribution as gravity.** Communities, ecosystems, and channels that direct attention become the choke points.
+- **Messy and regulated niches.** Domains with compliance friction or opaque workflows stay left of the map longer because learning trumps automation.
+- **Integration inertia.** Components that must connect to legacy stacks or ingest expensive data accrue defensibility through switching costs.
+- **Ecosystems and network effects.** When user participation compounds value, you reshape the landscape rather than sell a feature.
+- **Systems of record.** Platforms that store operational history accumulate power as daily workflows become dependent.
+- **Regulation as tempo control.** Policy drag creates temporary scarcity, buying time for differentiated service even as everything else speeds up.
+
+## 5. The industrial sweep
+
+As components mature, Town Planners move in. Large platforms will bundle "good enough" copies of standalone AI tools, not out of malice but because evolution drives every product toward utility. Founders feel the squeeze, yet the answer is not despair—it is to map faster than the market evolves. Anticipate which components commoditise next and reposition before the crowd realises. Strategy is movement, not marketing copy.
+
+## 6. Leading through acceleration
+
+Wardley Mapping reframes the AI red ocean as a predictable stage of industrialisation, but today the stages blur:
+
+| Stage | Character | Strategic focus |
+| --- | --- | --- |
+| Genesis / Custom | Unknown needs, creativity dominant | Experiment, learn fast, explore |
+| Product | Growing market, feature race | Standardise, stabilise, prepare to scale |
+| Commodity / Utility | Hyper-competition, margin collapse | Automate, bundle, move up the value chain |
+
+AI drops new offerings into the market already halfway through their own commoditisation. To lead in that context:
+
+1. **Map relentlessly.** Keep situational awareness current so you can see where scarcity still exists.
+2. **Move with evolution.** Accept that components will keep sliding right and design the next play accordingly.
+3. **Anchor power beyond novelty.** Invest in distribution, ecosystems, inertia, and regulation-aware positioning.
+
+## 7. The leadership takeaway
+
+AI makes software easy to build and hard to defend. Differentiation has not died—it has migrated. Leaders who understand Wardley evolution and the accelerating evolution of evolution itself will sense where advantage relocated and move before competitors react. The goal is not to escape the red ocean; it is to surf the accelerating tide while others are still staring at last year's map.


### PR DESCRIPTION
## Summary
- add a new AI and Leadership blog post explaining how rapid evolution collapses software differentiation
- highlight Wardley Mapping climatic patterns on accelerating evolution and leadership implications for positioning advantage

## Testing
- npm run lint:md:fix
- python -m pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68e40a5e8690832b9dd3d06ee1336179