### PR TITLE
Humanize competitor strategy overview page

### DIFF
--- a/docs/strategies/competitor/index.md
+++ b/docs/strategies/competitor/index.md
@@ -4,53 +4,51 @@ description: Engaging rivals to erode their advantages, waste resources, or neut
 authors: [dave-hulbert]
 ---
 
+Competitor strategies are deliberate plays that change what a rival can do next. Instead of only improving your own execution, you shape the opponent's choices, timing, and costs.
 
-This category of strategies encompasses a diverse array of tactical and strategic actions aimed at directly or indirectly engaging with rivals. These approaches come into play when a competitor's presence is too significant to ignore, or when strategic absorption isn't feasible or desirable. The core objectives often revolve around diminishing a rival's competitive edge, misdirecting their strategic focus, depleting their valuable resources, maneuvering them into strategically unfavorable circumstances, or otherwise shaping the competitive landscape to your advantage.
-
-This might involve exploiting a competitor's known weaknesses, turning their apparent strengths into liabilities, or subtly altering market conditions. The ultimate aim is to improve your own strategic position, often by constraining the options available to your rivals. These strategies are particularly potent for organizations that might lack the scale or resources for a direct, sustained confrontation with larger, more entrenched competitors. Through astute, often indirect plays, a company can endeavor to level the playing field, engineer strategic openings, or neutralize specific threats.
+This category matters when direct head-to-head competition is expensive, slow, or likely to favor the incumbent. A well-timed competitor play can open space, buy time, or force a stronger rival into awkward trade-offs.
 
 ## 🤔 **What are Competitor Strategies?**
 
-At their core, competitor strategies are about moving beyond a purely internal focus to actively understanding and influencing the competitive landscape. They involve viewing a competitor as a system that can be analyzed, predicted, and ultimately influenced. Key characteristics and goals include:
+Competitor strategies focus on how your moves affect a rival system, not just your own roadmap.
 
-* **Eroding Competitive Advantage:** Identifying and targeting the sources of a competitor's strength – be it technology, market share, talent, or brand – and taking actions to weaken or neutralize that advantage.
-* **Resource Depletion:** Designing plays that force a competitor to expend resources (time, money, attention) in areas that are non-core to their strategy or in ways that yield minimal returns for them. This can include forcing them to react to your moves, defend unprofitable segments, or invest in countermeasures.
-* **Strategic Misdirection:** Leading competitors towards incorrect assumptions about your intentions or market trends, causing them to invest in the wrong areas or prepare for the wrong scenarios.
-* **Creating Decision Dilemmas:** Engineering situations where any move a competitor makes comes with significant downsides, effectively trapping them or forcing them into suboptimal choices.
-* **Exploiting Inertia:** Capitalizing on a competitor's unwillingness or inability to change due to past successes, established processes, or cultural resistance.
-* **Shaping the Playing Field:** Actively working to alter the "rules of the game" in a market, such as influencing standards, creating new channels, or disrupting existing networks in ways that favor your position.
+Common goals include:
 
-These strategies often require a deep understanding of a competitor's psychology, organizational structure, decision-making processes, and market dependencies.
+- **Eroding advantage:** Target a specific source of strength such as distribution, talent, or ecosystem control.
+- **Forcing expensive responses:** Push a rival into spending time, money, or leadership attention where returns are weak.
+- **Shaping decisions:** Create situations where every available response has a downside.
+- **Exploiting inertia:** Use the fact that successful organizations often struggle to change quickly.
+- **Changing the field:** Alter channels, standards, or partner dynamics so your position improves over time.
+
+These plays work best when informed by a clear map of user needs, dependencies, and likely counter-moves.
 
 ## 🚀 **Why Use Competitor Strategies?**
 
-Employing competitor-focused strategies can be essential for survival and growth in contested markets. They offer several strategic advantages:
+Use these strategies when market pressure is real and passive defense is not enough.
 
