### PR TITLE
Add ISBN front matter to book pages

### DIFF
--- a/docs/books/bell-labs-life-in-the-crown-jewel.md
+++ b/docs/books/bell-labs-life-in-the-crown-jewel.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780929306278"
+---
+
 # Bell Labs: Life in the Crown Jewel
 
 Narain Gehani's **Bell Labs: Life in the Crown Jewel** offers an insider's account of Bell Laboratories during its most productive decades. It recounts the culture, research programmes, and management systems that supported breakthroughs such as the transistor, information theory, and satellite communications.

--- a/docs/books/blue-ocean-strategy.md
+++ b/docs/books/blue-ocean-strategy.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9781625274496"
+---
+
 # Blue Ocean Strategy
 
 **Blue Ocean Strategy: How to Create Uncontested Market Space and Make the Competition Irrelevant** (2005) by W. Chan Kim and Renée Mauborgne outlines how companies can unlock new demand by redefining market boundaries.

--- a/docs/books/competition-demystified.md
+++ b/docs/books/competition-demystified.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9781591841807"
+---
+
 # Competition Demystified
 
 **Competition Demystified** by Bruce C. Greenwald and Judd Kahn simplifies strategic analysis by focusing on competitive advantage and barriers to entry. The authors argue that most industries boil down to either localised monopolies or commodity competition, and they offer frameworks for identifying which applies to your situation.

--- a/docs/books/competitive-strategy.md
+++ b/docs/books/competitive-strategy.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780684841489"
+---
+
 # Competitive Strategy
 
 Michael E. Porter's **Competitive Strategy: Techniques for Analyzing Industries and Competitors** (1980) introduced the Five Forces framework and generic strategies of cost leadership, differentiation, and focus. It equips leaders with analytical tools to evaluate industry structure, anticipate competitor moves, and understand how barriers to entry, supplier power, and substitutes shape profitability.

--- a/docs/books/confessions-of-the-pricing-man.md
+++ b/docs/books/confessions-of-the-pricing-man.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9783319203997"
+---
+
 # Confessions of the Pricing Man
 
 In **Confessions of the Pricing Man**, pricing expert Hermann Simon shares stories and frameworks from decades of advising companies on price strategy. He explains value-based pricing, price differentiation, and the psychology behind willingness to pay, illustrating concepts with real client engagements.

--- a/docs/books/differentiate-or-die.md
+++ b/docs/books/differentiate-or-die.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780470223390"
+---
+
 # Differentiate or Die
 
 **Differentiate or Die** by Jack Trout and Steve Rivkin focuses on positioning and the imperative to stand out in crowded markets. The authors outline techniques for carving a unique space in customers' minds, using examples across consumer goods, services, and B2B industries.

--- a/docs/books/dynamic-capabilities-and-strategic-management.md
+++ b/docs/books/dynamic-capabilities-and-strategic-management.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780199691906"
+---
+
 # Dynamic Capabilities and Strategic Management
 
 **Dynamic Capabilities and Strategic Management: Organizing for Innovation and Growth** by David J. Teece explores how firms sense opportunities, seize them, and reconfigure assets to stay competitive. Drawing on decades of research, Teece explains why advantage rests on organisational processes, knowledge integration, and the ability to realign resources as markets evolve.

--- a/docs/books/empowered.md
+++ b/docs/books/empowered.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9781119691297"
+---
+
 # Empowered
 
 **Empowered** (2020) by Marty Cagan and Chris Jones outlines how technology organisations build empowered product teams. It emphasises outcome-focused missions, autonomous squads, and product leadership that provides vision, coaching, and guardrails rather than feature roadmaps.

--- a/docs/books/fast-second.md
+++ b/docs/books/fast-second.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780787971540"
+---
+
 # Fast Second
 
 **Fast Second: How Smart Companies Bypass Radical Innovation to Enter and Dominate New Markets** by Constantinos C. Markides and Paul A. Geroski studies companies that wait for pioneers to prove demand before entering aggressively. It argues that second movers can scale faster by leveraging superior assets, distribution, and timing once uncertainty drops.

--- a/docs/books/influence-the-psychology-of-persuasion.md
+++ b/docs/books/influence-the-psychology-of-persuasion.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780062937650"
+---
+
 # Influence: The Psychology of Persuasion
 
 Robert B. Cialdini's **Influence: The Psychology of Persuasion** distils decades of social psychology research into six principles—reciprocity, commitment, social proof, authority, liking, and scarcity—that explain how people are persuaded. The book uses experiments and real-world stories to reveal how subtle cues shape behaviour.

