### PR TITLE
Add regression test for missing book ISBN metadata

### DIFF
--- a/tests/test_books.py
+++ b/tests/test_books.py
@@ -1,0 +1,45 @@
+import re
+from pathlib import Path
+
+import pytest
+
+BOOKS_DIR = Path("docs/books")
+
+
+def get_book_files():
+    return [path for path in BOOKS_DIR.glob("*.md") if path.name != "index.md"]
+
+
+def parse_front_matter(text: str):
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n", text, re.DOTALL)
+    if not match:
+        return {}
+
+    front_matter_content = match.group(1)
+    data = {}
+    for line in front_matter_content.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if ":" not in stripped:
+            continue
+        key, value = stripped.split(":", 1)
+        key = key.strip()
+        value = value.strip().strip('"')
+        data[key] = value
+    return data
+
+
+def test_all_books_have_isbns():
+    missing_isbn = []
+    for book_file in get_book_files():
+        content = book_file.read_text(encoding="utf-8")
+        front_matter = parse_front_matter(content)
+        isbn = front_matter.get("isbn13") or front_matter.get("isbn10")
+        if not isbn or not isbn.strip():
+            missing_isbn.append(book_file)
+
+    assert not missing_isbn, (
+        "Books missing ISBN front matter: " + ", ".join(str(path) for path in missing_isbn)
+    )
+


### PR DESCRIPTION
## Summary
- add a dedicated test suite for book content quality
- ensure every book markdown file declares a non-empty ISBN

## Testing
- python -m pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68e5707287c0832bb1dad963de87620b