-* **Leveling the Playing Field:** Smaller or newer entrants can use these strategies to negate some of the scale advantages of larger incumbents, creating space for themselves to grow.
-* **Responding to Aggression:** When a competitor makes aggressive moves, these strategies provide a toolkit for responding effectively, rather than simply ceding ground.
-* **Creating Market Opportunities:** By disrupting a competitor's plans or weakening their hold on a market segment, new opportunities can be created for your own offerings.
-* **Defending Market Share:** These tactics can be used defensively to protect your existing market position from encroaching rivals.
-* **Preemptive Action:** Anticipating a competitor's likely moves and taking action to preempt them or reduce their impact.
-* **Improving Negotiating Positions:** Demonstrating an ability to impact a competitor can strengthen your position in potential partnerships, supplier relationships, or even co-opetition scenarios.
-* **Accelerating Market Shifts:** Certain competitor strategies can help accelerate underlying market trends that are favorable to your long-term position, particularly if competitors are resistant to those trends.
+They can help you:
 
-While a strong focus on customer value and internal excellence is paramount, a sophisticated understanding and selective application of competitor strategies can provide a crucial edge in achieving strategic objectives. They are about playing the whole game, not just your own part of it.
+- **Create room to grow:** Especially when you are smaller than the incumbent.
+- **Respond to hostile moves:** Without defaulting to price wars or copycat launches.
+- **Protect critical positions:** By making it harder for rivals to attack your core.
+- **Pre-empt predictable threats:** By acting before a competitor fully commits.
+- **Strengthen bargaining power:** In partnerships, supply negotiations, or ecosystem coordination.
+
+This is not a substitute for customer value. It is a layer on top of customer value, used when the competitive game itself needs active shaping.
 
 ## ♟️ **Types of Competitor Strategies**
 
-Here are several approaches for engaging with competitors, each with a distinct focus:
+These pages cover different ways to engage rivals:
 
-* **[Tech Drops](/strategies/competitor/tech-drops)**: Exploiting a competitor's marketing efforts or public presence to gain visibility and market share, often by associating your brand with an event or message they initiated.
-* **[Circling and Probing](/strategies/competitor/circling-and-probing)**: Systematically testing a competitor's defenses, responses, and capabilities across different areas to identify weaknesses and unexploited opportunities.
-* **[Fragmentation](/strategies/competitor/fragmentation)**: Breaking up a larger, dominant competitor or market by targeting niche segments, supporting competing standards, or fostering a diverse ecosystem that collectively chips away at their position.
-* **[Misdirection](/strategies/competitor/misdirection)**: Leading a competitor to believe you are pursuing one course of action while you are actually implementing another, causing them to misallocate resources or focus.
-* **[Reinforcing Competitor Inertia](/strategies/competitor/reinforcing-competitor-inertia)**: Subtly encouraging a competitor to continue with their existing, suboptimal strategies or to double down on outdated practices, thereby hindering their adaptation.
-* **[Restriction of Movement](/strategies/competitor/restriction-of-movement)**: Limiting a competitor's strategic options by securing key resources, channels, partnerships, or by creating dependencies that constrain their ability to maneuver.
-* **[Sapping](/strategies/competitor/sapping)**: Gradually draining a competitor's strength, resources, or morale through sustained, often low-intensity actions that individually seem minor but collectively have a significant impact.
-* **[Talent Raid](/strategies/competitor/talent-raid)**: Systematically hiring key personnel from a competitor to acquire their expertise, disrupt their operations, and gain market intelligence.
-* **[Ambush](/strategies/competitor/ambush)**: Reactively undermining a specific competitor's progress or negating their advantage with a surprise strategic maneuver.
-
-Each of these strategies offers a different method for engaging with and potentially neutralizing competitor actions, requiring careful consideration of the context and potential consequences.
+- **[Tech Drops](/strategies/competitor/tech-drops):** Use a sudden capability release to reset expectations and force competitors to react.
+- **[Circling and Probing](/strategies/competitor/circling-and-probing):** Run focused tests around a rival's edges to discover weak points before committing fully.
+- **[Fragmentation](/strategies/competitor/fragmentation):** Break concentration of power by supporting alternatives, niches, or different standards.
+- **[Misdirection](/strategies/competitor/misdirection):** Signal one intention while executing another so competitors allocate resources poorly.
+- **[Reinforcing Competitor Inertia](/strategies/competitor/reinforcing-competitor-inertia):** Encourage a rival to stay with outdated assumptions.
+- **[Restriction of Movement](/strategies/competitor/restriction-of-movement):** Limit rival options by controlling key resources, channels, or dependencies.
+- **[Sapping](/strategies/competitor/sapping):** Apply sustained low-intensity pressure that gradually reduces rival capacity.
+- **[Talent Raid](/strategies/competitor/talent-raid):** Acquire key people or teams to weaken a rival and accelerate your own capability.
+- **[Ambush](/strategies/competitor/ambush):** Launch a targeted response that neutralizes a rival's latest advantage.
 
 ### Comparison of Competitor Strategies
 