--- a/docs/books/judo-strategy.md
+++ b/docs/books/judo-strategy.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9781591391265"
+---
+
 # Judo Strategy
 
 In **Judo Strategy**, David B. Yoffie and Mary Kwak analyse how smaller companies can exploit the strength and momentum of incumbents. Using martial arts metaphors and business cases (such as Netscape vs. Microsoft), they describe tactics for rapid movement, leverage, and balance that let challengers turn a giant's size into a liability.

--- a/docs/books/leading-change.md
+++ b/docs/books/leading-change.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9781422186435"
+---
+
 # Leading Change
 
 In **Leading Change**, John P. Kotter presents an eight-step model for delivering successful organisational transformations. The book emphasises establishing urgency, forming guiding coalitions, crafting vision, communicating for buy-in, empowering action, generating wins, consolidating gains, and anchoring new approaches in culture.

--- a/docs/books/made-by-customers.md
+++ b/docs/books/made-by-customers.md
@@ -1,3 +1,7 @@
+---
+isbn13: ""
+---
+
 # Made by Customers
 
 In **Made by Customers: The New Revolution in Creating and Marketing Products**, Stefan Thomke and Eric von Hippel explore how companies harness user innovation. The authors show how customer toolkits, lead-user programmes, and feedback loops let organisations co-design offerings that better meet emerging needs.

--- a/docs/books/mergers-and-acquisitions-for-dummies.md
+++ b/docs/books/mergers-and-acquisitions-for-dummies.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780470385561"
+---
+
 # Mergers & Acquisitions For Dummies
 
 Bill Snow's **Mergers & Acquisitions For Dummies** is a practical guide to planning, valuing, and closing M&A deals. It explains the roles of advisors, due diligence workflows, financing structures, and negotiation tactics from both buy-side and sell-side perspectives.

--- a/docs/books/modern-monopolies.md
+++ b/docs/books/modern-monopolies.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9781250091895"
+---
+
 # Modern Monopolies
 
 In **Modern Monopolies**, Alex Moazed and Nicholas L. Johnson examine how platform businesses create and capture value. They explain the economics of multi-sided markets, network effects, and data-driven feedback loops that allow platform companies to outpace traditional linear businesses.

--- a/docs/books/monetizing-innovation.md
+++ b/docs/books/monetizing-innovation.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9781119240860"
+---
+
 # Monetizing Innovation
 
 **Monetizing Innovation** by Madhavan Ramanujam and Georg Tacke focuses on integrating pricing into product innovation. The authors describe how to test willingness to pay early, design offers around monetisation models, and avoid common traps like feature bloat or underpricing breakthroughs.

--- a/docs/books/obviously-awesome.md
+++ b/docs/books/obviously-awesome.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9781999023003"
+---
+
 # Obviously Awesome
 
 April Dunford's **Obviously Awesome** provides a step-by-step positioning process for technology products. It guides teams through identifying competitive alternatives, isolating unique attributes, mapping true value, and defining customer segments that care most about that value.

--- a/docs/books/platform-revolution.md
+++ b/docs/books/platform-revolution.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780393354355"
+---
+
 # Platform Revolution
 
 **Platform Revolution: How Networked Markets Are Transforming the Economy—and How to Make Them Work for You** (2016) by Geoffrey G. Parker, Marshall W. Van Alstyne, and Sangeet Paul Choudary explores how platform businesses orchestrate interactions between producers and consumers.

--- a/docs/books/platforms-markets-and-innovation.md
+++ b/docs/books/platforms-markets-and-innovation.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9781848447899"
+---
+
 # Platforms, Markets and Innovation
 
 **Platforms, Markets and Innovation** (2009) edited by Annabelle Gawer examines how platform leaders orchestrate ecosystems of complementors. The collection analyses case studies such as Intel, Microsoft, and mobile telecoms to explain how modular architectures, governance choices, and standards battles shape competitive outcomes.

--- a/docs/books/priceless-the-myth-of-fair-value.md
+++ b/docs/books/priceless-the-myth-of-fair-value.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780809078813"
+---
+
 # Priceless: The Myth of Fair Value
 
 William Poundstone's **Priceless: The Myth of Fair Value (and How to Take Advantage of It)** explores behavioural pricing and why perceptions of fairness shape buying decisions. Drawing on experiments in psychology and behavioural economics, it demonstrates anchoring, decoy pricing, and other techniques that influence willingness to pay.

