### PR TITLE
Add new strategy guides for ecosystem, supply, and AI plays

### DIFF
--- a/docs/strategy-guides/ai-transformation-navigator.md
+++ b/docs/strategy-guides/ai-transformation-navigator.md
@@ -1,0 +1,27 @@
+# AI Transformation Navigator
+
+AI promises step-change performance, but unmanaged hype burns capital and trust. This navigator blends [Experimentation](/strategies/attacking/experimentation), [Directed Investment](/strategies/attacking/directed-investment), and the [Press Release Process](/strategies/attacking/press-release-process) with adoption plays like [Education](/strategies/user-perception/education) so leaders can industrialise AI responsibly.
+
+## 🧪 **Frame the Right Experiments**
+
+Resist the urge to automate everything at once. Map the customer journey and internal workflows to spot high-friction steps where AI can relieve cognitive load. Launch tightly scoped proofs of value using [Experimentation](/strategies/attacking/experimentation): define success metrics, capture qualitative feedback, and sunset trials that fail to deliver. Keep experiments in the differentiating zone until reliability is proven.
+
+## 🎯 **Channel Investment Deliberately**
+
+Hype attracts scattershot funding. Apply [Directed Investment](/strategies/attacking/directed-investment) to concentrate resources on experiments that show signal. Fund shared platforms—feature stores, governance tooling, data pipelines—that multiple teams can reuse. Pair investment decisions with map reviews so you can see whether you're building new differentiators or accidentally reinventing commodities that vendors already provide.
+
+## 🗞️ **Communicate the Future State Clearly**
+
+Use the [Press Release Process](/strategies/attacking/press-release-process) to articulate what success looks like before heavy build begins. Draft the narrative, FAQs, and launch metrics that would make the AI initiative newsworthy. This backward planning exposes gaps in user understanding, regulatory posture, or operating model design. Share the press release broadly to align executives, compliance, and delivery teams on the same destination.
+
+## 🧑‍🏫 **Elevate Organisational Literacy**
+
+Most AI programs stall because the workforce is unsure how to use the new capabilities. Launch an [Education](/strategies/user-perception/education) campaign targeted to each role: frontline staff need playbooks, managers need dashboards, and executives need risk primers. Encourage teams to annotate Wardley Maps with doctrine like [Use a Common Language](/doctrines/use-a-common-language) so that data scientists, engineers, and business owners describe evolution in consistent terms.
+
+## ⚙️ **Industrialise What Works**
+
+Once an experiment proves value, shift into a scaling posture. Combine [Market Enablement](/strategies/accelerators/market-enablement) with platform thinking: offer reusable services, guardrails, and compliance templates so other teams can plug in quickly. Where third-party utilities already excel—speech-to-text, document classification—prefer integration over bespoke builds. Reserve custom models for the differentiating slices that map data uniqueness to user delight.
+
+## 📏 **Measure Adoption and Trust**
+
+Track both technical and human signals: deployment frequency, percentage of decisions augmented by AI, model drift incidents, employee confidence scores, and regulatory approvals secured. When metrics degrade, revisit the map to identify whether the issue stems from data quality, process misalignment, or a component that has evolved into a commodity. Continuous sensing keeps the transformation grounded in value rather than novelty.

--- a/docs/strategy-guides/platform-ecosystem-launchpad.md
+++ b/docs/strategy-guides/platform-ecosystem-launchpad.md
@@ -1,0 +1,27 @@
+# Platform Ecosystem Launchpad
+
+This guide helps product leaders assemble a coherent play that turns a differentiated product into a thriving ecosystem. It combines [Platform Envelopment](/strategies/ecosystem/platform-envelopment), [Two-Factor Markets](/strategies/ecosystem/two-factor-markets), and [Co-creation](/strategies/ecosystem/co-creation) with foundational doctrine so that partners and users reinforce each other's success.
+
+## 🧭 **Define the Anchor and Adjacent Plays**
+
+Start by mapping your current value chain and identifying the anchor capability that keeps users loyal. Evaluate nearby needs that competitors satisfy poorly—payments, identity, analytics, or compliance. Use [Platform Envelopment](/strategies/ecosystem/platform-envelopment) logic to determine which adjacent markets can be merged into your offering without diluting focus. When an adjacency shares users and routines with your core, bundle it so that your ecosystem becomes the default destination.
+
+## ⚖️ **Design the Two-Sided Incentives**
+
+A platform falters when one side of the market lags. Use a Wardley Map to visualize each participant journey and pinpoint friction. Offer credible incentives to the side that is harder to attract: subsidies, marketing support, or accelerated onboarding. Draw from [Two-Factor Markets](/strategies/ecosystem/two-factor-markets) by sequencing growth—first secure the side that values differentiation, then commoditize access for the other side with clear APIs and predictable economics. Track liquidity metrics so you can rebalance quickly.
+
+## 🤝 **Codify Co-creation Boundaries**
+
+Co-creation thrives when participants know where they can experiment versus where stability matters. Publish interaction contracts that outline shared data schemas, customer ownership, and escalation paths. Combine [Co-creation](/strategies/ecosystem/co-creation) with [Use a Common Language](/doctrines/use-a-common-language) so that partners see how their components evolve on the map. Encourage extension building in differentiating zones while protecting commoditised utilities with reference implementations and automated quality checks.
+
+## 🔌 **Lower Integration Friction Relentlessly**
+
+Every integration step that feels bespoke will choke ecosystem momentum. Pair your technical roadmap with [Market Enablement](/strategies/accelerators/market-enablement) moves: curated starter kits, sandbox environments, and certification programs that reward reliability. Instrument the developer journey to detect where partners stall and feed those signals back into your backlog. The goal is to make participation cheaper than building alone.
+
+## 🛡️ **Guard Against Ecosystem Backlash**
+
+As your platform expands, expect regulators and competitors to question your fairness. Pre-empt accusations of abuse by aligning with [Alliances](/strategies/ecosystem/alliances) and setting transparent governance. Offer data portability options and independent audits so you can demonstrate that success is earned, not coerced. Keep an eye on components sliding toward commodity status and be willing to open-source or standardise them before external pressure forces your hand.
+
+## 📊 **Run the Ecosystem Control Loop**
+
+Treat the platform as a living system. Maintain a dashboard of leading indicators: number of active builders, partner-led revenue share, time-to-first-integration, and NPS for both sides of the market. When a metric dips, revisit the map to see whether a component has evolved, a new entrant has appeared, or incentives have drifted. A disciplined loop of sensing, adjusting, and reinvesting keeps the ecosystem vibrant and compounds your competitive advantage.