@@ -68,23 +66,23 @@ Each of these strategies offers a different method for engaging with and potenti
 
 ## ⚖️ **Ethical Considerations and Risks**
 
-While competitor-focused strategies can be effective, they also carry significant risks and ethical considerations that must be carefully weighed:
+Competitor plays carry real downside risk, and leadership should treat that risk as part of the strategy, not an afterthought.
 
-* **Retaliation:** Aggressive moves can provoke strong responses from competitors, potentially leading to costly battles that harm all parties involved.
-* **Reputational Damage:** Strategies perceived as unethical, underhanded, or overly aggressive can damage a company's reputation with customers, partners, and the wider industry.
-* **Legal Challenges:** Some tactics, if not carefully implemented, can stray into anti-competitive behavior, intellectual property infringement, or other legal pitfalls.
-* **Internal Focus Erosion:** An excessive focus on competitors can distract from innovation and customer needs, leading to a reactive rather than proactive strategy.
-* **Moral Hazard:** Certain tactics might create a culture that prioritizes winning at any cost, potentially leading to unethical decision-making internally.
-* **Market Instability:** Some competitor strategies, especially those aimed at broad disruption, can create instability that negatively impacts the entire market ecosystem.
-* **Short-Term Gains vs. Long-Term Value:** Aggressive tactics might yield short-term advantages but could undermine long-term trust and sustainable growth if they alienate stakeholders or are built on unsustainable premises.
+Key risks to assess up front:
 
-It's crucial to align competitor strategies with the company's overall values and ethical guidelines, ensuring that actions taken are defensible and contribute to a healthy competitive environment where possible. A clear understanding of legal boundaries and potential market perceptions is essential.
+- **Retaliation loops:** An aggressive move can trigger a cycle that damages both sides.
+- **Legal exposure:** Poorly designed tactics can drift into anti-competitive or IP risk.
+- **Trust erosion:** Customers, partners, or regulators may view some actions as manipulative or unfair.
+- **Strategic drift:** Teams can become competitor-obsessed and neglect users.
+- **Culture damage:** Win-at-all-costs behavior can spread internally if leaders do not set clear boundaries.
+
+Good governance means defining red lines early, pressure-testing likely consequences, and documenting why a move is defensible.
 
 ## ✨ **Conclusion**
 
-Understanding and strategically applying competitor-focused strategies is a vital component of a comprehensive approach to navigating the business landscape. These strategies are not about mindless aggression but about informed, calculated actions designed to shape the competitive environment to your advantage, neutralize threats, and create opportunities for growth.
+Competitor strategies are useful when they are precise, bounded, and tied to a broader plan.
 
-However, they must be used judiciously, with a keen awareness of the potential risks, ethical implications, and the broader impact on the market. The most effective long-term strategies often blend a strong customer focus with a sophisticated understanding of competitive dynamics, allowing organizations to adapt, innovate, and thrive in even the most challenging environments. The key is to integrate these plays into a coherent overall strategy that is both effective and sustainable.
+The goal is not permanent warfare. The goal is to create better strategic options for your organization while staying effective, lawful, and credible.
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';


### PR DESCRIPTION
### Motivation
- Improve the readability and tone of the competitor category page by removing AI-like, inflated, and formulaic phrasing so the content reads more direct and human. 
- Preserve the page structure and links while making the guidance more actionable and leadership-focused.

### Description
- Rewrote `docs/strategies/competitor/index.md` to tighten the intro and reframe the core sections (`What are Competitor Strategies?`, `Why Use Competitor Strategies?`) with clearer, simpler language. 
- Simplified the “Types of Competitor Strategies” list and clarified the ethics and conclusion sections to avoid abstract or promotional wording. 
- Kept all existing internal links, the comparison table, front matter, and the MDX `DocCardList` block intact.

### Testing
- Ran `python -m pytest tests` and all tests passed (`8 passed`).
- Ran `npm run lint:md:fix` to apply markdown fixes and formatting, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f8584ddbc832b9a2728b30eee2302)