--- a/docs/books/seeing-like-a-state.md
+++ b/docs/books/seeing-like-a-state.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780300078152"
+---
+
 # Seeing Like a State
 
 James C. Scott's **Seeing Like a State** critiques high-modernist planning and the tendency of large institutions to impose simplified schemes on complex societies. Through historical case studies, Scott shows how top-down standardisation can erase local knowledge and provoke resistance.

--- a/docs/books/strategic-management-of-technological-innovation.md
+++ b/docs/books/strategic-management-of-technological-innovation.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9781260087956"
+---
+
 # Strategic Management of Technological Innovation
 
 Melissa A. Schilling's **Strategic Management of Technological Innovation** provides a comprehensive framework for managing innovation portfolios. The text explores technology S-curves, dominant design emergence, innovation diffusion, and the organisational structures required to shepherd ideas from research through commercialisation.

--- a/docs/books/the-art-of-deception.md
+++ b/docs/books/the-art-of-deception.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780764542800"
+---
+
 # The Art of Deception
 
 **The Art of Deception** by Kevin D. Mitnick and William L. Simon chronicles social engineering attacks and the psychology behind them. Through case studies, it explains how attackers exploit trust, authority, and urgency to persuade people into revealing secrets or granting access to systems.

--- a/docs/books/the-art-of-war.md
+++ b/docs/books/the-art-of-war.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780140439199"
+---
+
 # The Art of War
 
 **The Art of War** is an ancient Chinese military treatise attributed to Sun Tzu.

--- a/docs/books/the-business-of-america-is-lobbying.md
+++ b/docs/books/the-business-of-america-is-lobbying.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780190215514"
+---
+
 # The Business of America is Lobbying
 
 Lee Drutman's **The Business of America is Lobbying** analyses how corporate lobbying became a permanent part of the U.S. political system. It traces the growth of influence campaigns, the economics of lobbying firms, and why companies build in-house public affairs capabilities.

--- a/docs/books/the-business-of-platforms.md
+++ b/docs/books/the-business-of-platforms.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780062896322"
+---
+
 # The Business of Platforms
 
 **The Business of Platforms: Strategy in the Age of Digital Competition, Innovation, and Power** (2019) by Michael A. Cusumano, Annabelle Gawer, and David B. Yoffie examines how platform companies compete, collaborate, and evolve.

--- a/docs/books/the-cold-start-problem.md
+++ b/docs/books/the-cold-start-problem.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9781847942791"
+---
+
 # The Cold Start Problem
 
 Andrew Chen's **The Cold Start Problem** explains how to launch and scale network-effect businesses. Drawing on experiences from Uber and other tech companies, Chen describes the atomic networks that ignite growth, the roles of acquisition loops, engagement loops, and economics loops, and the tactics required to move from niche communities to mass-market platforms.

--- a/docs/books/the-direct-to-consumer-playbook.md
+++ b/docs/books/the-direct-to-consumer-playbook.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9781398605425"
+---
+
 # The Direct-to-Consumer Playbook
 
 Mike Stevens' **The Direct-to-Consumer Playbook** distils lessons from building and advising DTC brands. It covers positioning, digital acquisition, subscription economics, and the operational foundations needed to serve customers directly without intermediaries.

--- a/docs/books/the-everything-store.md
+++ b/docs/books/the-everything-store.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780316219280"
+---
+
 # The Everything Store
 
 Brad Stone's **The Everything Store: Jeff Bezos and the Age of Amazon** chronicles Amazon's rise from online bookstore to diversified platform. It details strategic choices around logistics, marketplace expansion, AWS, and the culture of relentless customer focus and frugality that underpinned growth.

--- a/docs/books/the-future-of-competition.md
+++ b/docs/books/the-future-of-competition.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9781578519538"
+---
+
 # The Future of Competition
 
 C.K. Prahalad and Venkat Ramaswamy's **The Future of Competition: Co-Creating Unique Value with Customers** argues that value creation is shifting from firm-centric offerings to collaborative experiences. The authors illustrate how companies invite customers into design, production, and delivery, using dialogue, access, risk-benefits, and transparency as the DART model for co-creation.

--- a/docs/books/the-goal.md
+++ b/docs/books/the-goal.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780884271956"
+---
+
 # The Goal
 
 **The Goal** by Eliyahu M. Goldratt and Jeff Cox is a business novel that introduces the Theory of Constraints. Through the story of a manufacturing plant manager, it explains how to identify bottlenecks, optimise flow, and align metrics with overall system throughput rather than local efficiencies.