--- a/docs/strategy-guides/resilient-supply-network.md
+++ b/docs/strategy-guides/resilient-supply-network.md
@@ -1,0 +1,27 @@
+# Resilient Supply Network Field Guide
+
+Supply shocks are inevitable; the organisations that thrive turn mapping insight into deliberate redundancy and leverage. This field guide weaves [Buyer-Supplier Power](/strategies/markets/buyer-supplier-power), [Creating Constraints](/strategies/decelerators/creating-constraints), and [Threat Acquisition](/strategies/defensive/threat-acquisition) into a repeatable cycle that stabilises your supply base without suffocating innovation.
+
+## 🗺️ **Map Critical Dependencies End-to-End**
+
+Begin with a Wardley Map that traces the entire flow from raw inputs to customer outcomes. Highlight components with single points of failure or lead times that dwarf customer tolerance. Classify suppliers by evolution stage: genesis partners demand joint exploration, while commodity vendors should be interchangeable. This visual clarity reveals where concentration risk hides behind otherwise healthy metrics.
+
+## 🔀 **Rebalance Power Dynamics Intentionally**
+
+Apply [Buyer-Supplier Power](/strategies/markets/buyer-supplier-power) to negotiate from a position of insight rather than fear. Where suppliers dominate, increase optionality: cultivate alternate vendors, invest in automation, or redesign the product so that a bespoke part becomes a utility. Where you hold leverage, avoid complacency by offering long-term commitments tied to performance metrics that reinforce mutual resilience.
+
+## 🧱 **Introduce Smart Constraints**
+
+Use [Creating Constraints](/strategies/decelerators/creating-constraints) to slow down risky expansions while you fortify the base. Cap order volumes in markets prone to bullwhip effects, require dual-sourcing for components above a defined risk threshold, and set decision gates that demand fresh map reviews before major supplier switches. Constraints are not bureaucracy; they are shock absorbers that keep teams honest about risk trade-offs.
+
+## 🛡️ **Acquire Threats Before They Erupt**
+
+Some bottlenecks will not budge through negotiation alone. Deploy [Threat Acquisition](/strategies/defensive/threat-acquisition) selectively to buy capabilities that jeopardise continuity—specialist tooling firms, niche data providers, or regional logistics hubs. When acquisition is impractical, pursue [Alliances](/strategies/ecosystem/alliances) that give you veto power over critical decisions. Integrate these moves into your map so you can see how the supply network evolves post-deal.
+
+## 🧪 **Institutionalise Stress Testing**
+
+Schedule recurring war games that simulate supplier failure, regulatory shocks, or transportation breakdowns. Feed the scenarios into your maps and document the decision playbooks that emerge. Pair these exercises with real-world telemetry—inventory buffers, supplier financial health, and lead-time variance—so you can trigger contingency plans early. The goal is to make resilience a muscle, not a one-off project.
+
+## 📈 **Measure Resilience as a Portfolio**
+
+Track composite indicators: percentage of spend under dual-source coverage, average time to re-route production, revenue concentration by supplier, and the cadence of map refreshes. When a metric drifts, convene the cross-functional team responsible for the guide and update both constraints and acquisition targets. Over time, this discipline shifts the organisation from reacting to supply shocks to shaping the market on its own terms.


### PR DESCRIPTION
## Summary
- add a platform ecosystem launchpad guide that blends envelopment, multi-sided incentives, and partner governance
- create a resilient supply network playbook covering supplier power, constraints, and targeted acquisitions
- introduce an AI transformation navigator that structures experimentation, investment, communication, and scaling

## Testing
- npm run lint:md:fix
- python -m pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68e428d972a8832bac1a787c8c7c474e