### PR TITLE
Add Assessment Tool to Tools menu

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -151,12 +151,16 @@ const config: Config = {
               to: '/strategy-navigator',
             },
             {
-              label: 'Strategy Maturity Model',
-              to: '/tools/strategy-maturity-model',
+              label: 'Assessment Tool',
+              to: '/about/assessment-tool',
             },
             {
               label: 'My Assessments',
               to: '/my-progress',
+            },
+            {
+              label: 'Strategy Maturity Model',
+              to: '/tools/strategy-maturity-model',
             },
           ],
         },


### PR DESCRIPTION
## Summary
- add the Assessment Tool link to the Tools navigation dropdown
- reorder the dropdown entries to match the desired priority

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e43433495c832bb02a47b4e2be454e