--- a/docs/books/the-innovators-dilemma.md
+++ b/docs/books/the-innovators-dilemma.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9781633691780"
+---
+
 # The Innovator's Dilemma
 
 **The Innovator's Dilemma: When New Technologies Cause Great Firms to Fail** is a book by Clayton M. Christensen.

--- a/docs/books/the-power-of-pull.md
+++ b/docs/books/the-power-of-pull.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780465028764"
+---
+
 # The Power of Pull
 
 In **The Power of Pull**, John Hagel III, John Seely Brown, and Lang Davison argue that advantage comes from attracting resources, talent, and ideas when needed rather than owning them outright. They describe how digital networks enable organisations to sense opportunities, mobilise ecosystems, and accelerate learning through open flows of knowledge.

--- a/docs/books/the-strategy-and-tactics-of-pricing.md
+++ b/docs/books/the-strategy-and-tactics-of-pricing.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9781138737518"
+---
+
 # The Strategy and Tactics of Pricing
 
 **The Strategy and Tactics of Pricing** by Thomas T. Nagle, John Hogan, and Joseph Zale offers a structured approach to building and executing pricing strategies. It covers economic foundations, value-based pricing, segmentation, and the organisational processes required to align sales and product teams around price realisation.

--- a/docs/books/thinking-fast-and-slow.md
+++ b/docs/books/thinking-fast-and-slow.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780141033570"
+---
+
 # Thinking, Fast and Slow
 
 **Thinking, Fast and Slow** (2011) by Daniel Kahneman synthesises behavioural economics research on how people make judgements under uncertainty. It introduces the dual-system model—fast, intuitive "System 1" thinking and slower, analytical "System 2" reasoning—and shows how cognitive shortcuts shape perception, probability assessments, and risk appetite.

--- a/docs/books/thinking-in-bets.md
+++ b/docs/books/thinking-in-bets.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780735216358"
+---
+
 # Thinking in Bets
 
 In **Thinking in Bets**, former professional poker player Annie Duke explains how to make better decisions under uncertainty. She introduces concepts such as resulting, probabilistic thinking, and decision accountability groups to help leaders separate decision quality from outcomes.

--- a/docs/books/trust-me-im-lying.md
+++ b/docs/books/trust-me-im-lying.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9781788160063"
+---
+
 # Trust Me, I'm Lying
 
 In **Trust Me, I'm Lying: Confessions of a Media Manipulator**, Ryan Holiday reveals how modern media incentives can be gamed. Drawing on his experience running marketing stunts, he explains how to seed stories in blogs, manufacture outrage, and exploit the viral news cycle.

--- a/docs/books/unlocking-the-customer-value-chain.md
+++ b/docs/books/unlocking-the-customer-value-chain.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9781524763084"
+---
+
 # Unlocking the Customer Value Chain
 
 **Unlocking the Customer Value Chain** by Thales S. Teixeira with Greg Piechota explains how disruptive companies decouple stages of the customer journey to win share. Drawing on academic research and case studies (including Amazon, Warby Parker, and Airbnb), it shows how startups exploit friction points in incumbent value chains and then re-bundle services on their own platforms.

--- a/docs/books/who-says-elephants-cant-dance.md
+++ b/docs/books/who-says-elephants-cant-dance.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9780060523800"
+---
+
 # Who Says Elephants Can't Dance?
 
 **Who Says Elephants Can't Dance?** is Louis V. Gerstner Jr.'s memoir of leading IBM's turnaround in the 1990s. He recounts how the company shifted from a hardware-centric culture to a services-led organisation, describing decisions on cost restructuring, cultural change, and market focus.

--- a/docs/books/working-backwards.md
+++ b/docs/books/working-backwards.md
@@ -1,3 +1,7 @@
+---
+isbn13: "9781529033847"
+---
+
 # Working Backwards
 
 **Working Backwards** by Colin Bryar and Bill Carr documents Amazon's leadership principles and product development mechanisms. It details practices like the PR/FAQ process, single-threaded leadership, and metrics-driven operational excellence that enable teams to start with customer outcomes and iterate toward launch.


### PR DESCRIPTION
## Summary
- add a YAML front matter block to every book page under docs/books
- record each book's ISBN-13 value in a new isbn13 field (leaving empty when unknown)

## Testing
- npm run lint:md:fix
- python -m pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68e4c43024a4832bb1db47db0e6da4b9