### PR TITLE
Add mermaid diagrams to selected strategy guides

### DIFF
--- a/docs/strategies/competitor/restriction-of-movement/index.md
+++ b/docs/strategies/competitor/restriction-of-movement/index.md
@@ -66,6 +66,26 @@ This strategy doesn't necessarily eliminate a competitor but restricts their gro
 
 By strategically controlling key aspects of the market, a business can limit a competitor's ability to grow or adapt. This can involve securing exclusive deals, establishing dominant standards, or creating patent thickets. The effect is to limit the competitor's options, forcing them into a constrained position.
 
+### Mapping the encirclement
+
+```mermaid
+flowchart TD
+    A[Map competitor avenues<br/>for adaptation] --> B{Which front?}
+    B -->|Product & market| C[Launch adjacent offers<br/>and saturate price points]
+    B -->|Partnerships| D[Secure exclusivity with suppliers,<br/>channels, data sources]
+    B -->|Talent & capability| E[Acquire key teams,<br/>tie talent into ecosystem]
+    B -->|Regulation & IP| F[Shape standards,<br/>file defensive patents]
+    C --> G[Narrow differentiation corridor]
+    D --> G
+    E --> G
+    F --> G
+    G --> H[Competitor options shrink]
+    H --> I[Monitor escape attempts<br/>and refresh the map]
+    I --> A
+```
+
+This view shows how multiple coordinated moves progressively reduce the viable moves available to a rival, making constant monitoring essential to keep the containment tight without overreaching.
+
 ## 🗺️ **Real-World Examples**
 
 - **Facebook "Circling" Snapchat:** Facebook copied Snapchat's core features across its apps after failing to acquire Snapchat. Instagram Stories, WhatsApp Status, and Facebook Stories effectively encircled Snapchat's niche. This limited Snapchat's growth by restricting its room to maneuver.

--- a/docs/strategies/ecosystem/channel-conflict-and-disintermediation/index.md
+++ b/docs/strategies/ecosystem/channel-conflict-and-disintermediation/index.md
@@ -67,6 +67,24 @@ While it can be disruptive, creating channel conflict is a powerful way to:
 - **Accelerate Market Evolution:** A direct channel allows you to innovate and iterate on your product and messaging much faster than if you had to work through partners.
 - **Shift Power Dynamics:** It can be used to weaken the power of entrenched distributors or retailers, forcing them to accept more favorable terms.
 
+### Visualising the conflict you are creating
+
+```mermaid
+flowchart LR
+    subgraph Legacy Channel
+        A[Producer] --> B[Intermediary / Partner]
+        B --> C[Customer]
+    end
+    A --> D[Direct channel<br/>(store, site, app)]
+    D --> C
+    D --> E[Data, experience & margin feedback]
+    E --> A
+    B -.->|Resistance, demands, lobbying| A
+    A -->|Rebalanced incentives, selective access| B
+```
+
+The diagram highlights how launching a direct route introduces a new feedback loop with customers while simultaneously creating tension with incumbent intermediaries that leaders must proactively manage.
+
 ## 🗺️ **Real-World Examples**
 
 ### Apple's Retail Stores

--- a/docs/strategies/ecosystem/channel-conflict-and-disintermediation/index.md
+++ b/docs/strategies/ecosystem/channel-conflict-and-disintermediation/index.md
@@ -75,7 +75,7 @@ flowchart LR
         A[Producer] --> B[Intermediary / Partner]
         B --> C[Customer]
     end
-    A --> D[Direct channel<br/>(store, site, app)]
+    A --> D["Direct channel (store, site, app)"]
     D --> C
     D --> E[Data, experience & margin feedback]
     E --> A

--- a/docs/strategies/markets/pricing-policy/index.md
+++ b/docs/strategies/markets/pricing-policy/index.md
@@ -137,6 +137,29 @@ Pricing policies can have significant ethical implications. Predatory pricing (s
 5. **Implement and Communicate:** Roll out the new pricing and clearly communicate the value proposition to your customers.
 6. **Monitor and Adapt:** Continuously monitor the impact of your pricing on sales, profit, and market share. Be prepared to adjust your strategy in response to competitor actions and changing market conditions.
 
+### Visualising pricing policy choices
+
+```mermaid
+flowchart TD
+    A[Map demand, elasticity<br/>and cost data] --> B{Primary objective?}
+    B -->|Accelerate adoption| C[Lower prices<br/>Penetration or freemium]
+    B -->|Protect margins| D[Signal premium value]
+    B -->|Shape segments| E[Create tiered or modular offers]
+    B -->|Throttle usage| F[Introduce usage-based controls]
+    C --> G[Monitor volume & CAC impact]
+    D --> H[Bundle differentiators<br/>to justify price]
+    E --> I[Align packages to willingness to pay]
+    F --> J[Match demand to capacity constraints]
+    G --> K[Measure market share, CLV,<br/>competitor reactions]
+    H --> K
+    I --> K
+    J --> K
+    K --> L[Iterate experiments<br/>and refine price architecture]
+    L --> A
+```
+
+This flow illustrates how teams connect strategic intent to pricing levers and then loop outcomes back into the next iteration of pricing experiments.
+
 ## 📈 **Measuring Success**
 
 - **Market Share:** Has your pricing policy helped you gain or maintain market share?


### PR DESCRIPTION
## Summary
- add a pricing-policy decision flow that links objectives to pricing levers and feedback loops
- illustrate the feedback tensions created by channel conflict and disintermediation moves
- map the multi-front encirclement steps used in restriction-of-movement plays

## Testing
- npm run lint:md:fix
- python -m pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68e423e3def4832b92b28cb5102faf52