### PR TITLE
Add book purchase card to book docs

### DIFF
--- a/src/components/BookCard/index.tsx
+++ b/src/components/BookCard/index.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import clsx from 'clsx';
+
+import styles from './styles.module.css';
+
+export type BookCardProps = {
+  title: string;
+  authors?: string[];
+  isbn13: string;
+  year?: number | null;
+  summary?: string;
+  tags?: string[];
+};
+
+const coverUrl = (isbn: string, size: 'S' | 'M' | 'L' = 'L') =>
+  `https://covers.openlibrary.org/b/isbn/${isbn}-${size}.jpg`;
+
+const bookshopUrl = (isbn: string, affiliateId?: string) =>
+  affiliateId
+    ? `https://bookshop.org/a/${affiliateId}/${isbn}`
+    : `https://bookshop.org/book/${isbn}`;
+
+const worldcatUrl = (isbn: string) => `https://worldcat.org/isbn/${isbn}`;
+
+function normaliseList(values: string[] | undefined): string[] {
+  return (values ?? [])
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+export default function BookCard({
+  title,
+  authors,
+  isbn13,
+  year,
+  summary,
+  tags,
+}: BookCardProps): React.ReactElement {
+  const affiliateId = process.env.BOOKSHOP_AFFILIATE_ID;
+  const authorList = normaliseList(authors);
+  const tagList = normaliseList(tags);
+  const summaryText = summary?.trim();
+  const publicationYear = typeof year === 'number' ? year : undefined;
+
+  return (
+    <article className={clsx('card', styles.card)}>
+      <div className={styles.cover}>
+        <img
+          src={coverUrl(isbn13)}
+          alt={`Cover of ${title}`}
+          loading="lazy"
+          width={96}
+          height={144}
+          onError={(event) => {
+            const image = event.currentTarget;
+            image.onerror = null;
+            image.src = '/img/book.svg';
+          }}
+        />
+      </div>
+      <div className={styles.details}>
+        <h3 className={styles.title}>
+          {title}
+          {publicationYear ? ` (${publicationYear})` : ''}
+        </h3>
+        {authorList.length > 0 && (
+          <p className={styles.authors}>{authorList.join(', ')}</p>
+        )}
+        {summaryText && <p className={styles.summary}>{summaryText}</p>}
+        {tagList.length > 0 && (
+          <ul className={styles.tags}>
+            {tagList.map((tag) => (
+              <li key={tag} className={styles.tag}>
+                {tag}
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className={styles.actions}>
+          <a
+            className={clsx('button', 'button--primary')}
+            rel="nofollow sponsored"
+            href={bookshopUrl(isbn13, affiliateId ?? undefined)}
+          >
+            Buy on Bookshop.org
+          </a>
+          <a
+            className={clsx('button', 'button--secondary')}
+            href={`https://openlibrary.org/isbn/${isbn13}`}
+          >
+            Open Library
+          </a>
+          <a
+            className={clsx('button', 'button--secondary')}
+            href={worldcatUrl(isbn13)}
+          >
+            Find in a library
+          </a>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/components/BookCard/index.tsx
+++ b/src/components/BookCard/index.tsx
@@ -36,7 +36,10 @@ export default function BookCard({
   summary,
   tags,
 }: BookCardProps): React.ReactElement {
-  const affiliateId = process.env.BOOKSHOP_AFFILIATE_ID;
+  const affiliateId =
+    typeof process !== 'undefined' && process.env?.BOOKSHOP_AFFILIATE_ID
+      ? process.env.BOOKSHOP_AFFILIATE_ID
+      : undefined;
   const authorList = normaliseList(authors);
   const tagList = normaliseList(tags);
   const summaryText = summary?.trim();
@@ -80,7 +83,7 @@ export default function BookCard({
           <a
             className={clsx('button', 'button--primary')}
             rel="nofollow sponsored"
-            href={bookshopUrl(isbn13, affiliateId ?? undefined)}
+            href={bookshopUrl(isbn13, affiliateId)}
           >
             Buy on Bookshop.org
           </a>

--- a/src/components/BookCard/styles.module.css
+++ b/src/components/BookCard/styles.module.css
@@ -1,0 +1,87 @@
+.card {
+  display: grid;
+  grid-template-columns: minmax(80px, 96px) 1fr;
+  gap: var(--ifm-spacing-lg);
+  padding: var(--ifm-spacing-lg);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--ifm-global-radius);
+  box-shadow: var(--ifm-global-shadow-lw);
+  background-color: var(--ifm-card-background-color);
+}
+
+.cover {
+  width: 96px;
+}
+
+.cover img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: calc(var(--ifm-global-radius) / 2);
+  box-shadow: var(--ifm-global-shadow-sm);
+}
+
+.details {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ifm-spacing-sm);
+}
+
+.title {
+  margin-bottom: 0;
+}
+
+.authors {
+  margin: 0;
+  color: var(--ifm-color-emphasis-600);
+  font-style: italic;
+}
+
+.summary {
+  margin: 0;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ifm-spacing-xs);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tag {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 999px;
+  padding: 0 var(--ifm-spacing-sm);
+  font-size: 0.75rem;
+  line-height: 1.75;
+  background-color: var(--ifm-color-emphasis-100);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ifm-spacing-sm);
+  margin-top: var(--ifm-spacing-md);
+}
+
+@media (max-width: 576px) {
+  .card {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    text-align: center;
+  }
+
+  .details {
+    align-items: center;
+  }
+
+  .tags {
+    justify-content: center;
+  }
+
+  .actions {
+    justify-content: center;
+  }
+}

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -9,6 +9,7 @@ import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {useWindowSize} from '@docusaurus/theme-common';
 import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import {usePluginData} from '@docusaurus/useGlobalData';
 import DocItemPaginator from '@theme/DocItem/Paginator';
 import DocVersionBanner from '@theme/DocVersionBanner';
 import DocVersionBadge from '@theme/DocVersionBadge';
@@ -20,8 +21,48 @@ import DocItemContent from '@theme/DocItem/Content';
 import DocBreadcrumbs from '@theme/DocBreadcrumbs';
 import ContentVisibility from '@theme/ContentVisibility';
 import type {Props} from '@theme/DocItem/Layout';
+import BookCard, {type BookCardProps} from '@site/src/components/BookCard';
 
 import styles from './styles.module.css';
+
+interface BookSummary {
+  slug: string;
+  title: string;
+  authors: string[];
+  isbn13: string;
+  year: number | null;
+  tags: string[];
+  summary: string;
+}
+
+interface BooksIndexData {
+  dataPath: string;
+  count: number;
+  books: BookSummary[];
+}
+
+function ensureStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const filtered = value.filter((item): item is string => typeof item === 'string');
+
+  return filtered.length > 0 ? filtered : undefined;
+}
+
+function ensureString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function ensureNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
 
 /**
  * Decide if the toc should be rendered, on mobile or desktop viewports
@@ -50,6 +91,43 @@ function useDocTOC() {
 export default function DocItemLayout({children}: Props): ReactNode {
   const docTOC = useDocTOC();
   const {metadata, frontMatter} = useDoc();
+  const frontMatterRecord = frontMatter as Record<string, unknown>;
+  const booksIndex = usePluginData('books-index') as BooksIndexData | undefined;
+  const docAuthors = ensureStringArray(frontMatterRecord.authors);
+
+  const bookCardProps = React.useMemo(() => {
+    const permalink = metadata.permalink?.replace(/\/$/, '') ?? '';
+    const isbn = ensureString(frontMatterRecord.isbn13);
+    const isBookPage = permalink.startsWith('/books/');
+
+    if (!isBookPage || !isbn) {
+      return undefined;
+    }
+
+    const bookFromIndex = booksIndex?.books?.find(
+      (entry) => entry.isbn13 === isbn || entry.slug === permalink,
+    );
+
+    const authors =
+      ensureStringArray(frontMatterRecord.bookAuthors) ?? bookFromIndex?.authors ?? [];
+    const summary =
+      ensureString(frontMatterRecord.summary) ?? bookFromIndex?.summary ?? metadata.description;
+    const tags = ensureStringArray(frontMatterRecord.bookTags) ?? bookFromIndex?.tags ?? [];
+    const year =
+      ensureNumber(frontMatterRecord.year) ?? ensureNumber(bookFromIndex?.year ?? undefined);
+
+    const card: BookCardProps = {
+      title: bookFromIndex?.title ?? metadata.title,
+      authors,
+      isbn13: isbn,
+      year: year ?? undefined,
+      summary,
+      tags,
+    };
+
+    return card;
+  }, [booksIndex, frontMatter, metadata.description, metadata.permalink, metadata.title]);
+
   return (
     <div className="row">
       <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
@@ -62,8 +140,13 @@ export default function DocItemLayout({children}: Props): ReactNode {
             {docTOC.mobile}
             <DocItemContent>{children}</DocItemContent>
             <DocItemFooter />
-            {frontMatter.authors && frontMatter.authors.length > 0 && (
-              <AuthorByline authorIds={frontMatter.authors} />
+            {docAuthors && docAuthors.length > 0 && (
+              <AuthorByline authorIds={docAuthors} />
+            )}
+            {bookCardProps && (
+              <div className="margin-top--lg">
+                <BookCard {...bookCardProps} />
+              </div>
             )}
           </article>
           <DocItemPaginator />


### PR DESCRIPTION
## Summary
- add a reusable `BookCard` component to show a book cover, summary and outbound links for ISBNs
- automatically render the new card on book documentation pages by pulling metadata from the books index when an ISBN is present

## Testing
- npm test
- npm run typecheck *(fails: existing TypeScript configuration lacks Jest and JSX typings)*

------
https://chatgpt.com/codex/tasks/task_e_68e580f8ef54832b9f91ef72ce530728